### PR TITLE
feat: implement asset deep dive pages with /assets/{symbol} routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Asset Deep Dive Pages (Phase 1)** - Dedicated `/assets/{symbol}` pages with comprehensive asset performance views
+  - **Multi-Page URL Routing** - Added `dcc.Location` for client-side URL routing between dashboard and asset pages
+  - **Asset Price Chart** - Candlestick chart with prediction overlay markers showing correct/incorrect outcomes
+  - **Date Range Selector** - Toggle between 30D, 90D, 180D, and 1Y price history views
+  - **Asset Performance Summary** - Accuracy vs system-wide average comparison with best/worst predictions
+  - **Prediction Timeline** - Chronological list of all predictions for the asset with outcomes and P&L
+  - **Related Assets** - Assets frequently co-mentioned in predictions with navigation links
+  - **New Data Layer Functions**:
+    - `get_asset_price_history(symbol, days)` - OHLCV data from market_prices table
+    - `get_asset_predictions(symbol, limit)` - All predictions with outcomes for an asset
+    - `get_asset_stats(symbol)` - Comprehensive stats with system-wide comparison
+    - `get_related_assets(symbol, limit)` - Co-occurring assets from prediction_outcomes
+  - **New Tests** - 16 new tests for asset deep dive data functions
 - **Data Layer Expansion (Phase 1)** - Performance aggregate functions and query caching for dashboard
   - **Query Caching** - TTL-based caching (5-10 min) for expensive aggregate queries:
     - `get_prediction_stats`, `get_performance_metrics`, `get_accuracy_by_confidence`

--- a/shitty_ui/data.py
+++ b/shitty_ui/data.py
@@ -1015,3 +1015,292 @@ def clear_all_caches() -> None:
     get_accuracy_by_asset.clear_cache()  # type: ignore
     get_active_assets_from_db.clear_cache()  # type: ignore
     get_sentiment_distribution.clear_cache()  # type: ignore
+    get_asset_stats.clear_cache()  # type: ignore
+
+
+# =============================================================================
+# Asset Deep Dive Functions
+# =============================================================================
+
+
+def get_asset_price_history(symbol: str, days: int = 180) -> pd.DataFrame:
+    """
+    Get historical price data for a specific asset.
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL', 'TSLA')
+        days: Number of days of history to fetch (default 180)
+
+    Returns:
+        DataFrame with columns: date, open, high, low, close, volume, adjusted_close
+        Sorted by date ascending (oldest first).
+        Returns empty DataFrame on error.
+    """
+    start_date = (datetime.now() - timedelta(days=days)).date()
+
+    query = text("""
+        SELECT
+            date,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            adjusted_close
+        FROM market_prices
+        WHERE symbol = :symbol
+            AND date >= :start_date
+        ORDER BY date ASC
+    """)
+
+    try:
+        rows, columns = execute_query(
+            query, {"symbol": symbol.upper(), "start_date": start_date}
+        )
+        df = pd.DataFrame(rows, columns=columns)
+        if not df.empty:
+            df["date"] = pd.to_datetime(df["date"])
+        return df
+    except Exception as e:
+        print(f"Error loading price history for {symbol}: {e}")
+        return pd.DataFrame()
+
+
+def get_asset_predictions(symbol: str, limit: int = 50) -> pd.DataFrame:
+    """
+    Get all predictions for a specific asset with their outcomes and tweet text.
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL')
+        limit: Maximum number of predictions to return
+
+    Returns:
+        DataFrame with columns: prediction_date, timestamp, text, shitpost_id,
+        prediction_id, prediction_sentiment, prediction_confidence,
+        price_at_prediction, price_t7, return_t1, return_t3, return_t7,
+        return_t30, correct_t7, pnl_t7, is_complete, confidence, thesis
+        Sorted by prediction_date descending (newest first).
+        Returns empty DataFrame on error.
+    """
+    query = text("""
+        SELECT
+            po.prediction_date,
+            tss.timestamp,
+            tss.text,
+            tss.shitpost_id,
+            p.id AS prediction_id,
+            po.prediction_sentiment,
+            po.prediction_confidence,
+            po.price_at_prediction,
+            po.price_t7,
+            po.return_t1,
+            po.return_t3,
+            po.return_t7,
+            po.return_t30,
+            po.correct_t1,
+            po.correct_t3,
+            po.correct_t7,
+            po.correct_t30,
+            po.pnl_t7,
+            po.is_complete,
+            p.confidence,
+            p.thesis
+        FROM prediction_outcomes po
+        INNER JOIN predictions p
+            ON po.prediction_id = p.id
+        INNER JOIN truth_social_shitposts tss
+            ON p.shitpost_id = tss.shitpost_id
+        WHERE po.symbol = :symbol
+        ORDER BY po.prediction_date DESC
+        LIMIT :limit
+    """)
+
+    try:
+        rows, columns = execute_query(query, {"symbol": symbol.upper(), "limit": limit})
+        df = pd.DataFrame(rows, columns=columns)
+        if not df.empty:
+            df["prediction_date"] = pd.to_datetime(df["prediction_date"])
+            df["timestamp"] = pd.to_datetime(df["timestamp"])
+        return df
+    except Exception as e:
+        print(f"Error loading predictions for {symbol}: {e}")
+        return pd.DataFrame()
+
+
+@ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
+def get_asset_stats(symbol: str) -> Dict[str, Any]:
+    """
+    Get aggregate performance statistics for a specific asset,
+    alongside overall system averages for comparison.
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL')
+
+    Returns:
+        Dictionary with keys:
+          - total_predictions (int)
+          - correct_predictions (int)
+          - incorrect_predictions (int)
+          - accuracy_t7 (float, percentage)
+          - avg_return_t7 (float, percentage)
+          - total_pnl_t7 (float, dollar amount)
+          - avg_confidence (float, 0-1)
+          - bullish_count (int)
+          - bearish_count (int)
+          - neutral_count (int)
+          - best_return_t7 (float or None)
+          - worst_return_t7 (float or None)
+          - overall_accuracy_t7 (float, percentage, system-wide)
+          - overall_avg_return_t7 (float, percentage, system-wide)
+        Returns zeroed dict on error.
+    """
+    query = text("""
+        WITH asset_stats AS (
+            SELECT
+                COUNT(*) AS total_predictions,
+                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS correct,
+                COUNT(CASE WHEN correct_t7 = false THEN 1 END) AS incorrect,
+                COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS evaluated,
+                AVG(CASE WHEN correct_t7 IS NOT NULL THEN return_t7 END) AS avg_return,
+                SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) AS total_pnl,
+                AVG(prediction_confidence) AS avg_confidence,
+                COUNT(CASE WHEN prediction_sentiment = 'bullish' THEN 1 END) AS bullish_count,
+                COUNT(CASE WHEN prediction_sentiment = 'bearish' THEN 1 END) AS bearish_count,
+                COUNT(CASE WHEN prediction_sentiment = 'neutral' THEN 1 END) AS neutral_count,
+                MAX(return_t7) AS best_return,
+                MIN(return_t7) AS worst_return
+            FROM prediction_outcomes
+            WHERE symbol = :symbol
+        ),
+        overall_stats AS (
+            SELECT
+                COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS overall_evaluated,
+                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS overall_correct,
+                AVG(CASE WHEN correct_t7 IS NOT NULL THEN return_t7 END) AS overall_avg_return
+            FROM prediction_outcomes
+        )
+        SELECT
+            a.total_predictions,
+            a.correct,
+            a.incorrect,
+            a.evaluated,
+            a.avg_return,
+            a.total_pnl,
+            a.avg_confidence,
+            a.bullish_count,
+            a.bearish_count,
+            a.neutral_count,
+            a.best_return,
+            a.worst_return,
+            o.overall_evaluated,
+            o.overall_correct,
+            o.overall_avg_return
+        FROM asset_stats a, overall_stats o
+    """)
+
+    try:
+        rows, columns = execute_query(query, {"symbol": symbol.upper()})
+        if rows and rows[0]:
+            row = rows[0]
+            evaluated = row[3] or 0
+            correct = row[1] or 0
+            accuracy = (correct / evaluated * 100) if evaluated > 0 else 0.0
+
+            overall_evaluated = row[12] or 0
+            overall_correct = row[13] or 0
+            overall_accuracy = (
+                (overall_correct / overall_evaluated * 100)
+                if overall_evaluated > 0
+                else 0.0
+            )
+
+            return {
+                "total_predictions": row[0] or 0,
+                "correct_predictions": correct,
+                "incorrect_predictions": row[2] or 0,
+                "accuracy_t7": round(accuracy, 1),
+                "avg_return_t7": round(float(row[4]), 2) if row[4] else 0.0,
+                "total_pnl_t7": round(float(row[5]), 2) if row[5] else 0.0,
+                "avg_confidence": round(float(row[6]), 2) if row[6] else 0.0,
+                "bullish_count": row[7] or 0,
+                "bearish_count": row[8] or 0,
+                "neutral_count": row[9] or 0,
+                "best_return_t7": round(float(row[10]), 2) if row[10] else None,
+                "worst_return_t7": round(float(row[11]), 2) if row[11] else None,
+                "overall_accuracy_t7": round(overall_accuracy, 1),
+                "overall_avg_return_t7": (round(float(row[14]), 2) if row[14] else 0.0),
+            }
+    except Exception as e:
+        print(f"Error loading asset stats for {symbol}: {e}")
+
+    return {
+        "total_predictions": 0,
+        "correct_predictions": 0,
+        "incorrect_predictions": 0,
+        "accuracy_t7": 0.0,
+        "avg_return_t7": 0.0,
+        "total_pnl_t7": 0.0,
+        "avg_confidence": 0.0,
+        "bullish_count": 0,
+        "bearish_count": 0,
+        "neutral_count": 0,
+        "best_return_t7": None,
+        "worst_return_t7": None,
+        "overall_accuracy_t7": 0.0,
+        "overall_avg_return_t7": 0.0,
+    }
+
+
+def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
+    """
+    Get assets that frequently appear in the same predictions as the given symbol.
+
+    Logic: Find all predictions that mention `symbol`, extract all other assets
+    from those predictions, and count co-occurrences.
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL')
+        limit: Maximum number of related assets to return
+
+    Returns:
+        DataFrame with columns: related_symbol, co_occurrence_count, avg_return_t7
+        Sorted by co_occurrence_count descending.
+        Returns empty DataFrame on error.
+    """
+    query = text("""
+        WITH target_predictions AS (
+            -- Find all prediction IDs that mention this symbol
+            SELECT p.id AS prediction_id
+            FROM predictions p
+            WHERE p.assets::jsonb ? :symbol
+                AND p.analysis_status = 'completed'
+        ),
+        co_occurring_assets AS (
+            -- Find all OTHER assets in those same predictions
+            SELECT
+                po.symbol AS related_symbol,
+                COUNT(DISTINCT po.prediction_id) AS co_occurrence_count,
+                AVG(po.return_t7) AS avg_return_t7
+            FROM prediction_outcomes po
+            INNER JOIN target_predictions tp
+                ON po.prediction_id = tp.prediction_id
+            WHERE po.symbol != :symbol
+                AND po.symbol IS NOT NULL
+            GROUP BY po.symbol
+        )
+        SELECT
+            related_symbol,
+            co_occurrence_count,
+            ROUND(avg_return_t7::numeric, 2) AS avg_return_t7
+        FROM co_occurring_assets
+        ORDER BY co_occurrence_count DESC
+        LIMIT :limit
+    """)
+
+    try:
+        rows, columns = execute_query(query, {"symbol": symbol.upper(), "limit": limit})
+        df = pd.DataFrame(rows, columns=columns)
+        return df
+    except Exception as e:
+        print(f"Error loading related assets for {symbol}: {e}")
+        return pd.DataFrame()


### PR DESCRIPTION
- Add URL routing with dcc.Location for multi-page navigation
- Create dedicated asset pages with:
  - Price chart with candlestick visualization and prediction markers
  - Date range selector (30D, 90D, 180D, 1Y)
  - Performance summary comparing asset vs overall system accuracy
  - Prediction timeline with chronological cards showing outcomes
  - Related assets section with navigation links
- Add 4 new data layer functions:
  - get_asset_price_history() for OHLCV data
  - get_asset_predictions() for asset-specific predictions
  - get_asset_stats() for comprehensive stats with system comparison
  - get_related_assets() for co-occurring assets
- Add 16 new tests for asset deep dive data functions
- Update CHANGELOG.md

https://claude.ai/code/session_012fQqsP6fat4Ck8BoCtkwad