### PR TITLE
fix: proper SQLAlchemy async session cleanup in analyzer

### DIFF
--- a/shit_tests/shitpost_ai/test_shitpost_ai_main.py
+++ b/shit_tests/shitpost_ai/test_shitpost_ai_main.py
@@ -29,6 +29,14 @@ class TestMain:
                 self.dry_run = False
         
         return MockArgs()
+    
+    def _setup_mock_analyzer(self, mock_analyzer):
+        """Helper to setup mock analyzer with session context manager."""
+        mock_analyzer.db_client = MagicMock()
+        mock_session = MagicMock()
+        mock_analyzer.db_client.get_session.return_value.__aenter__.return_value = mock_session
+        mock_analyzer.db_client.get_session.return_value.__aexit__.return_value = None
+        return mock_session
 
     @pytest.mark.asyncio
     async def test_main_success(self, sample_args):
@@ -49,6 +57,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(return_value=5)
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -81,6 +90,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(return_value=3)
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -106,6 +116,7 @@ class TestMain:
             mock_analyzer_class.return_value = mock_analyzer
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -144,6 +155,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(return_value=15)
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -176,6 +188,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(side_effect=KeyboardInterrupt())
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -201,6 +214,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(side_effect=Exception("Analysis failed"))
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             with pytest.raises(SystemExit):
                 await main()
@@ -229,6 +243,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(side_effect=Exception("Analysis failed"))
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             with pytest.raises(SystemExit):
                 await main()
@@ -254,6 +269,7 @@ class TestMain:
             mock_analyzer_class.return_value = mock_analyzer
             mock_analyzer.initialize = AsyncMock(side_effect=Exception("Init failed"))
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             with pytest.raises(SystemExit):
                 await main()
@@ -285,6 +301,7 @@ class TestMain:
             mock_analyzer_class.return_value = mock_analyzer
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -318,6 +335,7 @@ class TestMain:
             mock_analyzer_class.return_value = mock_analyzer
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             
@@ -345,6 +363,7 @@ class TestMain:
             mock_analyzer.initialize = AsyncMock()
             mock_analyzer.analyze_shitposts = AsyncMock(return_value=0)
             mock_analyzer.cleanup = AsyncMock()
+            self._setup_mock_analyzer(mock_analyzer)
             
             await main()
             

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -69,11 +69,6 @@ class ShitpostAnalyzer:
         # Initialize database client
         await self.db_client.initialize()
         
-        # Create database operations
-        self.db_ops = DatabaseOperations(self.db_client.get_session())
-        self.shitpost_ops = ShitpostOperations(self.db_ops)
-        self.prediction_ops = PredictionOperations(self.db_ops)
-        
         # Initialize LLM client
         await self.llm_client.initialize()
         
@@ -527,10 +522,6 @@ class ShitpostAnalyzer:
     
     async def cleanup(self):
         """Cleanup analyzer resources."""
-        # Close the session if it exists
-        if self.db_ops and hasattr(self.db_ops, 'session'):
-            await self.db_ops.session.close()
-        
         if self.db_client:
             await self.db_client.cleanup()
         logger.info("Shitpost Analyzer cleanup completed")


### PR DESCRIPTION
Use async context manager for database sessions in analyzer to prevent connection pool warnings. Sessions are now properly managed through async with in __main__.py rather than manual close() calls.

- Remove session initialization from analyze.initialize()
- Use async with for session management in __main__.py
- Update tests to mock session context manager
- All 948 tests passing

Fixes SQLAlchemy warning: 'non-checked-in connection...'