### PR TITLE
Fix Railway deployment failure: Always pass --mode parameter to shitv…

### DIFF
--- a/shitpost_alpha.py
+++ b/shitpost_alpha.py
@@ -76,9 +76,8 @@ async def execute_s3_to_database_cli(args) -> bool:
         "load-database-from-s3"
     ]
     
-    # Add mode parameter (incremental is default, so only add if not incremental)
-    if args.mode != "incremental":
-        cmd.extend(["--mode", args.mode])
+    # Add mode parameter (always add mode for consistency)
+    cmd.extend(["--mode", args.mode])
     
     # Add date parameters (use same names as sub-CLI)
     if args.from_date:
@@ -286,8 +285,7 @@ Examples:
             sys.executable, "-m", "shitvault",
             "load-database-from-s3"
         ]
-        if args.mode != "incremental":
-            s3_cmd.extend(["--mode", args.mode])
+        s3_cmd.extend(["--mode", args.mode])
         if args.from_date:
             s3_cmd.extend(["--start-date", args.from_date])
         if args.to_date:


### PR DESCRIPTION
…ault CLI

- Fix issue where incremental mode wasn't explicitly passed to shitvault command
- Railway environment requires explicit --mode parameter for proper CLI parsing
- Update both execute_s3_to_database_cli() and print_pipeline_commands() functions
- Resolves Phase 2 failure in Railway cron job execution