### PR TITLE
v0.7.1: Documentation overhaul and mode consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,141 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional LLM provider support
 - Real-time alerting system
 - Dashboard and monitoring interface
-- S3 data lake integration for raw API data preservation
 - RAG enhancement system for combining multiple analyses
 - Advanced confidence scoring and quality metrics
 - Batch processing optimizations
 - Real-time streaming analysis
-- Categorical analysis status tracking for complete audit trail
+
+---
+
+## [0.7.1] - 2025-01-15
+
+### 📚 **Documentation Overhaul and Mode Consolidation**
+
+#### Added
+- **Comprehensive README updates** - All directory READMEs now accurately reflect current functionality
+- **Root README restructure** - Now serves as clear overview focusing on main entry point (`shitpost_alpha.py`)
+- **Enhanced documentation links** - Easy navigation between detailed component documentation
+- **Recent improvements sections** - Documents v0.7.0 changes and consolidations
+- **Manual testing examples** - Comprehensive testing documentation for all components
+
+#### Changed
+- **Mode consolidation** - Removed `from-date` mode globally, functionality integrated into `range` mode
+- **Incremental mode enhancement** - Now stops when encountering existing posts in S3 with clear logging
+- **Unified code path** - All harvesting modes (`incremental`, `backfill`, `range`) now use single `_harvest_backfill()` method
+- **CLI simplification** - Cleaner command-line interface with fewer mode options
+- **Documentation accuracy** - All READMEs now match actual implementation
+
+#### Removed
+- **`from-date` mode** - Removed from all CLIs (orchestrator, harvester, analyzer)
+- **Code duplication** - Consolidated multiple harvesting methods into unified approach
+- **Outdated examples** - Removed references to deprecated modes and functionality
+
+#### Technical Improvements
+- **S3 existence checks** - Efficient `head_object` API calls for incremental mode
+- **Enhanced logging** - Clear feedback about which posts are found and why harvest stops
+- **Consistent behavior** - All date-based analysis uses same `range` mode logic
+- **Better error handling** - Consistent error management across all modes
+
+#### Documentation Updates
+- **Root README** - Complete restructure as system overview with main entry point focus
+- **shitposts/README.md** - Updated to reflect S3 harvester and mode consolidations
+- **shitvault/README.md** - Enhanced with S3 processing and categorical tracking details
+- **shitpost_ai/README.md** - Updated to reflect mode consolidation and bypass functionality
+- **All CLI examples** - Updated to use current mode structure
+
+#### CLI Examples
+```bash
+# Main orchestrator (recommended entry point)
+python shitpost_alpha.py --mode backfill --limit 100
+python shitpost_alpha.py --mode range --from 2024-01-01 --limit 100
+
+# Individual components (for advanced usage)
+python -m shitposts.truth_social_s3_harvester --mode incremental --limit 5
+python -m shitpost_ai.shitpost_analyzer --mode range --from 2024-01-01 --limit 100
+```
+
+#### Files Modified
+- `README.md` - Complete restructure as system overview
+- `shitposts/README.md` - Updated for S3 harvester and mode consolidations
+- `shitvault/README.md` - Enhanced with S3 processing details
+- `shitpost_ai/README.md` - Updated for mode consolidation and bypass functionality
+- `shitposts/truth_social_s3_harvester.py` - Mode consolidation and enhanced logging
+- `shitposts/cli.py` - Removed `from-date` mode references
+- `shitpost_ai/shitpost_analyzer.py` - Removed `from-date` mode and updated examples
+- `shitpost_alpha.py` - Updated CLI validation and examples
+
+#### Benefits
+- **Simplified user experience** - Fewer modes to understand, consistent behavior
+- **Better documentation** - Clear navigation and accurate examples
+- **Reduced code complexity** - Unified code path for all harvesting modes
+- **Enhanced maintainability** - Less code duplication and clearer logic
+- **Improved user guidance** - Root README clearly directs users to main entry point
+
+---
+
+## [0.7.0] - 2025-01-15
+
+### 🚀 **S3 Data Lake Migration - Complete Success**
+
+#### Added
+- **S3 Data Lake Integration** - Complete migration from API → DB to API → S3 architecture
+- **Truth Social S3 Harvester** - New `truth_social_s3_harvester.py` for raw data storage in S3
+- **S3 Shared Utilities** - Centralized S3 operations in `shit/s3/` directory
+- **Resume Capability** - `--max-id` parameter for resuming interrupted backfills
+- **S3 to Database Processor** - Infrastructure for future S3 → Database processing
+- **Database CLI** - Command-line interface for database operations (`shitvault.cli`)
+
+#### Changed
+- **Architecture** - Migrated from direct API → Database to API → S3 → Database pipeline
+- **Data Storage** - Raw API data now stored in S3 with date-based key structure (`truth-social/raw/YYYY/MM/DD/post_id.json`)
+- **Main Orchestrator** - Updated `shitpost_alpha.py` to use S3 harvester instead of legacy harvester
+- **Documentation** - Updated all README files to reflect new S3-based architecture
+
+#### Removed
+- **Legacy Harvester** - Deleted `truth_social_shitposts.py` (API → DB direct harvester)
+- **Overwrite Protection** - Simplified S3 storage to always replace (removed file existence checks)
+
+#### Technical Achievements
+- **Massive Backfill Success** - Successfully harvested all ~28,000 historical tweets to S3
+- **Raw Data Preservation** - Complete API responses stored for future analysis and debugging
+- **Scalable Architecture** - S3-based storage supports unlimited data growth
+- **Resume Functionality** - Can resume interrupted backfills from any post ID
+- **Multiple Harvesting Modes** - incremental, backfill, range, from-date with consistent CLI interface
+
+#### CLI Examples
+```bash
+# Full historical backfill (successfully completed ~28,000 posts)
+python -m shitposts.truth_social_s3_harvester --mode backfill
+
+# Resume backfill from specific post ID
+python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+
+# Date range harvesting
+python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
+
+# Dry run testing
+python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100 --dry-run
+```
+
+#### Files Modified
+- `shitposts/truth_social_s3_harvester.py` (new)
+- `shitposts/cli.py` (updated)
+- `shitpost_alpha.py` (updated)
+- `shit/s3/` (new directory with shared utilities)
+- `shitvault/s3_to_database_processor.py` (new)
+- `shitvault/cli.py` (new)
+- `shitvault/shitpost_db.py` (enhanced)
+- All README files updated
+- `CHANGELOG.md` (this entry)
+
+#### Benefits
+- **Data Preservation** - Raw API data preserved in S3 for future analysis
+- **Scalability** - S3 storage supports unlimited data growth
+- **Cost Efficiency** - Raw data storage in S3 is more cost-effective than database storage
+- **Flexibility** - Can reprocess raw data with different analysis strategies
+- **Resume Capability** - No need to restart backfills from beginning
+- **Audit Trail** - Complete raw data available for debugging and analysis
 
 ---
 
@@ -225,58 +354,6 @@ python main.py --mode ingestion --harvest-mode from-date --from 2024-01-01
 
 ---
 
-## [0.7.0] - 2025-01-15
-
-### 🚀 S3 Data Lake Migration - Complete
-
-**Major milestone:** Successfully migrated from API → Database to API → S3 architecture, completing the S3 data lake integration.
-
-#### 🎯 Key Achievements
-
-- **✅ Complete S3 Migration** - Fully transitioned from legacy database harvesting to S3-based raw data storage
-- **✅ Resume Capability** - Added `--max-id` parameter for resuming large backfill operations
-- **✅ Legacy Cleanup** - Removed obsolete `truth_social_shitposts.py` and updated all references
-- **✅ Documentation Update** - Comprehensive documentation refresh for S3-only approach
-- **✅ Orchestrator Update** - Main pipeline now uses S3 harvester exclusively
-
-#### 🔧 Technical Improvements
-
-- **S3 Data Lake Integration** - Raw data stored in organized structure (`truth-social/raw/YYYY/MM/DD/post_id.json`)
-- **Resume Functionality** - Can resume backfill from specific post ID for large operations
-- **Simplified Storage** - Removed overwrite complexity, always replace for reliability
-- **Enhanced CLI** - Added `--max-id` parameter for resuming operations
-- **Clean Architecture** - Removed legacy code and updated all references
-
-#### 📊 New CLI Features
-
-```bash
-# Resume backfill from specific post ID
-python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
-
-# Full backfill with resume capability
-python -m shitposts.truth_social_s3_harvester --mode backfill
-
-# All existing modes now use S3 storage
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
-```
-
-#### 🗂️ Files Modified
-
-- **Removed:** `shitposts/truth_social_shitposts.py` - Legacy database harvester
-- **Updated:** `shitpost_alpha.py` - Now uses S3 harvester exclusively
-- **Updated:** `shit/tests/test_integration.py` - Updated imports for S3 harvester
-- **Updated:** All README files - Reflect S3-only approach
-- **Updated:** `CHANGELOG.md` - Document S3 migration completion
-
-#### 🎉 Impact
-
-- **Scalable Architecture** - S3-based storage can handle unlimited data volume
-- **Resume Capability** - Large backfill operations can be resumed from any point
-- **Raw Data Preservation** - Complete API responses stored for future processing
-- **Clean Codebase** - Removed legacy code and simplified architecture
-- **Future Ready** - Foundation set for S3 → Database processing pipeline
-
----
 
 ## [0.2.0] - 2024-09-01
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,66 @@
 # Shitpost-Alpha
 
-Real-time financial analysis of Donald Trump's Truth Social posts using LLMs to extract market implications and send trading alerts.
+**Real-time financial analysis of Donald Trump's Truth Social posts using LLMs to extract market implications and send trading alerts.**
 
 ## 🎯 Overview
 
-Shitpost-Alpha monitors Donald Trump's Truth Social account in real-time, analyzes posts for financial implications using advanced LLMs, and provides actionable trading signals via SMS alerts. The system tracks prediction accuracy to continuously improve analysis quality.
+Shitpost-Alpha is a comprehensive data pipeline that monitors Donald Trump's Truth Social account, harvests posts to S3, processes them into a database, and analyzes them using advanced LLMs to extract financial market implications. The system provides actionable trading signals and tracks prediction accuracy to continuously improve analysis quality.
 
-## 🚀 Features
+**Main Entry Point:** `python shitpost_alpha.py` - Orchestrates the complete pipeline from API to analyzed predictions.
 
-- **Real-time Truth Social monitoring** - Captures posts as they happen
-- **LLM-powered analysis** - Uses GPT-4/Claude to extract financial implications
-- **Market sentiment detection** - Identifies bullish/bearish signals for specific assets
-- **SMS alerting system** - Sends actionable trading signals (Phase 2)
-- **Performance tracking** - Monitors prediction accuracy over time
-- **Modular architecture** - Easy to extend and maintain
+## 🚀 Key Features
 
-## 🏗 Architecture
+- **Complete Data Pipeline** - API → S3 → Database → LLM → Database
+- **S3 Data Lake** - Scalable raw data storage with organized structure
+- **LLM-Powered Analysis** - GPT-4/Claude financial sentiment analysis
+- **Market Sentiment Detection** - Identifies bullish/bearish signals for specific assets
+- **Categorical Tracking** - Tracks all posts including those bypassed by analysis
+- **Multiple Processing Modes** - Incremental, backfill, and date range processing
+- **Unified Orchestration** - Single entry point for complete pipeline execution
+- **Modular Architecture** - Easy to extend and maintain
+
+## 🏗 System Architecture
+
+The system follows a **complete data pipeline architecture** with three main phases:
+
+```
+API → S3 → Database → LLM → Database
+```
+
+### 📁 Directory Structure
 
 ```
 shitpost_alpha/
-├── shitpost_alpha.py       # Main orchestrator
+├── shitpost_alpha.py       # 🎯 MAIN ENTRY POINT - Pipeline orchestrator
 ├── shit/                   # Supporting infrastructure
 │   ├── config/             # Configuration management
+│   ├── s3/                 # Shared S3 utilities
 │   ├── tests/              # Testing framework
 │   └── utils/              # Utility functions
-├── shitvault/              # Data persistence
-│   ├── shitpost_models.py  # Shitpost database models
-│   └── shitpost_db.py      # Shitpost database manager
-├── shitposts/              # Shitpost collection
+├── shitvault/              # Data persistence & S3 processing
+│   ├── README.md           # 📖 Database & S3 processing documentation
+│   ├── shitpost_models.py  # Database models
+│   ├── shitpost_db.py      # Database manager
+│   ├── s3_to_database_processor.py  # S3 → Database processor
+│   └── cli.py              # Database CLI operations
+├── shitposts/              # Content harvesting
+│   ├── README.md           # 📖 Harvesting documentation
 │   ├── truth_social_s3_harvester.py  # S3-based harvester
-│   ├── s3_data_lake.py               # S3 data lake management
-│   └── cli.py                        # Shared CLI functionality
+│   └── cli.py              # Shared CLI functionality
 └── shitpost_ai/            # AI analysis engine
+    ├── README.md           # 📖 AI analysis documentation
     ├── llm_client.py       # LLM API interaction layer
-    ├── shitpost_analyzer.py # Shitpost analysis orchestrator
+    ├── shitpost_analyzer.py # Analysis orchestrator
     └── prompts.py          # Analysis prompts
 ```
 
-### 🎭 Directory Structure Benefits
+### 🎭 Themed Directory Structure
 
 The project uses a delightfully themed directory structure that's both memorable and logical:
 
-- **`shit/`** - Universal container for supporting infrastructure (config, tests, utils)
-- **`shitvault/`** - Secure data storage with memorable naming
-- **`shitposts/`** - Content harvesting and monitoring
+- **`shit/`** - Universal container for supporting infrastructure
+- **`shitvault/`** - Secure data storage and S3 processing
+- **`shitposts/`** - Content harvesting and monitoring  
 - **`shitpost_ai/`** - AI analysis and LLM integration
 
 This structure improves code organization while adding a touch of humor that makes the project unforgettable!
@@ -113,15 +130,16 @@ ENVIRONMENT=development
 DEBUG=true
 ```
 
-## 🚀 Usage
+## 🚀 Quick Start
 
-### New Workflow Architecture
+### Main Entry Point: `shitpost_alpha.py`
 
-The system now supports a unified processing mode that orchestrates both harvesting and analysis via the main `shitpost_alpha.py` orchestrator:
-
-#### Processing Modes (Mirrors Sub-CLI Exactly)
+The system is designed around a **unified orchestrator** that executes the complete pipeline: **API → S3 → Database → LLM → Database**
 
 ```bash
+# Show help and available options
+python shitpost_alpha.py --help
+
 # Steady state monitoring (default)
 python shitpost_alpha.py
 
@@ -131,20 +149,39 @@ python shitpost_alpha.py --mode backfill --limit 1000
 # Date range processing
 python shitpost_alpha.py --mode range --from 2024-01-01 --to 2024-01-31 --limit 100
 
-# Process from specific date onwards
-python shitpost_alpha.py --mode from-date --from 2024-01-01 --limit 100
+# Process from specific date onwards (defaults to today)
+python shitpost_alpha.py --mode range --from 2024-01-01 --limit 100
+
+# Complete pipeline with verbose output
+python shitpost_alpha.py --mode incremental --limit 50 --verbose
+
+# Dry run to see what would be executed
+python shitpost_alpha.py --mode backfill --limit 10 --dry-run
 ```
 
-#### Key Features:
-- **Unified Mode**: Single `--mode` parameter controls both harvesting and analysis
-- **Sequential Execution**: Harvesting completes before analysis begins
-- **Shared Parameters**: Same settings apply to both phases
-- **Clean CLI**: Mirrors sub-CLI parameter names exactly
-- **Progress Reporting**: Shows output from both sub-CLIs
+### Pipeline Phases
 
-### Environment Configuration
+The orchestrator executes three sequential phases:
 
-Add to your `.env` file:
+1. **🚀 Phase 1: API → S3** - Harvest raw data from Truth Social API and store in S3
+2. **💾 Phase 2: S3 → Database** - Process raw S3 data and load into database  
+3. **🧠 Phase 3: LLM Analysis** - Analyze posts and store predictions in database
+
+### Key Features
+
+- **Complete Pipeline**: End-to-end data flow from API to analyzed predictions
+- **S3 Data Lake**: Raw data stored in S3 for scalability and backup
+- **Sequential Execution**: Each phase completes before the next begins
+- **Shared Parameters**: Same settings apply to all phases
+- **Progress Reporting**: Shows output from all pipeline phases
+- **Error Handling**: Pipeline stops on any phase failure
+
+## ⚙️ Configuration
+
+### Environment Variables
+
+Create a `.env` file with the following variables:
+
 ```bash
 # System Launch Date (prevents processing old posts)
 SYSTEM_LAUNCH_DATE=2025-01-01T00:00:00Z
@@ -157,83 +194,99 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 
 # ScrapeCreators API
 SCRAPECREATORS_API_KEY=your_scrapecreators_api_key
+
+# S3 Data Lake Configuration
+S3_BUCKET_NAME=your-s3-bucket-name
+S3_PREFIX=truth-social
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
 ```
 
-### Enhanced CLI Functionality
+## 📚 Detailed Documentation
 
-The system now includes comprehensive CLIs for both harvesting and analysis, orchestrated by shitpost_alpha.py:
+For comprehensive information about each component, see the detailed README files:
 
-#### Direct Sub-CLI Usage
+### 🎯 [Main Orchestrator](shitpost_alpha.py)
+- Complete pipeline execution
+- Command-line interface
+- Error handling and logging
+
+### 🚀 [Content Harvesting](shitposts/README.md)
+- Truth Social S3 harvester
+- Multiple harvesting modes (incremental, backfill, range)
+- S3 data lake integration
+- Resume capability for large backfills
+
+### 💾 [Data Processing](shitvault/README.md)
+- S3 to Database processor
+- Database models and management
+- Categorical analysis tracking
+- Database CLI operations
+
+### 🧠 [AI Analysis](shitpost_ai/README.md)
+- LLM client and analysis engine
+- Prompt engineering
+- Enhanced context analysis
+- Bypass functionality for unanalyzable content
+
+## 🔧 Advanced Usage
+
+### Direct Sub-CLI Access
+
+While `shitpost_alpha.py` is the recommended entry point, you can also run individual components directly:
+
 ```bash
-# Truth Social S3 Harvester CLI
+# Truth Social S3 Harvester
 python -m shitposts.truth_social_s3_harvester --help
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100
 
-# LLM Analyzer CLI  
+# S3 to Database Processor  
+python -m shitvault.cli --help
+
+# LLM Analyzer
 python -m shitpost_ai.shitpost_analyzer --help
-python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 100
 ```
 
-#### Shitpost-Alpha Orchestration
-```bash
-# Show shitpost_alpha.py help
-python shitpost_alpha.py --help
-
-# Steady state monitoring (default)
-python shitpost_alpha.py
-
-# Full historical backfill
-python shitpost_alpha.py --mode backfill --limit 1000
-
-# Date range processing
-python shitpost_alpha.py --mode range --from 2024-01-01 --to 2024-01-31 --limit 100
-
-# Dry run to see what would be executed
-python shitpost_alpha.py --mode range --from 2024-01-01 --to 2024-01-31 --limit 100 --dry-run
-```
-
-### Testing
-
-Test the new workflow architecture:
-```bash
-python shit/tests/test_workflow_validation.py
-```
-
-Test individual sub-CLIs:
-```bash
-# Test harvesting CLI
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
-
-# Test analysis CLI
-python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 5 --dry-run
-```
-
-Test shitpost_alpha.py orchestration:
-```bash
-# Test dry run mode
-python shitpost_alpha.py --mode range --from 2024-01-01 --to 2024-01-31 --limit 10 --dry-run
-
-# Test backfill mode
-python shitpost_alpha.py --mode backfill --limit 5 --dry-run
-```
-
-Test database queries:
-```bash
-python shit/tests/test_database_query.py
-```
-Test shitpost analyzer:
-```bash
-python shitpost_ai/shitpost_analyzer.py
-```
-
-Test database operations:
-```bash
-python shitvault/shitpost_db.py
-```
+**Note:** The main orchestrator (`shitpost_alpha.py`) is designed to coordinate all phases with shared parameters and proper error handling.
 
 ## 🧪 Testing
 
-Run the test suite:
+### Main Pipeline Testing
+
+Test the complete pipeline using the main orchestrator:
+
+```bash
+# Test dry run mode (recommended first test)
+python shitpost_alpha.py --mode backfill --limit 5 --dry-run
+
+# Test incremental mode
+python shitpost_alpha.py --mode incremental --limit 5
+
+# Test date range processing
+python shitpost_alpha.py --mode range --from 2024-01-01 --to 2024-01-02 --limit 5 --dry-run
+
+# Test with verbose output
+python shitpost_alpha.py --mode backfill --limit 5 --verbose
+```
+
+### Individual Component Testing
+
+Test individual components directly:
+
+```bash
+# Test harvesting
+python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
+
+# Test S3 to Database processing
+python -m shitvault.cli process-s3 --limit 5
+
+# Test LLM analysis
+python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 5 --dry-run
+```
+
+### Test Suite
+
+Run the comprehensive test suite:
 
 ```bash
 # Run all tests
@@ -242,42 +295,66 @@ pytest
 # Run with coverage
 pytest --cov=.
 
-# Run specific test file
-pytest shit/tests/test_llm_client.py
-
-# Run async tests
-pytest tests/ -v
+# Run specific test files
+pytest shit/tests/test_workflow_validation.py
 ```
+
 
 ## 📊 Database Schema
 
 The system uses the following main tables:
 
-- **truth_social_posts** - Raw Truth Social posts
-- **predictions** - LLM analysis results
-- **market_movements** - Actual market performance tracking
-- **subscribers** - SMS alert subscribers (Phase 2)
-- **llm_feedback** - Performance feedback for LLM improvement
+- **`truth_social_shitposts`** - Raw Truth Social posts from S3 processing
+- **`predictions`** - LLM analysis results with categorical tracking
+- **`market_movements`** - Actual market performance tracking (Phase 2)
+- **`subscribers`** - SMS alert subscribers (Phase 2)
+- **`llm_feedback`** - Performance feedback for LLM improvement
+
+For detailed schema information, see [shitvault/README.md](shitvault/README.md).
+
+## 🚀 Recent Improvements (v0.7.0)
+
+### S3 Data Lake Migration
+- **Complete API → S3 Pipeline** - Raw data now stored in S3 for scalability
+- **Massive Backfill Success** - Successfully harvested ~28,000 historical posts
+- **Resume Capability** - Can resume large backfill operations from specific post IDs
+
+### Mode Consolidation
+- **Unified Code Path** - All harvesting modes use consolidated logic
+- **Removed `from-date` Mode** - Functionality integrated into `range` mode
+- **Enhanced Incremental Mode** - Stops when encountering existing posts in S3
+
+### Enhanced Analysis Pipeline
+- **Pre-LLM Filtering** - Bypasses posts with no analyzable content
+- **Categorical Tracking** - Tracks all posts including those bypassed by analysis
+- **Improved Logging** - Clear feedback about processing decisions
+
+### Architecture Improvements
+- **S3 Shared Utilities** - Centralized S3 operations in `shit/s3/`
+- **Database CLI** - Comprehensive database management tools
+- **Unified Orchestration** - Single entry point for complete pipeline
 
 ## 🔄 Development Phases
 
-### Phase 1: MVP ✅
-- [x] Truth Social monitoring
-- [x] LLM analysis pipeline
-- [x] Database storage
-- [x] Basic error handling
+### Phase 1: Core Pipeline ✅
+- [x] Truth Social monitoring and S3 storage
+- [x] S3 to Database processing
+- [x] LLM analysis pipeline with categorical tracking
+- [x] Complete API → S3 → Database → LLM → Database pipeline
+- [x] Unified orchestration via `shitpost_alpha.py`
+- [x] Comprehensive error handling and logging
 
 ### Phase 2: Enhanced Features 🚧
 - [ ] SMS alerting system
 - [ ] Market data integration
-- [ ] Performance tracking
+- [ ] Performance tracking dashboard
 - [ ] Alert filtering and rate limiting
 
 ### Phase 3: Advanced Features 📋
 - [ ] Feedback loop implementation
-- [ ] Prediction accuracy dashboard
+- [ ] Prediction accuracy analytics
 - [ ] Multi-source aggregation
-- [ ] Advanced analytics
+- [ ] Advanced market correlation analysis
 
 ## 🤝 Contributing
 

--- a/shit/s3/__init__.py
+++ b/shit/s3/__init__.py
@@ -1,0 +1,17 @@
+"""
+S3 Shared Utilities
+Provides shared S3 operations for the Shitpost-Alpha project.
+"""
+
+from .s3_client import S3Client
+from .s3_data_lake import S3DataLake
+from .s3_models import S3StorageData, S3Stats
+from .s3_config import S3Config
+
+__all__ = [
+    'S3Client',
+    'S3DataLake', 
+    'S3StorageData',
+    'S3Stats',
+    'S3Config'
+]

--- a/shit/s3/s3_client.py
+++ b/shit/s3/s3_client.py
@@ -1,0 +1,111 @@
+"""
+S3 Client
+S3 connection management and configuration.
+"""
+
+import logging
+from typing import Optional
+import boto3
+from botocore.exceptions import ClientError
+
+from shit.config.shitpost_settings import settings
+from .s3_config import S3Config
+
+logger = logging.getLogger(__name__)
+
+
+class S3Client:
+    """Manages S3 connections and provides client instances."""
+    
+    def __init__(self, config: Optional[S3Config] = None):
+        """Initialize S3 client.
+        
+        Args:
+            config: S3 configuration (optional, uses settings if not provided)
+        """
+        if config:
+            self.config = config
+        else:
+            # Create config from settings
+            self.config = S3Config(
+                bucket_name=settings.S3_BUCKET_NAME,
+                prefix=settings.S3_PREFIX,
+                region=settings.AWS_REGION,
+                access_key_id=settings.AWS_ACCESS_KEY_ID,
+                secret_access_key=settings.AWS_SECRET_ACCESS_KEY
+            )
+        
+        self._client = None
+        self._resource = None
+    
+    async def initialize(self) -> None:
+        """Initialize S3 client and verify connection."""
+        try:
+            logger.info(f"Initializing S3 client for bucket: {self.config.bucket_name}")
+            
+            # Create S3 client
+            self._client = boto3.client(
+                's3',
+                aws_access_key_id=self.config.access_key_id,
+                aws_secret_access_key=self.config.secret_access_key,
+                region_name=self.config.region
+            )
+            
+            # Create S3 resource (for higher-level operations)
+            self._resource = boto3.resource(
+                's3',
+                aws_access_key_id=self.config.access_key_id,
+                aws_secret_access_key=self.config.secret_access_key,
+                region_name=self.config.region
+            )
+            
+            # Verify connection
+            await self._verify_connection()
+            
+            logger.info("S3 client initialized successfully")
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize S3 client: {e}")
+            raise
+    
+    async def _verify_connection(self) -> None:
+        """Verify S3 connection and bucket access."""
+        try:
+            # Test bucket access
+            self._client.head_bucket(Bucket=self.config.bucket_name)
+            logger.info(f"S3 bucket {self.config.bucket_name} is accessible")
+            
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            if error_code == '404':
+                raise Exception(f"S3 bucket {self.config.bucket_name} does not exist")
+            elif error_code == '403':
+                raise Exception(f"Access denied to S3 bucket {self.config.bucket_name}")
+            else:
+                raise Exception(f"Error accessing S3 bucket {self.config.bucket_name}: {e}")
+    
+    @property
+    def client(self):
+        """Get S3 client instance."""
+        if not self._client:
+            raise RuntimeError("S3 client not initialized. Call initialize() first.")
+        return self._client
+    
+    @property
+    def resource(self):
+        """Get S3 resource instance."""
+        if not self._resource:
+            raise RuntimeError("S3 resource not initialized. Call initialize() first.")
+        return self._resource
+    
+    @property
+    def bucket(self):
+        """Get S3 bucket instance."""
+        if not self._resource:
+            raise RuntimeError("S3 resource not initialized. Call initialize() first.")
+        return self._resource.Bucket(self.config.bucket_name)
+    
+    async def cleanup(self) -> None:
+        """Cleanup S3 client resources."""
+        # S3 clients don't need explicit cleanup
+        logger.info("S3 client cleanup completed")

--- a/shit/s3/s3_config.py
+++ b/shit/s3/s3_config.py
@@ -1,0 +1,48 @@
+"""
+S3 Configuration
+S3-specific configuration and constants.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class S3Config:
+    """S3 configuration settings."""
+    
+    # S3 Connection
+    bucket_name: str
+    prefix: str = "truth-social"
+    region: str = "us-east-1"
+    
+    # AWS Credentials
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
+    
+    # S3 Operations
+    timeout_seconds: int = 30
+    max_retries: int = 3
+    chunk_size: int = 8192
+    
+    # Data Organization
+    raw_data_prefix: str = "raw"
+    processed_data_prefix: str = "processed"
+    
+    def __post_init__(self):
+        """Validate configuration after initialization."""
+        if not self.bucket_name:
+            raise ValueError("S3 bucket name is required")
+        
+        if not self.prefix:
+            raise ValueError("S3 prefix is required")
+    
+    @property
+    def raw_prefix(self) -> str:
+        """Get the full prefix for raw data."""
+        return f"{self.prefix}/{self.raw_data_prefix}"
+    
+    @property
+    def processed_prefix(self) -> str:
+        """Get the full prefix for processed data."""
+        return f"{self.prefix}/{self.processed_data_prefix}"

--- a/shit/s3/s3_models.py
+++ b/shit/s3/s3_models.py
@@ -1,0 +1,109 @@
+"""
+S3 Data Models
+S3 data types, response models, and validation schemas.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+
+
+@dataclass
+class S3StorageData:
+    """Model for data stored in S3."""
+    
+    shitpost_id: str
+    post_timestamp: str
+    raw_api_data: Dict[str, Any]
+    metadata: Dict[str, Any]
+    
+    def __post_init__(self):
+        """Validate data after initialization."""
+        if not self.shitpost_id:
+            raise ValueError("shitpost_id is required")
+        
+        if not self.post_timestamp:
+            raise ValueError("post_timestamp is required")
+        
+        if not self.raw_api_data:
+            raise ValueError("raw_api_data is required")
+        
+        if not self.metadata:
+            raise ValueError("metadata is required")
+
+
+@dataclass
+class S3Stats:
+    """Model for S3 storage statistics."""
+    
+    total_files: int
+    total_size_bytes: int
+    total_size_mb: float
+    bucket: str
+    prefix: str
+    
+    def __post_init__(self):
+        """Calculate derived fields."""
+        self.total_size_mb = round(self.total_size_bytes / (1024 * 1024), 2)
+
+
+@dataclass
+class S3KeyInfo:
+    """Model for S3 key information."""
+    
+    key: str
+    size: int
+    last_modified: datetime
+    etag: str
+    
+    @property
+    def is_raw_data(self) -> bool:
+        """Check if this is a raw data file."""
+        return "/raw/" in self.key and self.key.endswith(".json")
+    
+    @property
+    def is_processed_data(self) -> bool:
+        """Check if this is a processed data file."""
+        return "/processed/" in self.key and self.key.endswith(".json")
+    
+    @property
+    def date_path(self) -> Optional[str]:
+        """Extract date path from S3 key."""
+        try:
+            # Extract YYYY/MM/DD from key like "truth-social/raw/2024/01/15/post_id.json"
+            parts = self.key.split("/")
+            if len(parts) >= 4:
+                return "/".join(parts[-4:-1])  # YYYY/MM/DD
+        except:
+            pass
+        return None
+    
+    @property
+    def post_id(self) -> Optional[str]:
+        """Extract post ID from S3 key."""
+        try:
+            # Extract post_id from key like "truth-social/raw/2024/01/15/post_id.json"
+            filename = self.key.split("/")[-1]
+            return filename.replace(".json", "")
+        except:
+            pass
+        return None
+
+
+@dataclass
+class S3ProcessingResult:
+    """Model for S3 processing results."""
+    
+    success: bool
+    s3_key: str
+    post_id: str
+    error_message: Optional[str] = None
+    processing_time_ms: Optional[int] = None
+    
+    def __post_init__(self):
+        """Validate result after initialization."""
+        if not self.s3_key:
+            raise ValueError("s3_key is required")
+        
+        if not self.post_id:
+            raise ValueError("post_id is required")

--- a/shitvault/cli.py
+++ b/shitvault/cli.py
@@ -1,0 +1,229 @@
+"""
+Database CLI
+Command-line interface for database operations.
+"""
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import datetime
+from typing import Optional
+
+from shit.config.shitpost_settings import settings
+from shit.utils.error_handling import handle_exceptions
+from .s3_to_database_processor import S3ToDatabaseProcessor
+from .shitpost_db import ShitpostDatabase
+
+logger = logging.getLogger(__name__)
+
+
+def create_database_parser() -> argparse.ArgumentParser:
+    """Create argument parser for database operations."""
+    parser = argparse.ArgumentParser(
+        description="Database operations for Shitpost-Alpha",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Process all S3 data to database
+  python -m shitvault.cli process-s3
+
+  # Process S3 data with date range
+  python -m shitvault.cli process-s3 --start-date 2024-01-01 --end-date 2024-01-31
+
+  # Process S3 data with limit
+  python -m shitvault.cli process-s3 --limit 1000
+
+  # Get database statistics
+  python -m shitvault.cli stats
+
+  # Get processing statistics
+  python -m shitvault.cli processing-stats
+        """
+    )
+    
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+    
+    # Process S3 data command
+    process_parser = subparsers.add_parser('process-s3', help='Process S3 data to database')
+    process_parser.add_argument('--start-date', type=str, help='Start date (YYYY-MM-DD)')
+    process_parser.add_argument('--end-date', type=str, help='End date (YYYY-MM-DD)')
+    process_parser.add_argument('--limit', type=int, help='Maximum number of records to process')
+    process_parser.add_argument('--dry-run', action='store_true', help='Dry run mode (no database writes)')
+    
+    # Database stats command
+    stats_parser = subparsers.add_parser('stats', help='Get database statistics')
+    
+    # Processing stats command
+    processing_stats_parser = subparsers.add_parser('processing-stats', help='Get S3 to database processing statistics')
+    
+    # Global options
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
+    parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], 
+                       default='INFO', help='Log level')
+    
+    return parser
+
+
+def setup_database_logging(args):
+    """Setup logging for database operations."""
+    log_level = getattr(logging, args.log_level.upper())
+    
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.StreamHandler(sys.stdout)
+        ]
+    )
+    
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+
+def print_database_start(args):
+    """Print database operation start message."""
+    print(f"\n🚀 Starting Database Operation: {args.command}")
+    print(f"📊 Log Level: {args.log_level}")
+    if args.verbose:
+        print(f"🔍 Verbose Mode: Enabled")
+    print("-" * 50)
+
+
+def print_database_complete(stats: dict):
+    """Print database operation completion message."""
+    print("\n✅ Database Operation Completed Successfully!")
+    print(f"📈 Statistics:")
+    for key, value in stats.items():
+        print(f"  {key}: {value}")
+    print("-" * 50)
+
+
+def print_database_error(error: Exception):
+    """Print database operation error message."""
+    print(f"\n❌ Database Operation Failed: {error}")
+    print("-" * 50)
+
+
+def print_database_interrupted():
+    """Print database operation interruption message."""
+    print("\n⚠️  Database Operation Interrupted")
+    print("-" * 50)
+
+
+async def process_s3_data(args):
+    """Process S3 data to database."""
+    try:
+        print_database_start(args)
+        
+        # Parse dates
+        start_date = None
+        end_date = None
+        
+        if args.start_date:
+            start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+        
+        if args.end_date:
+            end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+        
+        # Initialize processor
+        processor = S3ToDatabaseProcessor()
+        await processor.initialize()
+        
+        if args.dry_run:
+            logger.info("Dry run mode - no database writes will be performed")
+            # In dry run, just get stats
+            stats = await processor.get_processing_stats()
+            print_database_complete(stats)
+        else:
+            # Process S3 data
+            stats = await processor.process_s3_stream(
+                start_date=start_date,
+                end_date=end_date,
+                limit=args.limit
+            )
+            print_database_complete(stats)
+        
+        # Cleanup
+        await processor.cleanup()
+        
+    except Exception as e:
+        print_database_error(e)
+        raise
+
+
+async def get_database_stats(args):
+    """Get database statistics."""
+    try:
+        print_database_start(args)
+        
+        # Initialize database
+        db_manager = ShitpostDatabase()
+        await db_manager.initialize()
+        
+        # Get stats
+        stats = await db_manager.get_database_stats()
+        print_database_complete(stats)
+        
+        # Cleanup
+        await db_manager.cleanup()
+        
+    except Exception as e:
+        print_database_error(e)
+        raise
+
+
+async def get_processing_stats(args):
+    """Get S3 to database processing statistics."""
+    try:
+        print_database_start(args)
+        
+        # Initialize processor
+        processor = S3ToDatabaseProcessor()
+        await processor.initialize()
+        
+        # Get stats
+        stats = await processor.get_processing_stats()
+        print_database_complete(stats)
+        
+        # Cleanup
+        await processor.cleanup()
+        
+    except Exception as e:
+        print_database_error(e)
+        raise
+
+
+async def main():
+    """Main CLI entry point."""
+    parser = create_database_parser()
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return
+    
+    # Setup logging
+    setup_database_logging(args)
+    
+    try:
+        # Execute command
+        if args.command == 'process-s3':
+            await process_s3_data(args)
+        elif args.command == 'stats':
+            await get_database_stats(args)
+        elif args.command == 'processing-stats':
+            await get_processing_stats(args)
+        else:
+            print(f"Unknown command: {args.command}")
+            parser.print_help()
+            
+    except KeyboardInterrupt:
+        print_database_interrupted()
+    except Exception as e:
+        print_database_error(e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/shitvault/s3_to_database_processor.py
+++ b/shitvault/s3_to_database_processor.py
@@ -1,0 +1,295 @@
+"""
+S3 to Database Processor
+Processes raw data from S3 and loads it into the database.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional, AsyncGenerator
+import json
+
+from shit.s3 import S3DataLake, S3Config
+from shit.config.shitpost_settings import settings
+from shit.utils.error_handling import handle_exceptions
+from .shitpost_db import ShitpostDatabase
+from .shitpost_models import TruthSocialShitpost
+
+logger = logging.getLogger(__name__)
+
+
+class S3ToDatabaseProcessor:
+    """Processes raw data from S3 and loads it into the database."""
+    
+    def __init__(self, s3_config: Optional[S3Config] = None):
+        """Initialize S3 to Database processor.
+        
+        Args:
+            s3_config: S3 configuration (optional, uses settings if not provided)
+        """
+        if s3_config:
+            self.s3_config = s3_config
+        else:
+            # Create config from settings
+            self.s3_config = S3Config(
+                bucket_name=settings.S3_BUCKET_NAME,
+                prefix=settings.S3_PREFIX,
+                region=settings.AWS_REGION,
+                access_key_id=settings.AWS_ACCESS_KEY_ID,
+                secret_access_key=settings.AWS_SECRET_ACCESS_KEY
+            )
+        
+        self.s3_data_lake = S3DataLake(self.s3_config)
+        self.db_manager = ShitpostDatabase()
+        
+    async def initialize(self):
+        """Initialize S3 and database connections."""
+        try:
+            logger.info("Initializing S3 to Database processor...")
+            
+            # Initialize S3 Data Lake
+            await self.s3_data_lake.initialize()
+            logger.info("S3 Data Lake initialized successfully")
+            
+            # Initialize database
+            await self.db_manager.initialize()
+            logger.info("Database initialized successfully")
+            
+            logger.info("S3 to Database processor initialized successfully")
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize S3 to Database processor: {e}")
+            raise
+    
+    def _parse_timestamp(self, timestamp_str: str) -> datetime:
+        """Parse timestamp string to datetime object.
+        
+        Args:
+            timestamp_str: ISO format timestamp string
+            
+        Returns:
+            datetime object
+        """
+        try:
+            # Handle ISO format with 'Z' suffix
+            if timestamp_str.endswith('Z'):
+                timestamp_str = timestamp_str.replace('Z', '+00:00')
+            
+            # Parse and convert to timezone-naive
+            dt = datetime.fromisoformat(timestamp_str)
+            return dt.replace(tzinfo=None)
+            
+        except Exception as e:
+            logger.warning(f"Could not parse timestamp {timestamp_str}: {e}")
+            return datetime.now()
+    
+    def _transform_s3_data_to_shitpost(self, s3_data: Dict) -> Dict:
+        """Transform S3 data to database format.
+        
+        Args:
+            s3_data: Raw data from S3
+            
+        Returns:
+            Transformed data for database storage
+        """
+        try:
+            # Extract raw API data
+            raw_api_data = s3_data.get('raw_api_data', {})
+            account_data = raw_api_data.get('account', {})
+            
+            # Transform to database format (matching database field names)
+            transformed_data = {
+                'id': raw_api_data.get('id'),  # This is the shitpost_id
+                'content': raw_api_data.get('content', ''),
+                'text': raw_api_data.get('text', ''),
+                'timestamp': self._parse_timestamp(raw_api_data.get('created_at', '')),
+                'username': account_data.get('username', ''),
+                'platform': 'truth_social',
+                
+                # Shitpost metadata
+                'language': raw_api_data.get('language', ''),
+                'visibility': raw_api_data.get('visibility', ''),
+                'sensitive': raw_api_data.get('sensitive', False),
+                'spoiler_text': raw_api_data.get('spoiler_text', ''),
+                'uri': raw_api_data.get('uri', ''),
+                'url': raw_api_data.get('url', ''),
+                
+                # Engagement metrics
+                'replies_count': raw_api_data.get('replies_count', 0),
+                'reblogs_count': raw_api_data.get('reblogs_count', 0),
+                'favourites_count': raw_api_data.get('favourites_count', 0),
+                'upvotes_count': raw_api_data.get('upvotes_count', 0),
+                'downvotes_count': raw_api_data.get('downvotes_count', 0),
+                
+                # Account information
+                'account_id': account_data.get('id'),
+                'account_display_name': account_data.get('display_name', ''),
+                'account_followers_count': account_data.get('followers_count', 0),
+                'account_following_count': account_data.get('following_count', 0),
+                'account_statuses_count': account_data.get('statuses_count', 0),
+                'account_verified': account_data.get('verified', False),
+                'account_website': account_data.get('website', ''),
+                
+                # Media and attachments
+                'has_media': len(raw_api_data.get('media_attachments', [])) > 0,
+                'media_attachments': json.dumps(raw_api_data.get('media_attachments', [])),
+                'mentions': json.dumps(raw_api_data.get('mentions', [])),
+                'tags': json.dumps(raw_api_data.get('tags', [])),
+                
+                # Additional fields
+                'in_reply_to_id': raw_api_data.get('in_reply_to_id'),
+                'quote_id': raw_api_data.get('quote_id'),
+                'in_reply_to_account_id': raw_api_data.get('in_reply_to_account_id'),
+                'card': json.dumps(raw_api_data.get('card')) if raw_api_data.get('card') else None,
+                'group': json.dumps(raw_api_data.get('group')) if raw_api_data.get('group') else None,
+                'quote': json.dumps(raw_api_data.get('quote')) if raw_api_data.get('quote') else None,
+                'in_reply_to': json.dumps(raw_api_data.get('in_reply_to')) if raw_api_data.get('in_reply_to') else None,
+                'reblog': json.dumps(raw_api_data.get('reblog')) if raw_api_data.get('reblog') else None,
+                'sponsored': raw_api_data.get('sponsored', False),
+                'reaction': json.dumps(raw_api_data.get('reaction')) if raw_api_data.get('reaction') else None,
+                'favourited': raw_api_data.get('favourited', False),
+                'reblogged': raw_api_data.get('reblogged', False),
+                'muted': raw_api_data.get('muted', False),
+                'pinned': raw_api_data.get('pinned', False),
+                'bookmarked': raw_api_data.get('bookmarked', False),
+                'poll': json.dumps(raw_api_data.get('poll')) if raw_api_data.get('poll') else None,
+                'emojis': json.dumps(raw_api_data.get('emojis', [])),
+                'votable': raw_api_data.get('votable', False),
+                'edited_at': self._parse_timestamp(raw_api_data.get('edited_at', '')) if raw_api_data.get('edited_at') else None,
+                'version': raw_api_data.get('version', ''),
+                'editable': raw_api_data.get('editable', False),
+                'title': raw_api_data.get('title', ''),
+                'raw_api_data': json.dumps(raw_api_data),
+                'created_at': self._parse_timestamp(raw_api_data.get('created_at', '')),
+                'updated_at': self._parse_timestamp(raw_api_data.get('edited_at', '')) if raw_api_data.get('edited_at') else self._parse_timestamp(raw_api_data.get('created_at', ''))
+            }
+            
+            return transformed_data
+            
+        except Exception as e:
+            logger.error(f"Error transforming S3 data to shitpost format: {e}")
+            raise
+    
+    async def process_s3_data(self, s3_data: Dict) -> bool:
+        """Process a single S3 data record and store in database.
+        
+        Args:
+            s3_data: Raw data from S3
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            # Transform S3 data to database format
+            transformed_data = self._transform_s3_data_to_shitpost(s3_data)
+            
+            # Store in database (deduplication handled by database)
+            await self.db_manager.store_shitpost(transformed_data)
+            
+            logger.debug(f"Successfully processed S3 data for shitpost {transformed_data['shitpost_id']}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Error processing S3 data: {e}")
+            return False
+    
+    async def process_s3_stream(self, start_date: Optional[datetime] = None,
+                               end_date: Optional[datetime] = None,
+                               limit: Optional[int] = None) -> Dict[str, int]:
+        """Process a stream of S3 data and load into database.
+        
+        Args:
+            start_date: Start date for filtering (optional)
+            end_date: End date for filtering (optional)
+            limit: Maximum number of records to process (optional)
+            
+        Returns:
+            Dictionary with processing statistics
+        """
+        try:
+            logger.info(f"Starting S3 to Database processing...")
+            logger.info(f"Date range: {start_date} to {end_date}")
+            logger.info(f"Limit: {limit}")
+            
+            stats = {
+                'total_processed': 0,
+                'successful': 0,
+                'failed': 0,
+                'skipped': 0
+            }
+            
+            # Stream data from S3
+            async for s3_data in self.s3_data_lake.stream_raw_data(start_date, end_date, limit):
+                stats['total_processed'] += 1
+                
+                try:
+                    # Process the data
+                    success = await self.process_s3_data(s3_data)
+                    
+                    if success:
+                        stats['successful'] += 1
+                    else:
+                        stats['failed'] += 1
+                        
+                except Exception as e:
+                    logger.error(f"Error processing S3 data: {e}")
+                    stats['failed'] += 1
+                
+                # Log progress
+                if stats['total_processed'] % 100 == 0:
+                    logger.info(f"Processed {stats['total_processed']} records...")
+            
+            logger.info(f"S3 to Database processing completed:")
+            logger.info(f"  Total processed: {stats['total_processed']}")
+            logger.info(f"  Successful: {stats['successful']}")
+            logger.info(f"  Failed: {stats['failed']}")
+            logger.info(f"  Skipped: {stats['skipped']}")
+            
+            return stats
+            
+        except Exception as e:
+            logger.error(f"Error in S3 to Database processing: {e}")
+            raise
+    
+    async def get_processing_stats(self) -> Dict[str, any]:
+        """Get statistics about S3 and database data.
+        
+        Returns:
+            Dictionary with processing statistics
+        """
+        try:
+            # Get S3 stats
+            s3_stats = await self.s3_data_lake.get_data_stats()
+            
+            # Get database stats
+            db_stats = await self.db_manager.get_database_stats()
+            
+            return {
+                's3_stats': s3_stats.__dict__,
+                'db_stats': db_stats,
+                'processing_summary': {
+                    's3_files': s3_stats.total_files,
+                    'db_records': db_stats.get('total_shitposts', 0),
+                    'processing_ratio': round(
+                        db_stats.get('total_shitposts', 0) / max(s3_stats.total_files, 1) * 100, 2
+                    )
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"Error getting processing stats: {e}")
+            return {
+                's3_stats': {},
+                'db_stats': {},
+                'processing_summary': {}
+            }
+    
+    async def cleanup(self):
+        """Cleanup resources."""
+        try:
+            await self.s3_data_lake.cleanup()
+            await self.db_manager.cleanup()
+            logger.info("S3 to Database processor cleanup completed")
+            
+        except Exception as e:
+            logger.error(f"Error during cleanup: {e}")

--- a/shitvault/shitpost_db.py
+++ b/shitvault/shitpost_db.py
@@ -569,6 +569,75 @@ class ShitpostDatabase:
                 'analysis_rate': 0.0
             }
     
+    async def get_database_stats(self) -> Dict[str, Any]:
+        """Get comprehensive database statistics."""
+        try:
+            from shitvault.shitpost_models import TruthSocialShitpost, Prediction
+            from sqlalchemy import func, select
+            
+            async with self.get_session() as session:
+                # Count shitposts
+                shitpost_count_result = await session.execute(
+                    select(func.count(TruthSocialShitpost.id))
+                )
+                shitpost_count = shitpost_count_result.scalar()
+                
+                # Count analyses
+                analysis_count_result = await session.execute(
+                    select(func.count(Prediction.id))
+                )
+                analysis_count = analysis_count_result.scalar()
+                
+                # Count by analysis status
+                status_counts = {}
+                for status in ['analyzed', 'bypassed', 'error', 'pending']:
+                    status_result = await session.execute(
+                        select(func.count(Prediction.id)).where(Prediction.analysis_status == status)
+                    )
+                    status_counts[f'{status}_count'] = status_result.scalar()
+                
+                # Average confidence
+                avg_confidence_result = await session.execute(
+                    select(func.avg(Prediction.confidence))
+                )
+                avg_confidence = avg_confidence_result.scalar() or 0.0
+                
+                # Date range
+                date_range_result = await session.execute(
+                    select(func.min(TruthSocialShitpost.created_at))
+                )
+                min_date = date_range_result.scalar()
+                
+                date_range_result = await session.execute(
+                    select(func.max(TruthSocialShitpost.created_at))
+                )
+                max_date = date_range_result.scalar()
+                
+                return {
+                    'total_shitposts': shitpost_count,
+                    'total_analyses': analysis_count,
+                    'average_confidence': round(avg_confidence, 3),
+                    'analysis_rate': round(analysis_count / max(shitpost_count, 1), 3),
+                    'earliest_post': min_date.isoformat() if min_date else None,
+                    'latest_post': max_date.isoformat() if max_date else None,
+                    **status_counts
+                }
+                
+        except Exception as e:
+            logger.error(f"Error fetching database stats: {e}")
+            return {
+                'total_shitposts': 0,
+                'total_analyses': 0,
+                'average_confidence': 0.0,
+                'analysis_rate': 0.0,
+                'earliest_post': None,
+                'latest_post': None,
+                'analyzed_count': 0,
+                'bypassed_count': 0,
+                'error_count': 0,
+                'pending_count': 0
+            }
+    
     async def cleanup(self):
         """Cleanup shitpost database resources."""
         if self.engine:


### PR DESCRIPTION
- Complete README restructure focusing on main entry point (shitpost_alpha.py)
- Removed from-date mode globally, integrated into range mode
- Consolidated all harvesting modes into unified _harvest_backfill() method
- Enhanced incremental mode with S3 existence checks and clear logging
- Updated all documentation to reflect current functionality
- Added comprehensive testing examples and navigation links
- Simplified CLI interface with fewer mode options
- Improved user experience with consistent behavior across all modes

Files modified:
- README.md: Complete restructure as system overview
- shitposts/README.md: Updated for S3 harvester and consolidations
- shitvault/README.md: Enhanced with S3 processing details
- shitpost_ai/README.md: Updated for mode consolidation
- All CLI files: Removed from-date mode references
- CHANGELOG.md: Added v0.7.1 entry documenting all changes