### PR TITLE
v0.9.0: CLI Standardization and Entry Point Consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CLI Standardization**: Standardized CLI entry points across all packages
+  - All packages now use `python -m package` execution pattern
+  - Created `__main__.py` files for `shitposts` and `shitvault` packages
+  - Updated main orchestrator to use standardized commands
+  - Fixed documentation inconsistencies across all README files
+
+### Changed
+- **CLI Commands**: Updated all CLI examples to use standardized commands
+  - `python -m shitposts` (instead of `python -m shitposts.truth_social_s3_harvester`)
+  - `python -m shitvault` (instead of `python -m shitvault.cli`)
+  - `python -m shitpost_ai` (already correct)
+- **Documentation**: Updated all README files and CHANGELOG examples
+- **Orchestrator**: Updated `shitpost_alpha.py` to use standardized CLI calls
+
+### Fixed
+- **Documentation Errors**: Fixed incorrect CLI examples in `shitpost_ai/cli.py`
+- **Command Consistency**: All packages now follow the same CLI execution pattern
+
+### Removed
+- **Old CLI Commands**: Completely removed old CLI entry points
+  - `python -m shitposts.truth_social_s3_harvester` → Use `python -m shitposts`
+  - `python -m shitvault.cli` → Use `python -m shitvault`
+  - Old commands now produce no output and are effectively disabled
+
 ### Planned
 - Enhanced error handling and resilience
 - Performance optimizations
@@ -184,8 +209,8 @@ python shitpost_alpha.py --mode backfill --limit 100
 python shitpost_alpha.py --mode range --from 2024-01-01 --limit 100
 
 # Individual components (for advanced usage)
-python -m shitposts.truth_social_s3_harvester --mode incremental --limit 5
-python -m shitpost_ai.shitpost_analyzer --mode range --from 2024-01-01 --limit 100
+python -m shitposts --mode incremental --limit 5
+python -m shitpost_ai --mode range --from 2024-01-01 --limit 100
 ```
 
 #### Files Modified
@@ -239,16 +264,16 @@ python -m shitpost_ai.shitpost_analyzer --mode range --from 2024-01-01 --limit 1
 #### CLI Examples
 ```bash
 # Full historical backfill (successfully completed ~28,000 posts)
-python -m shitposts.truth_social_s3_harvester --mode backfill
+python -m shitposts --mode backfill
 
 # Resume backfill from specific post ID
-python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+python -m shitposts --mode backfill --max-id 114858915682735686
 
 # Date range harvesting
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
+python -m shitposts --mode range --from 2024-01-01 --to 2024-01-31
 
 # Dry run testing
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100 --dry-run
+python -m shitposts --mode backfill --limit 100 --dry-run
 ```
 
 #### Files Modified
@@ -419,25 +444,25 @@ python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100 --dry-
 #### New CLI Usage Examples
 ```bash
 # Incremental harvesting (default)
-python -m shitposts.truth_social_s3_harvester
+python -m shitposts
 
 # Full historical backfill
-python -m shitposts.truth_social_s3_harvester --mode backfill
+python -m shitposts --mode backfill
 
 # Date range harvesting
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
+python -m shitposts --mode range --from 2024-01-01 --to 2024-01-31
 
 # Harvest from specific date onwards
-python -m shitposts.truth_social_s3_harvester --mode from-date --from 2024-01-01
+python -m shitposts --mode from-date --from 2024-01-01
 
 # Harvest with limit
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100
+python -m shitposts --mode backfill --limit 100
 
 # Resume from specific post ID
-python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+python -m shitposts --mode backfill --max-id 114858915682735686
 
 # Dry run mode
-python -m shitposts.truth_social_s3_harvester --mode backfill --dry-run
+python -m shitposts --mode backfill --dry-run
 ```
 
 #### Enhanced Main.py Integration

--- a/README.md
+++ b/README.md
@@ -238,13 +238,13 @@ While `shitpost_alpha.py` is the recommended entry point, you can also run indiv
 
 ```bash
 # Truth Social S3 Harvester
-python -m shitposts.truth_social_s3_harvester --help
+python -m shitposts --help
 
 # S3 to Database Processor  
-python -m shitvault.cli --help
+python -m shitvault --help
 
 # LLM Analyzer
-python -m shitpost_ai.shitpost_analyzer --help
+python -m shitpost_ai --help
 ```
 
 **Note:** The main orchestrator (`shitpost_alpha.py`) is designed to coordinate all phases with shared parameters and proper error handling.
@@ -275,13 +275,13 @@ Test individual components directly:
 
 ```bash
 # Test harvesting
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
+python -m shitposts --mode backfill --limit 5 --dry-run
 
 # Test S3 to Database processing
-python -m shitvault.cli process-s3 --limit 5
+python -m shitvault load-database-from-s3 --limit 5
 
 # Test LLM analysis
-python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 5 --dry-run
+python -m shitpost_ai --mode backfill --limit 5 --dry-run
 ```
 
 ### Test Suite

--- a/shitpost_ai/cli.py
+++ b/shitpost_ai/cli.py
@@ -223,23 +223,23 @@ def print_analysis_error_result(shitpost_id: str, error: str, dry_run: bool = Fa
 ANALYZER_EXAMPLES = """
 Examples:
   # Incremental analysis (default)
-  python -m shitpost_ai.shitpost_analyzer
+  python -m shitpost_ai
   
   # Full historical backfill analysis
-  python -m shitpost_ai.shitpost_analyzer --mode backfill
+  python -m shitpost_ai --mode backfill
   
   # Date range analysis
-  python -m shitpost_ai.shitpost_analyzer --mode range --from 2024-01-01 --to 2024-01-31
+  python -m shitpost_ai --mode range --from 2024-01-01 --to 2024-01-31
   
   # Analysis from specific date onwards (using range mode)
-  python -m shitpost_ai.shitpost_analyzer --mode range --from 2024-01-01
+  python -m shitpost_ai --mode range --from 2024-01-01
   
   # Limited backfill with custom batch size
-  python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 100 --batch-size 10
+  python -m shitpost_ai --mode backfill --limit 100 --batch-size 10
   
   # Dry run to see what would be analyzed
-  python -m shitpost_ai.shitpost_analyzer --mode backfill --limit 10 --dry-run
+  python -m shitpost_ai --mode backfill --limit 10 --dry-run
   
   # Verbose logging
-  python -m shitpost_ai.shitpost_analyzer --verbose
+  python -m shitpost_ai --verbose
 """

--- a/shitpost_alpha.py
+++ b/shitpost_alpha.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 async def execute_harvesting_cli(args) -> bool:
     """Execute the harvesting CLI with appropriate parameters."""
     cmd = [
-        sys.executable, "-m", "shitposts.truth_social_s3_harvester",
+        sys.executable, "-m", "shitposts",
         "--mode", args.mode
     ]
     
@@ -72,7 +72,7 @@ async def execute_harvesting_cli(args) -> bool:
 async def execute_s3_to_database_cli(args) -> bool:
     """Execute the S3 to Database CLI with appropriate parameters."""
     cmd = [
-        sys.executable, "-m", "shitvault.cli",
+        sys.executable, "-m", "shitvault",
         "load-database-from-s3"
     ]
     
@@ -264,7 +264,7 @@ Examples:
         
         # Show harvesting command
         harvest_cmd = [
-            sys.executable, "-m", "shitposts.truth_social_s3_harvester",
+            sys.executable, "-m", "shitposts",
             "--mode", args.mode
         ]
         if args.from_date:
@@ -279,7 +279,7 @@ Examples:
         
         # Show S3 to Database command
         s3_cmd = [
-            sys.executable, "-m", "shitvault.cli",
+            sys.executable, "-m", "shitvault",
             "load-database-from-s3"
         ]
         if args.from_date:

--- a/shitposts/README.md
+++ b/shitposts/README.md
@@ -177,7 +177,7 @@ print(f"Total size: {stats.total_size_mb} MB")
 ### Test Harvester
 ```python
 # Run the built-in test
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
+python -m shitposts --mode backfill --limit 5 --dry-run
 ```
 
 ## 🖥️ Command Line Interface (CLI)
@@ -189,43 +189,43 @@ The Truth Social harvester includes a comprehensive CLI for different harvesting
 #### 1. **Incremental Mode** (Default)
 ```bash
 # Continuous monitoring of new posts
-python -m shitposts.truth_social_s3_harvester
+python -m shitposts
 
 # With verbose logging
-python -m shitposts.truth_social_s3_harvester --verbose
+python -m shitposts --verbose
 ```
 
 #### 2. **Backfill Mode**
 ```bash
 # Full historical data harvesting
-python -m shitposts.truth_social_s3_harvester --mode backfill
+python -m shitposts --mode backfill
 
 # Limited backfill (e.g., last 100 posts)
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100
+python -m shitposts --mode backfill --limit 100
 
 # Resume backfill from specific post ID
-python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+python -m shitposts --mode backfill --max-id 114858915682735686
 
 # Dry run to see what would be harvested
-python -m shitposts.truth_social_s3_harvester --mode backfill --dry-run
+python -m shitposts --mode backfill --dry-run
 ```
 
 #### 3. **Date Range Mode**
 ```bash
 # Harvest posts within specific date range
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
+python -m shitposts --mode range --from 2024-01-01 --to 2024-01-31
 
 # With limit and verbose logging
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31 --limit 500 --verbose
+python -m shitposts --mode range --from 2024-01-01 --to 2024-01-31 --limit 500 --verbose
 ```
 
 #### 4. **Date Range Mode (From Date to Today)**
 ```bash
 # Harvest posts from specific date to today
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01
+python -m shitposts --mode range --from 2024-01-01
 
 # With limit
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --limit 200
+python -m shitposts --mode range --from 2024-01-01 --limit 200
 ```
 
 ### CLI Options
@@ -244,19 +244,19 @@ python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --l
 
 ```bash
 # Quick test with 5 posts
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
+python -m shitposts --mode backfill --limit 5 --dry-run
 
 # Harvest last week's posts
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-15 --to 2024-01-22
+python -m shitposts --mode range --from 2024-01-15 --to 2024-01-22
 
 # Continuous monitoring with verbose logging
-python -m shitposts.truth_social_s3_harvester --verbose
+python -m shitposts --verbose
 
 # Harvest posts from election day onwards
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-11-05 --limit 1000
+python -m shitposts --mode range --from 2024-11-05 --limit 1000
 
 # Resume large backfill from specific post ID
-python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+python -m shitposts --mode backfill --max-id 114858915682735686
 ```
 
 ## 📊 Data Format
@@ -475,16 +475,16 @@ async def test_s3_storage():
 ### Manual Testing
 ```bash
 # Test incremental mode (stops when finding existing posts)
-python -m shitposts.truth_social_s3_harvester --mode incremental --limit 5
+python -m shitposts --mode incremental --limit 5
 
 # Test with dry run (no S3 storage)
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5 --dry-run
+python -m shitposts --mode backfill --limit 5 --dry-run
 
 # Test actual S3 storage
-python -m shitposts.truth_social_s3_harvester --mode backfill --limit 5
+python -m shitposts --mode backfill --limit 5
 
 # Test different modes
-python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-02 --dry-run
+python -m shitposts --mode range --from 2024-01-01 --to 2024-01-02 --dry-run
 ```
 
 ## 🔄 Continuous Operation

--- a/shitposts/__main__.py
+++ b/shitposts/__main__.py
@@ -1,0 +1,8 @@
+"""
+CLI entry point for shitposts package.
+"""
+import asyncio
+from shitposts.truth_social_s3_harvester import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/shitposts/cli.py
+++ b/shitposts/cli.py
@@ -193,23 +193,23 @@ def print_database_stats(stats: dict) -> None:
 HARVESTER_EXAMPLES = """
 Examples:
   # Incremental harvesting (default)
-  python -m shitposts.truth_social_s3_harvester
+  python -m shitposts
   
   # Full historical backfill to S3
-  python -m shitposts.truth_social_s3_harvester --mode backfill
+  python -m shitposts --mode backfill
   
   # Date range harvesting to S3
-  python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01 --to 2024-01-31
+  python -m shitposts --mode range --from 2024-01-01 --to 2024-01-31
   
   # Harvest from specific date onwards to S3 (using range mode)
-  python -m shitposts.truth_social_s3_harvester --mode range --from 2024-01-01
+  python -m shitposts --mode range --from 2024-01-01
   
   # Limited backfill with dry run
-  python -m shitposts.truth_social_s3_harvester --mode backfill --limit 100 --dry-run
+  python -m shitposts --mode backfill --limit 100 --dry-run
   
   # Verbose logging
-  python -m shitposts.truth_social_s3_harvester --verbose
+  python -m shitposts --verbose
   
   # Resume backfill from specific post ID
-  python -m shitposts.truth_social_s3_harvester --mode backfill --max-id 114858915682735686
+  python -m shitposts --mode backfill --max-id 114858915682735686
 """

--- a/shitposts/truth_social_s3_harvester.py
+++ b/shitposts/truth_social_s3_harvester.py
@@ -414,5 +414,4 @@ async def main():
         await harvester.cleanup()
 
 
-if __name__ == "__main__":
-    asyncio.run(main())
+# CLI entry point removed - use 'python -m shitposts' instead

--- a/shitvault/README.md
+++ b/shitvault/README.md
@@ -253,16 +253,16 @@ The `cli.py` provides command-line access to database operations:
 
 ```bash
 # Process S3 data to database
-python -m shitvault.cli process-s3 --limit 100
+python -m shitvault load-database-from-s3 --limit 100
 
 # Process with date range
-python -m shitvault.cli process-s3 --start-date 2024-01-01 --end-date 2024-01-31
+python -m shitvault load-database-from-s3 --start-date 2024-01-01 --end-date 2024-01-31
 
 # Get database statistics
-python -m shitvault.cli stats
+python -m shitvault stats
 
 # Get processing statistics
-python -m shitvault.cli processing-stats
+python -m shitvault processing-stats
 ```
 
 ### Initialize Database

--- a/shitvault/__main__.py
+++ b/shitvault/__main__.py
@@ -1,0 +1,8 @@
+"""
+CLI entry point for shitvault package.
+"""
+import asyncio
+from shitvault.cli import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/shitvault/cli.py
+++ b/shitvault/cli.py
@@ -25,19 +25,19 @@ def create_database_parser() -> argparse.ArgumentParser:
         epilog="""
 Examples:
   # Load all S3 data to database
-  python -m shitvault.cli load-database-from-s3
+  python -m shitvault load-database-from-s3
 
   # Load S3 data with date range
-  python -m shitvault.cli load-database-from-s3 --start-date 2024-01-01 --end-date 2024-01-31
+  python -m shitvault load-database-from-s3 --start-date 2024-01-01 --end-date 2024-01-31
 
   # Load S3 data with limit
-  python -m shitvault.cli load-database-from-s3 --limit 1000
+  python -m shitvault load-database-from-s3 --limit 1000
 
   # Get database statistics
-  python -m shitvault.cli stats
+  python -m shitvault stats
 
   # Get processing statistics
-  python -m shitvault.cli processing-stats
+  python -m shitvault processing-stats
         """
     )
     
@@ -238,5 +238,4 @@ async def main():
         sys.exit(1)
 
 
-if __name__ == "__main__":
-    asyncio.run(main())
+# CLI entry point removed - use 'python -m shitvault' instead


### PR DESCRIPTION
Added:
- CLI Standardization: Standardized CLI entry points across all packages
  - All packages now use 'python -m package' execution pattern
  - Created __main__.py files for shitposts and shitvault packages
  - Updated main orchestrator to use standardized commands
  - Fixed documentation inconsistencies across all README files

Changed:
- CLI Commands: Updated all CLI examples to use standardized commands
  - python -m shitposts (instead of python -m shitposts.truth_social_s3_harvester)
  - python -m shitvault (instead of python -m shitvault.cli)
  - python -m shitpost_ai (already correct)
- Documentation: Updated all README files and CHANGELOG examples
- Orchestrator: Updated shitpost_alpha.py to use standardized CLI calls

Fixed:
- Documentation Errors: Fixed incorrect CLI examples in shitpost_ai/cli.py
- Command Consistency: All packages now follow the same CLI execution pattern

Removed:
- Old CLI Commands: Completely removed old CLI entry points
  - python -m shitposts.truth_social_s3_harvester → Use python -m shitposts
  - python -m shitvault.cli → Use python -m shitvault
  - Old commands now produce no output and are effectively disabled

This standardization improves consistency, maintainability, and user experience by providing a unified CLI interface across all packages.