### PR TITLE
test: add test coverage for outcome_calculator, market_data client, and sync_session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Critical Test Coverage** - 85 new tests across 4 files for previously untested production-critical modules
+  - `test_outcome_calculator.py` (29 tests) — init, context manager, `_extract_sentiment`, `calculate_outcome_for_prediction`, `_calculate_single_outcome`, `calculate_outcomes_for_all_predictions`, `get_accuracy_stats`; coverage 92%
+  - `test_client.py` (22 tests) — init, context manager, `_get_existing_prices`, `fetch_price_history`, `get_price_on_date`, `get_latest_price`, `update_prices_for_symbols`, `get_price_stats`; coverage 76%
+  - `test_sync_session.py` (9 tests) — `get_session()` commit/rollback/close lifecycle, operation ordering, exception re-raise, `create_tables()`; coverage 97%
+  - `test_models.py` (25 tests) — `PredictionOutcome.calculate_return()`, `.is_correct()`, `.calculate_pnl()` with edge cases and boundary values
+
 ### Fixed
 - **SQL Injection Prevention** - Added `_UPDATABLE_COLUMNS` whitelist to `notifications/db.py` `update_subscription()` to prevent column name injection via dynamic kwargs
 - **HTML Injection Prevention** - Applied `html.escape()` to all 4 user-derived values in `format_alert_message_html()` (sentiment, assets, post text, thesis)

--- a/documentation/planning/tech_debt/full-scan_2026-02-10/02_critical-test-coverage.md
+++ b/documentation/planning/tech_debt/full-scan_2026-02-10/02_critical-test-coverage.md
@@ -1,0 +1,426 @@
+# Plan 02: Critical Test Coverage
+
+**Status**: ✅ COMPLETE
+**Started**: 2026-02-10
+**Completed**: 2026-02-10
+
+**PR Title**: `test: add test coverage for outcome_calculator, market_data client, and sync_session`
+**Risk Level**: Low (test-only changes, no production code modified)
+**Effort**: 2-3 days
+**Findings Addressed**: #4, #5, #6
+
+---
+
+## Context
+
+Three production-critical modules have **zero test coverage**. These modules handle the core data pipeline — fetching market prices, calculating prediction outcomes, and managing database sessions for all synchronous operations. A bug in any of these would silently corrupt the dashboard.
+
+---
+
+## Finding #4: Zero Coverage on `outcome_calculator.py`
+
+### Location
+
+`shit/market_data/outcome_calculator.py` (full file, ~200+ lines)
+
+### Why This Matters
+
+The `OutcomeCalculator` is responsible for:
+- Looking up predictions and their associated assets
+- Fetching actual market prices at T+1, T+3, T+7, T+30
+- Calculating returns and determining if predictions were correct
+- Writing `PredictionOutcome` records to the database
+
+If this code has a bug, the entire dashboard shows wrong accuracy numbers.
+
+### Required Tests
+
+Create `shit_tests/market_data/test_outcome_calculator.py`:
+
+```python
+"""Tests for prediction outcome calculator."""
+
+import pytest
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+
+from shit.market_data.outcome_calculator import OutcomeCalculator
+from shit.market_data.models import PredictionOutcome, MarketPrice
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock SQLAlchemy session."""
+    session = MagicMock(spec=Session)
+    return session
+
+
+@pytest.fixture
+def calculator(mock_session):
+    """Create OutcomeCalculator with mocked session."""
+    calc = OutcomeCalculator(session=mock_session)
+    calc.session = mock_session
+    calc.market_client = MagicMock()
+    return calc
+
+
+class TestOutcomeCalculatorInit:
+    """Test OutcomeCalculator initialization."""
+
+    def test_init_with_session(self, mock_session):
+        calc = OutcomeCalculator(session=mock_session)
+        assert calc.session == mock_session
+        assert calc._own_session is False
+
+    def test_init_without_session(self):
+        calc = OutcomeCalculator()
+        assert calc.session is None
+        assert calc._own_session is True
+
+    def test_context_manager_with_external_session(self, mock_session):
+        calc = OutcomeCalculator(session=mock_session)
+        with calc as c:
+            assert c.session == mock_session
+
+
+class TestCalculateOutcome:
+    """Test outcome calculation for predictions."""
+
+    def test_missing_prediction_returns_empty(self, calculator, mock_session):
+        """Prediction not found should return empty list."""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        result = calculator.calculate_outcome_for_prediction(999)
+        assert result == []
+
+    def test_bypassed_prediction_returns_empty(self, calculator, mock_session):
+        """Bypassed predictions should be skipped."""
+        mock_pred = MagicMock()
+        mock_pred.analysis_status = "bypassed"
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_prediction_with_no_assets_returns_empty(self, calculator, mock_session):
+        """Prediction with no assets should return empty list."""
+        mock_pred = MagicMock()
+        mock_pred.analysis_status = "completed"
+        mock_pred.assets = None
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_bullish_prediction_correct_when_price_rises(self, calculator, mock_session):
+        """A bullish prediction should be marked correct when price goes up."""
+        mock_pred = MagicMock()
+        mock_pred.analysis_status = "completed"
+        mock_pred.assets = ["AAPL"]
+        mock_pred.market_impact = {"AAPL": "bullish"}
+        mock_pred.confidence = 0.8
+        mock_pred.created_at = date(2026, 1, 1)
+
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_pred
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+
+        # Mock market client to return rising prices
+        calculator.market_client.get_price_at_date = MagicMock(
+            side_effect=lambda symbol, d: MagicMock(close=100 + (d - date(2026, 1, 1)).days)
+        )
+
+        # Test should verify correct_t7 is True for bullish + rising price
+        # (Implementation details depend on actual calculate_outcome_for_prediction logic)
+
+    def test_bearish_prediction_correct_when_price_falls(self, calculator, mock_session):
+        """A bearish prediction should be marked correct when price drops."""
+        # Similar structure to bullish test but with falling prices
+        pass  # TODO: Implement based on actual method signature
+
+    def test_outcome_already_exists_skips_recalculation(self, calculator, mock_session):
+        """Existing outcomes should not be recalculated unless force_refresh."""
+        mock_pred = MagicMock()
+        mock_pred.analysis_status = "completed"
+        mock_pred.assets = ["AAPL"]
+        existing_outcome = MagicMock(spec=PredictionOutcome)
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_pred
+        mock_session.query.return_value.filter.return_value.all.return_value = [existing_outcome]
+
+        # Should skip when not force_refresh (depends on implementation)
+
+
+class TestReturnCalculation:
+    """Test return percentage calculations."""
+
+    def test_positive_return_calculated_correctly(self):
+        """Return should be (price_later - price_at_prediction) / price_at_prediction."""
+        # price_at_prediction = 100, price_t7 = 110
+        # expected return = 0.10 (10%)
+        pass  # TODO: Test the specific return calculation method
+
+    def test_zero_price_at_prediction_handled(self):
+        """Division by zero should be handled when price_at_prediction is 0."""
+        pass  # TODO: Edge case test
+
+    def test_pnl_calculation_for_bullish(self):
+        """P&L for bullish = return * confidence."""
+        pass  # TODO: Test P&L formula
+
+    def test_pnl_calculation_for_bearish(self):
+        """P&L for bearish = -return * confidence (profit when price falls)."""
+        pass  # TODO: Test P&L formula for bearish
+```
+
+**Minimum test count**: 10-15 tests covering init, calculation, edge cases, and error handling.
+
+---
+
+## Finding #5: Zero Coverage on `market_data/client.py`
+
+### Location
+
+`shit/market_data/client.py` (full file, ~200+ lines)
+
+### Why This Matters
+
+The `MarketDataClient` fetches real stock prices via `yfinance` and stores them in the `market_prices` table. It's the data foundation for all outcome calculations and dashboard price charts.
+
+### Required Tests
+
+Create `shit_tests/market_data/test_client.py`:
+
+```python
+"""Tests for market data client."""
+
+import pytest
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch, PropertyMock
+from sqlalchemy.orm import Session
+
+from shit.market_data.client import MarketDataClient
+from shit.market_data.models import MarketPrice
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock(spec=Session)
+    return session
+
+
+@pytest.fixture
+def client(mock_session):
+    c = MarketDataClient(session=mock_session)
+    c.session = mock_session
+    return c
+
+
+class TestMarketDataClientInit:
+    def test_init_with_session(self, mock_session):
+        client = MarketDataClient(session=mock_session)
+        assert client.session == mock_session
+        assert client._own_session is False
+
+    def test_init_without_session(self):
+        client = MarketDataClient()
+        assert client.session is None
+        assert client._own_session is True
+
+
+class TestFetchPriceHistory:
+    def test_returns_existing_prices_when_cached(self, client, mock_session):
+        """Should return cached prices instead of re-fetching."""
+        existing = [MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.all.return_value = existing
+
+        result = client.fetch_price_history("AAPL", date(2026, 1, 1))
+        assert len(result) > 0
+        # yfinance should NOT have been called
+
+    @patch("shit.market_data.client.yf")
+    def test_fetches_from_yfinance_when_no_cache(self, mock_yf, client, mock_session):
+        """Should call yfinance when no cached data exists."""
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+
+        mock_ticker = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+        mock_ticker.history.return_value = MagicMock()  # Empty DataFrame-like
+
+        client.fetch_price_history("AAPL", date(2026, 1, 1), force_refresh=True)
+        # Verify yfinance was called
+
+    def test_force_refresh_bypasses_cache(self, client, mock_session):
+        """force_refresh=True should skip the cache check."""
+        pass  # TODO
+
+    def test_end_date_defaults_to_today(self, client):
+        """When end_date is None, should default to date.today()."""
+        pass  # TODO
+
+    def test_invalid_symbol_handled_gracefully(self, client, mock_session):
+        """Invalid ticker symbols should not crash."""
+        pass  # TODO
+
+
+class TestGetExistingPrices:
+    def test_queries_correct_date_range(self, client, mock_session):
+        """Should filter by symbol and date range."""
+        client._get_existing_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        # Verify the query was called with correct filters
+
+    def test_empty_result_returns_empty_list(self, client, mock_session):
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+        result = client._get_existing_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert result == []
+```
+
+**Minimum test count**: 8-12 tests.
+
+---
+
+## Finding #6: Zero Coverage on `sync_session.py`
+
+### Location
+
+`shit/db/sync_session.py` (72 lines)
+
+### Why This Matters
+
+`get_session()` is imported by:
+- `notifications/db.py` (all subscription queries)
+- `shit/market_data/cli.py`
+- `shit/market_data/client.py`
+- `shit/market_data/outcome_calculator.py`
+
+If the session context manager has a bug (e.g., doesn't roll back on error, doesn't close properly), every consumer silently leaks connections or corrupts data.
+
+### Required Tests
+
+Create `shit_tests/db/test_sync_session.py`:
+
+```python
+"""Tests for synchronous session management."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from shit.db.sync_session import get_session, SessionLocal
+
+
+class TestGetSession:
+    def test_yields_session(self):
+        """get_session() should yield a valid session object."""
+        with patch.object(SessionLocal, '__call__', return_value=MagicMock()) as mock:
+            with get_session() as session:
+                assert session is not None
+
+    def test_commits_on_success(self):
+        """Session should be committed when no exception occurs."""
+        mock_session = MagicMock()
+        with patch.object(SessionLocal, '__call__', return_value=mock_session):
+            with get_session() as session:
+                pass  # No error
+            mock_session.commit.assert_called_once()
+            mock_session.rollback.assert_not_called()
+
+    def test_rolls_back_on_exception(self):
+        """Session should be rolled back when an exception occurs."""
+        mock_session = MagicMock()
+        with patch.object(SessionLocal, '__call__', return_value=mock_session):
+            with pytest.raises(ValueError):
+                with get_session() as session:
+                    raise ValueError("test error")
+            mock_session.rollback.assert_called_once()
+            mock_session.commit.assert_not_called()
+
+    def test_closes_session_on_success(self):
+        """Session should always be closed, even on success."""
+        mock_session = MagicMock()
+        with patch.object(SessionLocal, '__call__', return_value=mock_session):
+            with get_session() as session:
+                pass
+            mock_session.close.assert_called_once()
+
+    def test_closes_session_on_exception(self):
+        """Session should always be closed, even on exception."""
+        mock_session = MagicMock()
+        with patch.object(SessionLocal, '__call__', return_value=mock_session):
+            with pytest.raises(ValueError):
+                with get_session() as session:
+                    raise ValueError("test error")
+            mock_session.close.assert_called_once()
+
+
+class TestCreateTables:
+    @patch("shit.db.sync_session.engine")
+    def test_creates_all_tables(self, mock_engine):
+        """create_tables() should call Base.metadata.create_all."""
+        from shit.db.sync_session import create_tables
+        with patch("shit.db.data_models.Base") as mock_base:
+            create_tables()
+            mock_base.metadata.create_all.assert_called_once_with(mock_engine)
+```
+
+**Minimum test count**: 6-8 tests.
+
+---
+
+## File Structure
+
+```
+shit_tests/shit/
+├── market_data/                              # EXISTS (has test_market_data_cli.py)
+│   ├── test_outcome_calculator.py            # NEW (~20 tests)
+│   ├── test_client.py                        # NEW (~15 tests)
+│   └── test_models.py                        # NEW (~12 tests, PredictionOutcome model)
+└── db/                                       # EXISTS (has other db test files)
+    └── test_sync_session.py                  # NEW (~8 tests)
+```
+
+Test directories already exist with other test files — no `__init__.py` needed (pytest discovers without them).
+
+---
+
+## Expanded Scope (Challenge Round Additions)
+
+The original plan only covered ~40% of the public API. The following methods are now in scope:
+
+**OutcomeCalculator** (Finding #4):
+- `calculate_outcome_for_prediction()` (original)
+- `calculate_outcomes_for_all_predictions()` (added)
+- `get_accuracy_stats()` (added)
+- `_extract_sentiment()` (added — critical helper)
+- `_calculate_single_outcome()` (added — core logic)
+
+**MarketDataClient** (Finding #5):
+- `fetch_price_history()` (original)
+- `get_price_on_date()` (added — used by outcome calculator)
+- `get_latest_price()` (added)
+- `update_prices_for_symbols()` (added)
+- `get_price_stats()` (added)
+- `_get_existing_prices()` (original)
+
+**PredictionOutcome model** (new scope):
+- `calculate_return()` — core financial math
+- `is_correct()` — prediction accuracy logic
+- `calculate_pnl()` — P&L simulation
+
+---
+
+## Verification Checklist
+
+- [ ] `pytest shit_tests/shit/market_data/test_outcome_calculator.py -v` — all tests pass
+- [ ] `pytest shit_tests/shit/market_data/test_client.py -v` — all tests pass
+- [ ] `pytest shit_tests/shit/market_data/test_models.py -v` — all tests pass
+- [ ] `pytest shit_tests/shit/db/test_sync_session.py -v` — all tests pass
+- [ ] `pytest shit_tests/ -v` — full suite still passes (no regressions)
+- [ ] Coverage for `outcome_calculator.py` > 70%: `pytest --cov=shit.market_data.outcome_calculator shit_tests/shit/market_data/test_outcome_calculator.py`
+- [ ] Coverage for `client.py` > 60%: `pytest --cov=shit.market_data.client shit_tests/shit/market_data/test_client.py`
+- [ ] Coverage for `sync_session.py` > 80%: `pytest --cov=shit.db.sync_session shit_tests/shit/db/test_sync_session.py`
+
+---
+
+## What NOT To Do
+
+1. **Do NOT test against the real database.** All tests must use mocked sessions. Integration tests are a separate concern.
+2. **Do NOT modify production code in this PR.** This is a test-only PR. If you discover bugs while writing tests, document them but fix them in a separate PR.
+3. **Do NOT mock at too high a level.** Mock the session and external APIs (yfinance), but let the actual business logic execute.
+4. **Do NOT write tests that depend on test execution order.** Each test must be independent.
+5. **Do NOT skip the `pass # TODO` tests.** The placeholders above are scaffolding — every `pass # TODO` must be replaced with a real implementation based on reading the actual source code.

--- a/shit_tests/shit/db/test_sync_session.py
+++ b/shit_tests/shit/db/test_sync_session.py
@@ -1,0 +1,127 @@
+"""Tests for synchronous session management (shit/db/sync_session.py)."""
+
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+
+class TestGetSession:
+    """Test the get_session() context manager."""
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_yields_session(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with get_session() as session:
+            assert session is mock_session
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_commits_on_success(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with get_session() as session:
+            pass  # No error
+
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_rolls_back_on_exception(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with pytest.raises(ValueError):
+            with get_session() as session:
+                raise ValueError("test error")
+
+        mock_session.rollback.assert_called_once()
+        mock_session.commit.assert_not_called()
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_closes_session_on_success(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with get_session() as session:
+            pass
+
+        mock_session.close.assert_called_once()
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_closes_session_on_exception(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with pytest.raises(ValueError):
+            with get_session() as session:
+                raise ValueError("test error")
+
+        mock_session.close.assert_called_once()
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_reraises_exception(self, mock_factory):
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+
+        with pytest.raises(RuntimeError, match="specific error"):
+            with get_session() as session:
+                raise RuntimeError("specific error")
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_operation_order_on_success(self, mock_factory):
+        """Verify commit happens before close."""
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+        call_order = []
+        mock_session.commit.side_effect = lambda: call_order.append("commit")
+        mock_session.close.side_effect = lambda: call_order.append("close")
+
+        with get_session() as session:
+            pass
+
+        assert call_order == ["commit", "close"]
+
+    @patch("shit.db.sync_session.SessionLocal")
+    def test_operation_order_on_error(self, mock_factory):
+        """Verify rollback happens before close on error."""
+        from shit.db.sync_session import get_session
+
+        mock_session = MagicMock()
+        mock_factory.return_value = mock_session
+        call_order = []
+        mock_session.rollback.side_effect = lambda: call_order.append("rollback")
+        mock_session.close.side_effect = lambda: call_order.append("close")
+
+        with pytest.raises(ValueError):
+            with get_session() as session:
+                raise ValueError("boom")
+
+        assert call_order == ["rollback", "close"]
+
+
+class TestCreateTables:
+    """Test create_tables() function."""
+
+    @patch("shit.db.sync_session.engine")
+    def test_calls_create_all(self, mock_engine):
+        from shit.db.data_models import Base
+        from shit.db.sync_session import create_tables
+
+        with patch.object(Base.metadata, "create_all") as mock_create:
+            create_tables()
+            mock_create.assert_called_once_with(mock_engine)

--- a/shit_tests/shit/market_data/test_client.py
+++ b/shit_tests/shit/market_data/test_client.py
@@ -1,0 +1,229 @@
+"""Tests for MarketDataClient (shit/market_data/client.py)."""
+
+import pytest
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch, PropertyMock
+from sqlalchemy.orm import Session
+
+from shit.market_data.client import MarketDataClient
+from shit.market_data.models import MarketPrice
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def client(mock_session):
+    c = MarketDataClient(session=mock_session)
+    return c
+
+
+class TestMarketDataClientInit:
+    def test_init_with_session(self, mock_session):
+        c = MarketDataClient(session=mock_session)
+        assert c.session is mock_session
+        assert c._own_session is False
+
+    def test_init_without_session(self):
+        c = MarketDataClient()
+        assert c.session is None
+        assert c._own_session is True
+
+    def test_context_manager_with_external_session(self, mock_session):
+        c = MarketDataClient(session=mock_session)
+        with c as ctx:
+            assert ctx.session is mock_session
+
+    @patch("shit.market_data.client.get_session")
+    def test_context_manager_creates_session_when_none(self, mock_get_session):
+        mock_sess = MagicMock()
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_sess)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        c = MarketDataClient()
+        with c as ctx:
+            assert ctx.session is mock_sess
+
+
+class TestGetExistingPrices:
+    def test_returns_matching_prices(self, client, mock_session):
+        existing = [MagicMock(spec=MarketPrice), MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = existing
+
+        result = client._get_existing_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert len(result) == 2
+
+    def test_returns_empty_list_when_none(self, client, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        result = client._get_existing_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert result == []
+
+
+class TestFetchPriceHistory:
+    def test_returns_cached_prices_when_available(self, client, mock_session):
+        existing = [MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = existing
+
+        result = client.fetch_price_history("AAPL", date(2026, 1, 1))
+        assert result == existing
+
+    @patch("shit.market_data.client.yf")
+    def test_fetches_from_yfinance_when_no_cache(self, mock_yf, client, mock_session):
+        # No cached data
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+        # No existing individual prices
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        # Mock yfinance ticker
+        mock_ticker = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+
+        # Mock empty history
+        mock_hist = MagicMock()
+        mock_hist.empty = True
+        mock_ticker.history.return_value = mock_hist
+
+        result = client.fetch_price_history("AAPL", date(2026, 1, 1))
+        assert result == []
+        mock_yf.Ticker.assert_called_once_with("AAPL")
+
+    @patch("shit.market_data.client.yf")
+    def test_force_refresh_skips_cache(self, mock_yf, client, mock_session):
+        # Even with existing data, force_refresh should call yfinance
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        mock_ticker = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+        mock_hist = MagicMock()
+        mock_hist.empty = True
+        mock_ticker.history.return_value = mock_hist
+
+        client.fetch_price_history("AAPL", date(2026, 1, 1), force_refresh=True)
+        # yfinance should have been called (cache was bypassed)
+        mock_yf.Ticker.assert_called_once_with("AAPL")
+
+    def test_end_date_defaults_to_today(self, client, mock_session):
+        existing = [MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = existing
+
+        result = client.fetch_price_history("AAPL", date(2026, 1, 1))
+        # Should succeed without passing end_date
+        assert len(result) == 1
+
+    @patch("shit.market_data.client.yf")
+    def test_rolls_back_on_error(self, mock_yf, client, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+        mock_yf.Ticker.side_effect = RuntimeError("API down")
+
+        with pytest.raises(RuntimeError, match="API down"):
+            client.fetch_price_history("AAPL", date(2026, 1, 1))
+
+        mock_session.rollback.assert_called_once()
+
+
+class TestGetPriceOnDate:
+    def test_returns_exact_date_match(self, client, mock_session):
+        mock_price = MagicMock(spec=MarketPrice)
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_price
+
+        result = client.get_price_on_date("AAPL", date(2026, 1, 15))
+        assert result is mock_price
+
+    def test_returns_none_when_not_found(self, client, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = client.get_price_on_date("AAPL", date(2026, 1, 15))
+        assert result is None
+
+    def test_looks_back_when_market_closed(self, client, mock_session):
+        # First call (exact date) returns None, second call (day before) returns price
+        mock_price = MagicMock(spec=MarketPrice)
+        mock_session.query.return_value.filter.return_value.first.side_effect = [
+            None,  # exact date
+            mock_price,  # 1 day back
+        ]
+
+        result = client.get_price_on_date("AAPL", date(2026, 1, 15))
+        assert result is mock_price
+
+    def test_respects_lookback_limit(self, client, mock_session):
+        # All lookback days return None
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = client.get_price_on_date("AAPL", date(2026, 1, 15), lookback_days=3)
+        assert result is None
+        # exact date + 3 lookback = 4 calls
+        assert mock_session.query.return_value.filter.return_value.first.call_count == 4
+
+
+class TestGetLatestPrice:
+    def test_returns_most_recent(self, client, mock_session):
+        mock_price = MagicMock(spec=MarketPrice, close=150.0)
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_price
+
+        result = client.get_latest_price("AAPL")
+        assert result is mock_price
+
+    def test_returns_none_when_no_data(self, client, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
+
+        result = client.get_latest_price("AAPL")
+        assert result is None
+
+
+class TestUpdatePricesForSymbols:
+    def test_updates_multiple_symbols(self, client, mock_session):
+        existing = [MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = existing
+
+        result = client.update_prices_for_symbols(["AAPL", "TSLA"])
+        assert result == {"AAPL": 1, "TSLA": 1}
+
+    @patch("shit.market_data.client.yf")
+    def test_continues_on_error(self, mock_yf, client, mock_session):
+        # First symbol fails, second succeeds
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+        mock_yf.Ticker.side_effect = RuntimeError("API down")
+
+        result = client.update_prices_for_symbols(["BAD", "ALSO_BAD"])
+        assert result["BAD"] == 0
+        assert result["ALSO_BAD"] == 0
+
+    def test_defaults_to_30_day_range(self, client, mock_session):
+        existing = [MagicMock(spec=MarketPrice)]
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = existing
+
+        result = client.update_prices_for_symbols(["AAPL"])
+        # Should succeed with default date range
+        assert "AAPL" in result
+
+
+class TestGetPriceStats:
+    def test_returns_stats_dict(self, client, mock_session):
+        mock_stats = MagicMock()
+        mock_stats.count = 100
+        mock_stats.earliest_date = date(2025, 1, 1)
+        mock_stats.latest_date = date(2026, 1, 31)
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_stats
+
+        # Mock get_latest_price via the order_by path
+        mock_latest = MagicMock(close=155.0)
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_latest
+
+        result = client.get_price_stats("AAPL")
+        assert result["symbol"] == "AAPL"
+        assert result["count"] == 100
+        assert result["latest_price"] == 155.0
+
+    def test_returns_empty_stats_when_no_data(self, client, mock_session):
+        mock_stats = MagicMock()
+        mock_stats.count = 0
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_stats
+
+        result = client.get_price_stats("NOPE")
+        assert result["count"] == 0
+        assert result["earliest_date"] is None
+        assert result["latest_price"] is None

--- a/shit_tests/shit/market_data/test_models.py
+++ b/shit_tests/shit/market_data/test_models.py
@@ -1,0 +1,124 @@
+"""Tests for PredictionOutcome model methods — core financial math."""
+
+from shit.market_data.models import PredictionOutcome
+
+
+class TestCalculateReturn:
+    """Test percentage return calculation."""
+
+    def test_positive_return(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_return(100.0, 110.0)
+        assert result == 10.0
+
+    def test_negative_return(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_return(100.0, 90.0)
+        assert result == -10.0
+
+    def test_zero_return(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_return(100.0, 100.0)
+        assert result == 0.0
+
+    def test_none_initial_price(self):
+        outcome = PredictionOutcome()
+        assert outcome.calculate_return(None, 110.0) is None
+
+    def test_none_final_price(self):
+        outcome = PredictionOutcome()
+        assert outcome.calculate_return(100.0, None) is None
+
+    def test_zero_initial_price(self):
+        outcome = PredictionOutcome()
+        assert outcome.calculate_return(0.0, 110.0) is None
+
+    def test_small_fractional_return(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_return(100.0, 100.5)
+        assert abs(result - 0.5) < 0.001
+
+
+class TestIsCorrect:
+    """Test prediction correctness logic."""
+
+    def test_bullish_correct_when_price_rises(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bullish", 5.0) is True
+
+    def test_bullish_incorrect_when_price_falls(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bullish", -5.0) is False
+
+    def test_bullish_incorrect_within_threshold(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bullish", 0.3) is False
+
+    def test_bearish_correct_when_price_falls(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bearish", -5.0) is True
+
+    def test_bearish_incorrect_when_price_rises(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bearish", 5.0) is False
+
+    def test_bearish_incorrect_within_threshold(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bearish", -0.3) is False
+
+    def test_neutral_correct_within_threshold(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("neutral", 0.3) is True
+
+    def test_neutral_incorrect_when_big_move(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("neutral", 5.0) is False
+
+    def test_custom_threshold(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bullish", 0.3, threshold=0.2) is True
+        assert outcome.is_correct("bullish", 0.3, threshold=0.5) is False
+
+    def test_none_return_pct(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("bullish", None) is None
+
+    def test_none_sentiment(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct(None, 5.0) is None
+
+    def test_unknown_sentiment(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("sideways", 5.0) is None
+
+    def test_case_insensitive(self):
+        outcome = PredictionOutcome()
+        assert outcome.is_correct("BULLISH", 5.0) is True
+        assert outcome.is_correct("Bearish", -5.0) is True
+
+
+class TestCalculatePnl:
+    """Test P&L simulation."""
+
+    def test_positive_pnl(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_pnl(10.0)
+        assert result == 100.0  # 10% of $1000
+
+    def test_negative_pnl(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_pnl(-5.0)
+        assert result == -50.0  # -5% of $1000
+
+    def test_custom_position_size(self):
+        outcome = PredictionOutcome()
+        result = outcome.calculate_pnl(10.0, position_size=5000.0)
+        assert result == 500.0  # 10% of $5000
+
+    def test_none_return(self):
+        outcome = PredictionOutcome()
+        assert outcome.calculate_pnl(None) is None
+
+    def test_zero_return(self):
+        outcome = PredictionOutcome()
+        assert outcome.calculate_pnl(0.0) == 0.0

--- a/shit_tests/shit/market_data/test_outcome_calculator.py
+++ b/shit_tests/shit/market_data/test_outcome_calculator.py
@@ -1,0 +1,333 @@
+"""Tests for OutcomeCalculator (shit/market_data/outcome_calculator.py)."""
+
+import pytest
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+
+from shit.market_data.outcome_calculator import OutcomeCalculator
+from shit.market_data.models import PredictionOutcome
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def calculator(mock_session):
+    calc = OutcomeCalculator(session=mock_session)
+    calc.market_client = MagicMock()
+    return calc
+
+
+def _make_prediction(**overrides):
+    """Helper to create a mock Prediction with sensible defaults."""
+    pred = MagicMock()
+    pred.id = overrides.get("id", 1)
+    pred.analysis_status = overrides.get("analysis_status", "completed")
+    pred.assets = overrides.get("assets", ["AAPL"])
+    pred.market_impact = overrides.get("market_impact", {"AAPL": "bullish"})
+    pred.confidence = overrides.get("confidence", 0.85)
+    pred.created_at = overrides.get("created_at", datetime(2025, 6, 15, 10, 0, 0))
+    return pred
+
+
+# ─── Init & Context Manager ─────────────────────────────────────────
+
+
+class TestOutcomeCalculatorInit:
+    def test_init_with_session(self, mock_session):
+        calc = OutcomeCalculator(session=mock_session)
+        assert calc.session is mock_session
+        assert calc._own_session is False
+
+    def test_init_without_session(self):
+        calc = OutcomeCalculator()
+        assert calc.session is None
+        assert calc._own_session is True
+
+    @patch("shit.market_data.outcome_calculator.get_session")
+    @patch("shit.market_data.outcome_calculator.MarketDataClient")
+    def test_context_manager_creates_session(self, mock_mdc, mock_get_session):
+        mock_ctx = MagicMock()
+        mock_sess = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_sess)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_get_session.return_value = mock_ctx
+
+        calc = OutcomeCalculator()
+        with calc as c:
+            assert c.session is mock_sess
+
+    def test_context_manager_with_external_session(self, mock_session):
+        calc = OutcomeCalculator(session=mock_session)
+        with calc as c:
+            assert c.session is mock_session
+            assert c.market_client is not None
+
+
+# ─── _extract_sentiment ─────────────────────────────────────────────
+
+
+class TestExtractSentiment:
+    def test_extracts_first_sentiment(self, calculator):
+        result = calculator._extract_sentiment({"AAPL": "Bullish"})
+        assert result == "bullish"
+
+    def test_returns_none_for_empty_dict(self, calculator):
+        assert calculator._extract_sentiment({}) is None
+
+    def test_returns_none_for_none(self, calculator):
+        assert calculator._extract_sentiment(None) is None
+
+    def test_lowercases_sentiment(self, calculator):
+        result = calculator._extract_sentiment({"TSLA": "BEARISH"})
+        assert result == "bearish"
+
+    def test_multi_asset_returns_first(self, calculator):
+        result = calculator._extract_sentiment({"AAPL": "bullish", "TSLA": "bearish"})
+        assert result in ("bullish", "bearish")  # dict ordering
+
+
+# ─── calculate_outcome_for_prediction ────────────────────────────────
+
+
+class TestCalculateOutcomeForPrediction:
+    def test_missing_prediction_returns_empty(self, calculator, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        result = calculator.calculate_outcome_for_prediction(999)
+        assert result == []
+
+    def test_bypassed_prediction_returns_empty(self, calculator, mock_session):
+        pred = _make_prediction(analysis_status="bypassed")
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_no_assets_returns_empty(self, calculator, mock_session):
+        pred = _make_prediction(assets=None)
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_empty_assets_returns_empty(self, calculator, mock_session):
+        pred = _make_prediction(assets=[])
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_no_created_at_returns_empty(self, calculator, mock_session):
+        pred = _make_prediction(created_at=None)
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert result == []
+
+    def test_continues_on_per_asset_error(self, calculator, mock_session):
+        pred = _make_prediction(assets=["BAD", "GOOD"])
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+
+        # _calculate_single_outcome: first call raises, second returns outcome
+        mock_outcome = MagicMock(spec=PredictionOutcome)
+        calculator._calculate_single_outcome = MagicMock(
+            side_effect=[RuntimeError("bad ticker"), mock_outcome]
+        )
+
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert len(result) == 1
+        assert result[0] is mock_outcome
+
+    def test_calls_calculate_single_for_each_asset(self, calculator, mock_session):
+        pred = _make_prediction(assets=["AAPL", "TSLA", "GOOG"])
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+
+        mock_outcome = MagicMock(spec=PredictionOutcome)
+        calculator._calculate_single_outcome = MagicMock(return_value=mock_outcome)
+
+        result = calculator.calculate_outcome_for_prediction(1)
+        assert len(result) == 3
+        assert calculator._calculate_single_outcome.call_count == 3
+
+
+# ─── _calculate_single_outcome ───────────────────────────────────────
+
+
+class TestCalculateSingleOutcome:
+    def test_returns_existing_when_not_force_refresh(self, calculator, mock_session):
+        existing = MagicMock(spec=PredictionOutcome)
+        mock_session.query.return_value.filter.return_value.first.return_value = existing
+
+        result = calculator._calculate_single_outcome(
+            prediction_id=1, symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish", confidence=0.8
+        )
+        assert result is existing
+
+    def test_returns_none_when_no_price_data(self, calculator, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        calculator.market_client.get_price_on_date.return_value = None
+        calculator.market_client.fetch_price_history.return_value = []
+
+        result = calculator._calculate_single_outcome(
+            prediction_id=1, symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish", confidence=0.8
+        )
+        assert result is None
+
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_creates_outcome_with_prices(self, mock_date, calculator, mock_session):
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        # No existing outcome
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        # Mock prices: t0=100, all timeframes=110
+        mock_price_t0 = MagicMock(close=100.0)
+        mock_price_tn = MagicMock(close=110.0)
+        calculator.market_client.get_price_on_date.return_value = mock_price_t0
+
+        # After first call (price_t0), return tn for timeframes
+        calculator.market_client.get_price_on_date.side_effect = [
+            mock_price_t0,  # price at prediction
+            mock_price_tn,  # T+1
+            mock_price_tn,  # T+3
+            mock_price_tn,  # T+7
+            mock_price_tn,  # T+30
+        ]
+
+        result = calculator._calculate_single_outcome(
+            prediction_id=1, symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish", confidence=0.8
+        )
+
+        assert result is not None
+        assert result.price_at_prediction == 100.0
+        assert result.return_t7 == 10.0  # (110-100)/100 * 100
+        assert result.correct_t7 is True  # bullish + positive return
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+    def test_force_refresh_recalculates_existing(self, calculator, mock_session):
+        existing = MagicMock(spec=PredictionOutcome)
+        # First query returns existing outcome, second returns None (no price check)
+        mock_session.query.return_value.filter.return_value.first.side_effect = [
+            existing,  # existing outcome check
+        ]
+        calculator.market_client.get_price_on_date.return_value = None
+        calculator.market_client.fetch_price_history.return_value = []
+
+        result = calculator._calculate_single_outcome(
+            prediction_id=1, symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish", confidence=0.8,
+            force_refresh=True
+        )
+        # Should attempt to recalculate (not just return existing)
+        calculator.market_client.get_price_on_date.assert_called()
+
+
+# ─── calculate_outcomes_for_all_predictions ───────────────────────────
+
+
+class TestCalculateOutcomesForAllPredictions:
+    def test_returns_stats_dict(self, calculator, mock_session):
+        pred = _make_prediction()
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = [pred]
+
+        # Mock the per-prediction calculation
+        calculator.calculate_outcome_for_prediction = MagicMock(return_value=[MagicMock()])
+
+        result = calculator.calculate_outcomes_for_all_predictions()
+        assert result["total_predictions"] == 1
+        assert result["processed"] == 1
+        assert result["outcomes_created"] == 1
+        assert result["errors"] == 0
+
+    def test_counts_errors(self, calculator, mock_session):
+        pred = _make_prediction()
+        mock_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = [pred]
+
+        calculator.calculate_outcome_for_prediction = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        result = calculator.calculate_outcomes_for_all_predictions()
+        assert result["errors"] == 1
+        assert result["processed"] == 0
+
+    def test_applies_limit(self, calculator, mock_session):
+        mock_query = mock_session.query.return_value.filter.return_value.order_by.return_value
+        mock_query.limit.return_value.all.return_value = []
+
+        calculator.calculate_outcomes_for_all_predictions(limit=5)
+        mock_query.limit.assert_called_once_with(5)
+
+    def test_applies_days_back_filter(self, calculator, mock_session):
+        mock_session.query.return_value.filter.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        calculator.calculate_outcomes_for_all_predictions(days_back=7)
+        # Should call filter twice (status + date cutoff)
+        assert mock_session.query.return_value.filter.call_count >= 1
+
+
+# ─── get_accuracy_stats ──────────────────────────────────────────────
+
+
+class TestGetAccuracyStats:
+    def test_returns_zeros_when_no_outcomes(self, calculator, mock_session):
+        mock_session.query.return_value.all.return_value = []
+
+        result = calculator.get_accuracy_stats()
+        assert result == {
+            "total": 0,
+            "correct": 0,
+            "incorrect": 0,
+            "pending": 0,
+            "accuracy": 0.0,
+        }
+
+    def test_calculates_accuracy(self, calculator, mock_session):
+        outcomes = []
+        for correct_val in [True, True, True, False, None]:
+            o = MagicMock()
+            o.correct_t7 = correct_val
+            outcomes.append(o)
+
+        mock_session.query.return_value.all.return_value = outcomes
+
+        result = calculator.get_accuracy_stats(timeframe="t7")
+        assert result["total"] == 5
+        assert result["correct"] == 3
+        assert result["incorrect"] == 1
+        assert result["pending"] == 1
+        assert result["accuracy"] == 75.0
+
+    def test_uses_specified_timeframe(self, calculator, mock_session):
+        o = MagicMock()
+        o.correct_t1 = True
+        o.correct_t30 = False
+        mock_session.query.return_value.all.return_value = [o]
+
+        result_t1 = calculator.get_accuracy_stats(timeframe="t1")
+        assert result_t1["correct"] == 1
+
+        result_t30 = calculator.get_accuracy_stats(timeframe="t30")
+        assert result_t30["incorrect"] == 1
+
+    def test_filters_by_min_confidence(self, calculator, mock_session):
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+
+        calculator.get_accuracy_stats(min_confidence=0.8)
+        mock_session.query.return_value.filter.assert_called_once()
+
+    def test_all_pending_returns_zero_accuracy(self, calculator, mock_session):
+        outcomes = [MagicMock(correct_t7=None), MagicMock(correct_t7=None)]
+        mock_session.query.return_value.all.return_value = outcomes
+
+        result = calculator.get_accuracy_stats()
+        assert result["accuracy"] == 0.0
+        assert result["pending"] == 2


### PR DESCRIPTION
## Summary
- **85 new tests** across 4 files covering 3 previously untested production-critical modules
- `outcome_calculator.py`: 29 tests, **92% coverage** (target >70%)
- `client.py`: 22 tests, **76% coverage** (target >60%)
- `sync_session.py`: 9 tests, **97% coverage** (target >80%)
- `PredictionOutcome` model: 25 tests for `calculate_return()`, `is_correct()`, `calculate_pnl()`
- Zero production code changes — test-only PR

## Findings Addressed
- **Finding #4**: Zero coverage on `outcome_calculator.py` — now 92%
- **Finding #5**: Zero coverage on `market_data/client.py` — now 76%
- **Finding #6**: Zero coverage on `sync_session.py` — now 97%

## Test plan
- [x] `pytest shit_tests/shit/market_data/test_outcome_calculator.py -v` — 29 passed
- [x] `pytest shit_tests/shit/market_data/test_client.py -v` — 22 passed
- [x] `pytest shit_tests/shit/market_data/test_models.py -v` — 25 passed
- [x] `pytest shit_tests/shit/db/test_sync_session.py -v` — 9 passed
- [x] Full suite: 1343 passed, 27 failed (all pre-existing on main)
- [x] Coverage thresholds met for all 3 target modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)