### PR TITLE
fix: resolve analyzer init bug, use async Anthropic, standardize error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Net reduction: 52 lines removed, application uses one shared pool instead of two
 
 ### Fixed
+- **Analyzer Init Bug** - `ShitpostAnalyzer.initialize()` now sets `db_ops`, `shitpost_ops`, and `prediction_ops` (previously left as `None`, causing `AttributeError` on first use)
+- **Async Anthropic Client** - Changed `anthropic.Anthropic` to `anthropic.AsyncAnthropic` in `LLMClient.__init__()` so `await` calls in `_call_llm()` work correctly
+- **Error Handling Consistency** - Converted 26 `print(f"Error ...")` calls to `logger.error()` in `shitty_ui/data.py` for consistent structured logging
+- **Stale Analyzer Tests** - Updated 6 tests mocking removed `_should_bypass_post()`/`_get_bypass_reason()` to use `bypass_service.should_bypass_post()` instead; removed 12 dead tests for methods that no longer exist (bypass logic covered by `test_bypass_service.py`)
 - **SQL Injection Prevention** - Added `_UPDATABLE_COLUMNS` whitelist to `notifications/db.py` `update_subscription()` to prevent column name injection via dynamic kwargs
 - **HTML Injection Prevention** - Applied `html.escape()` to all 4 user-derived values in `format_alert_message_html()` (sentiment, assets, post text, thesis)
 - **Bare Exception Clauses** - Replaced 4 bare `except:` with specific exception types across `llm_client.py`, `s3_models.py`, and `market_data/cli.py`

--- a/documentation/planning/tech_debt/full-scan_2026-02-10/05_architecture-fixes.md
+++ b/documentation/planning/tech_debt/full-scan_2026-02-10/05_architecture-fixes.md
@@ -1,0 +1,312 @@
+# Plan 05: Architecture Fixes
+
+**Status**: ✅ COMPLETE
+**Started**: 2026-02-10
+**Completed**: 2026-02-10
+
+**PR Title**: `fix: resolve analyzer init bug, use async Anthropic, remove sys.path hack, standardize error handling`
+**Risk Level**: Medium (touches LLM client and analyzer initialization)
+**Effort**: 1-2 days
+**Findings Addressed**: #3, #9, #10, #15, #18
+
+---
+
+## Finding #3: `ShitpostAnalyzer.initialize()` Never Sets Critical Attributes
+
+### Location
+
+`shitpost_ai/shitpost_analyzer.py:25-79`
+
+### Problem
+
+The `__init__` method sets three attributes to `None` with comments saying they'll be initialized in `initialize()`:
+
+```python
+# shitpost_ai/shitpost_analyzer.py:38-40
+self.db_ops = None  # Will be initialized in initialize()
+self.shitpost_ops = None  # Will be initialized in initialize()
+self.prediction_ops = None  # Will be initialized in initialize()
+```
+
+But `initialize()` (lines 63-79) only calls:
+```python
+# shitpost_ai/shitpost_analyzer.py:63-79
+async def initialize(self):
+    # ...
+    await self.db_client.initialize()
+    await self.llm_client.initialize()
+    logger.info("✅ Analyzer initialized successfully")
+```
+
+**It never sets `self.db_ops`, `self.shitpost_ops`, or `self.prediction_ops`.**
+
+This means when `_analyze_backfill()` calls `self.shitpost_ops.get_unprocessed_shitposts()` (line 125), it will crash with `AttributeError: 'NoneType' object has no attribute 'get_unprocessed_shitposts'`.
+
+### Fix
+
+Add the missing initialization in `initialize()`:
+
+```python
+# shitpost_ai/shitpost_analyzer.py — FIXED initialize()
+async def initialize(self):
+    logger.info("")
+    logger.info("═══════════════════════════════════════════════════════════")
+    logger.info("INITIALIZING ANALYZER")
+    logger.info("═══════════════════════════════════════════════════════════")
+    logger.info("Initializing Shitpost Analyzer...")
+
+    # Initialize database client
+    await self.db_client.initialize()
+
+    # Initialize operation classes with the database client's session
+    self.db_ops = DatabaseOperations(self.db_client)
+    self.shitpost_ops = ShitpostOperations(self.db_client)
+    self.prediction_ops = PredictionOperations(self.db_client)
+
+    # Initialize LLM client
+    await self.llm_client.initialize()
+
+    logger.info(f"Shitpost Analyzer initialized with launch date: {self.launch_date}")
+    logger.info("✅ Analyzer initialized successfully")
+    logger.info("")
+```
+
+**Important**: Verify the constructor signatures of `DatabaseOperations`, `ShitpostOperations`, and `PredictionOperations` to confirm they accept a `DatabaseClient` instance. Check imports at the top of the file — they're already imported (line 13-15):
+
+```python
+from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
+from shitvault.shitpost_operations import ShitpostOperations
+from shitvault.prediction_operations import PredictionOperations
+```
+
+### Test
+
+```python
+# shit_tests/shitpost_ai/test_analyzer_init.py
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+@pytest.mark.asyncio
+async def test_initialize_sets_ops():
+    """Verify initialize() sets db_ops, shitpost_ops, and prediction_ops."""
+    from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer
+
+    with patch("shitpost_ai.shitpost_analyzer.settings") as mock_settings:
+        mock_settings.DATABASE_URL = "sqlite:///test.db"
+        mock_settings.LLM_PROVIDER = "openai"
+        mock_settings.LLM_MODEL = "gpt-4"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+        mock_settings.SYSTEM_LAUNCH_DATE = "2025-01-01"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+
+        analyzer = ShitpostAnalyzer()
+        analyzer.db_client = AsyncMock()
+        analyzer.llm_client = AsyncMock()
+
+        await analyzer.initialize()
+
+        assert analyzer.db_ops is not None
+        assert analyzer.shitpost_ops is not None
+        assert analyzer.prediction_ops is not None
+```
+
+---
+
+## Finding #9: Sync Anthropic Client in Async Context
+
+### Location
+
+`shit/llm/llm_client.py:43-45` (init) and `shit/llm/llm_client.py:156-169` (usage)
+
+### Problem
+
+The `__init__` creates a **synchronous** Anthropic client:
+
+```python
+# shit/llm/llm_client.py:43-45
+elif self.provider == "anthropic":
+    import anthropic
+    self.client = anthropic.Anthropic(api_key=self.api_key)  # SYNC client
+```
+
+But `_call_llm()` calls it with `await`:
+
+```python
+# shit/llm/llm_client.py:156-169
+elif self.provider == "anthropic":
+    response = await asyncio.wait_for(
+        self.client.messages.create(  # <-- This is NOT awaitable
+            model=self.model,
+            ...
+        ),
+        timeout=30.0
+    )
+```
+
+`anthropic.Anthropic.messages.create()` is synchronous and returns a response directly — wrapping it in `await asyncio.wait_for()` will fail because it's not a coroutine.
+
+### Fix
+
+Use the async client:
+
+```python
+# shit/llm/llm_client.py — FIXED __init__
+elif self.provider == "anthropic":
+    import anthropic
+    self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
+```
+
+This is a one-word change: `Anthropic` → `AsyncAnthropic`. The `AsyncAnthropic.messages.create()` method returns a coroutine, making the existing `await` correct.
+
+**Verify**: Ensure `anthropic` package is installed in requirements.txt. Check the installed version supports `AsyncAnthropic` (it's been available since `anthropic>=0.18.0`).
+
+### Test
+
+```python
+# shit_tests/llm/test_llm_client.py
+
+def test_anthropic_client_is_async():
+    """Verify Anthropic provider creates an async client."""
+    with patch("shit.llm.llm_client.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = "claude-3-sonnet"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+
+        with patch("anthropic.AsyncAnthropic") as mock_async:
+            client = LLMClient(provider="anthropic")
+            mock_async.assert_called_once()
+```
+
+---
+
+## Finding #10: `sys.path.insert()` Hack in Dashboard
+
+### Location
+
+`shitty_ui/data.py:59`
+
+### Problem
+
+```python
+# shitty_ui/data.py:59
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+```
+
+This modifies `sys.path` at import time to find the `shit` package. It's fragile, can cause import conflicts, and indicates the package isn't properly installable.
+
+### Fix
+
+This is resolved as part of Plan 03 (session consolidation). When `data.py` imports from `shit.db.sync_session` instead of configuring its own engine, the `sys.path` hack becomes unnecessary because:
+
+1. The project root is already on `sys.path` when running `python app.py` from the project root
+2. The `shit` package is importable from the project root
+3. If running from the `shitty_ui/` directory, the fix is to run `python -m shitty_ui.app` from the project root instead
+
+**No additional action needed** beyond Plan 03.
+
+---
+
+## Finding #15: Inconsistent Error Handling
+
+### Problem
+
+The codebase uses three different error reporting mechanisms:
+
+| Pattern | Where Used | Example |
+|---------|-----------|---------|
+| `print("❌ ...")` | `shitty_ui/data.py:128`, `shitpost_alpha.py` (multiple) | Direct stdout |
+| `logger.error(...)` | `notifications/db.py`, `shit/llm/llm_client.py` | Standard logging |
+| `await handle_exceptions(e)` | `shitpost_ai/shitpost_analyzer.py:159,266` | Custom handler |
+
+### Fix
+
+Standardize on `logger.error()` for all error paths. Specific changes:
+
+**`shitty_ui/data.py:128-129`** (already addressed in Plan 03 — the `execute_query` function):
+
+```python
+# BEFORE
+print(f"❌ Database query error: {e}")
+print(f"🔍 DATABASE_URL: {DATABASE_URL[:50]}...")
+
+# AFTER
+logger.error(f"Database query error: {e}")
+```
+
+**`shitpost_ai/shitpost_analyzer.py`** — Keep `handle_exceptions()` calls but also log:
+
+The `handle_exceptions` utility adds structured error tracking. It's fine to keep it as a secondary mechanism, but ensure `logger.error()` is always called first:
+
+```python
+# BEFORE (line 157-159):
+except Exception as e:
+    logger.error(f"❌ Error in backfill analysis batch {batch_number}: {e}")
+    await handle_exceptions(e)
+    break
+
+# This is actually fine — logger.error is called first, then handle_exceptions.
+# No change needed here.
+```
+
+**`shitpost_alpha.py`** — The subprocess functions use `print()` for output because they're displaying subprocess stdout/stderr. This is intentional (the orchestrator is a CLI tool), so `print()` for subprocess output is acceptable. However, error conditions should still use `logger.error()`:
+
+```python
+# Already correct in the current code:
+logger.error(f"❌ Harvesting failed with return code {process.returncode}")
+```
+
+### Summary
+
+After Plans 01 and 03, the remaining `print()` statements for errors will be in `shitpost_alpha.py` for subprocess output display, which is acceptable for a CLI orchestrator.
+
+---
+
+## Finding #18: Inconsistent Function-Level Imports
+
+### Locations
+
+| File | Line | Import |
+|------|------|--------|
+| `notifications/dispatcher.py` | 91 | `from shit.config.shitpost_settings import settings` |
+| `notifications/dispatcher.py` | 202 | `import requests` |
+| `notifications/dispatcher.py` | 329 | `from twilio.rest import Client` |
+| `shit/market_data/cli.py` | 79 | `from shitvault.shitpost_models import Prediction` |
+| `shitpost_ai/shitpost_analyzer.py` | 60 | `from shitvault.shitpost_models import Prediction` |
+
+### Problem
+
+Some imports are at the top of the file, others are inside functions. This makes dependencies harder to track.
+
+### Fix
+
+Function-level imports are acceptable in two cases:
+1. **Optional dependencies** that may not be installed (e.g., `twilio`, `requests` in dispatcher.py)
+2. **Circular import avoidance** (e.g., importing models inside `create_tables()`)
+
+For `notifications/dispatcher.py`, the function-level imports are justified — `twilio` and `requests` are optional dependencies. The `settings` import at line 91 could be moved to the top level, but it's inside a try/except for graceful degradation. **Leave these as-is.**
+
+For `shit/market_data/cli.py:79` and `shitpost_ai/shitpost_analyzer.py:60`, the `Prediction` model import is inside a function to avoid circular imports with the database layer. **Leave these as-is** — they're a pragmatic solution to a real circular dependency.
+
+**No action needed** — document as an accepted pattern.
+
+---
+
+## Verification Checklist
+
+- [ ] `python -c "from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer; a = ShitpostAnalyzer(); print('init ok')"` — no import errors
+- [ ] `grep "AsyncAnthropic" shit/llm/llm_client.py` returns 1 match
+- [ ] `grep "anthropic.Anthropic(" shit/llm/llm_client.py` returns 0 matches
+- [ ] `grep "sys.path" shitty_ui/data.py` returns 0 matches (after Plan 03)
+- [ ] `pytest shit_tests/ -v` — all tests pass
+- [ ] If Anthropic provider is configured: `python -c "from shit.llm.llm_client import LLMClient; c = LLMClient(provider='anthropic', api_key='test'); print(type(c.client))"` prints `AsyncAnthropic`
+
+---
+
+## What NOT To Do
+
+1. **Do NOT replace `handle_exceptions()` with plain `logger.error()`.** The handle_exceptions utility provides structured error tracking that may feed into monitoring. Keep both.
+2. **Do NOT move all function-level imports to the top of files.** Some are intentionally function-level to handle optional dependencies or circular imports.
+3. **Do NOT change the analyzer's public API.** `initialize()` should still be called before `analyze_shitposts()` — we're just fixing what `initialize()` does internally.
+4. **Do NOT refactor the LLM client beyond the Anthropic fix.** The OpenAI path works correctly as-is.

--- a/shit/llm/llm_client.py
+++ b/shit/llm/llm_client.py
@@ -42,7 +42,7 @@ class LLMClient:
             self.client = AsyncOpenAI(api_key=self.api_key)
         elif self.provider == "anthropic":
             import anthropic
-            self.client = anthropic.Anthropic(api_key=self.api_key)
+            self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
         else:
             raise ValueError(f"Unsupported LLM provider: {self.provider}")
     

--- a/shit_tests/shit/llm/test_llm_client.py
+++ b/shit_tests/shit/llm/test_llm_client.py
@@ -71,7 +71,7 @@ class TestLLMClient:
     @pytest.mark.asyncio
     async def test_initialization_anthropic(self):
         """Test Anthropic client initialization."""
-        with patch('anthropic.Anthropic') as mock_anthropic_class:
+        with patch('anthropic.AsyncAnthropic') as mock_anthropic_class:
             mock_client = MagicMock()
             mock_anthropic_class.return_value = mock_client
             
@@ -317,7 +317,7 @@ class TestLLMClient:
     @pytest.mark.asyncio
     async def test_call_llm_anthropic(self):
         """Test Anthropic LLM call."""
-        with patch('anthropic.Anthropic') as mock_anthropic_class:
+        with patch('anthropic.AsyncAnthropic') as mock_anthropic_class:
             mock_client = MagicMock()
             mock_anthropic_class.return_value = mock_client
             

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -67,13 +67,18 @@ class ShitpostAnalyzer:
         logger.info("INITIALIZING ANALYZER")
         logger.info("═══════════════════════════════════════════════════════════")
         logger.info("Initializing Shitpost Analyzer...")
-        
+
         # Initialize database client
         await self.db_client.initialize()
-        
+
+        # Initialize operation classes with the database client
+        self.db_ops = DatabaseOperations(self.db_client)
+        self.shitpost_ops = ShitpostOperations(self.db_client)
+        self.prediction_ops = PredictionOperations(self.db_client)
+
         # Initialize LLM client
         await self.llm_client.initialize()
-        
+
         logger.info(f"Shitpost Analyzer initialized with launch date: {self.launch_date}")
         logger.info("✅ Analyzer initialized successfully")
         logger.info("")

--- a/shitty_ui/data.py
+++ b/shitty_ui/data.py
@@ -240,7 +240,7 @@ def get_available_assets() -> List[str]:
                     assets_set.update(assets_val)
             return sorted(assets_set)
         except Exception as e:
-            print(f"Error loading available assets (sqlite): {e}")
+            logger.error(f"Error loading available assets (sqlite): {e}")
             return []
     else:
         # PostgreSQL with JSONB support
@@ -257,7 +257,7 @@ def get_available_assets() -> List[str]:
             rows, columns = execute_query(query)
             return [row[0] for row in rows if row[0]]
         except Exception as e:
-            print(f"Error loading available assets: {e}")
+            logger.error(f"Error loading available assets: {e}")
             return []
 
 
@@ -371,7 +371,7 @@ def get_recent_signals(
         df = pd.DataFrame(rows, columns=columns)
         return df
     except Exception as e:
-        print(f"Error loading recent signals: {e}")
+        logger.error(f"Error loading recent signals: {e}")
         return pd.DataFrame()
 
 
@@ -423,7 +423,7 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
                 "avg_confidence": round(float(row[6]), 2) if row[6] else 0.0,
             }
     except Exception as e:
-        print(f"Error loading performance metrics: {e}")
+        logger.error(f"Error loading performance metrics: {e}")
 
     return {
         "total_outcomes": 0,
@@ -489,7 +489,7 @@ def get_accuracy_by_confidence(days: int = None) -> pd.DataFrame:
             df["accuracy"] = (df["correct"] / df["total"] * 100).round(1)
         return df
     except Exception as e:
-        print(f"Error loading accuracy by confidence: {e}")
+        logger.error(f"Error loading accuracy by confidence: {e}")
         return pd.DataFrame()
 
 
@@ -534,7 +534,7 @@ def get_accuracy_by_asset(limit: int = 15, days: int = None) -> pd.DataFrame:
             df["accuracy"] = (df["correct"] / df["total_predictions"] * 100).round(1)
         return df
     except Exception as e:
-        print(f"Error loading accuracy by asset: {e}")
+        logger.error(f"Error loading accuracy by asset: {e}")
         return pd.DataFrame()
 
 
@@ -592,7 +592,7 @@ def get_similar_predictions(
         df = pd.DataFrame(rows, columns=columns)
         return df
     except Exception as e:
-        print(f"Error loading similar predictions: {e}")
+        logger.error(f"Error loading similar predictions: {e}")
         return pd.DataFrame()
 
 
@@ -686,7 +686,7 @@ def get_predictions_with_outcomes(
         df = pd.DataFrame(rows, columns=columns)
         return df
     except Exception as e:
-        print(f"Error loading predictions with outcomes: {e}")
+        logger.error(f"Error loading predictions with outcomes: {e}")
         return pd.DataFrame()
 
 
@@ -725,7 +725,7 @@ def get_sentiment_distribution(days: int = None) -> Dict[str, int]:
                 result[sentiment] = row[1]
         return result
     except Exception as e:
-        print(f"Error loading sentiment distribution: {e}")
+        logger.error(f"Error loading sentiment distribution: {e}")
         return {"bullish": 0, "bearish": 0, "neutral": 0}
 
 
@@ -745,7 +745,7 @@ def get_active_assets_from_db() -> List[str]:
         rows, columns = execute_query(query)
         return [row[0] for row in rows if row[0]]
     except Exception as e:
-        print(f"Error loading active assets: {e}")
+        logger.error(f"Error loading active assets: {e}")
         return []
 
 
@@ -791,7 +791,7 @@ def get_cumulative_pnl(days: int = None) -> pd.DataFrame:
             df["cumulative_pnl"] = df["daily_pnl"].cumsum()
         return df
     except Exception as e:
-        print(f"Error loading cumulative P&L: {e}")
+        logger.error(f"Error loading cumulative P&L: {e}")
         return pd.DataFrame()
 
 
@@ -841,7 +841,7 @@ def get_rolling_accuracy(window: int = 30, days: int = None) -> pd.DataFrame:
             ).round(1)
         return df
     except Exception as e:
-        print(f"Error loading rolling accuracy: {e}")
+        logger.error(f"Error loading rolling accuracy: {e}")
         return pd.DataFrame()
 
 
@@ -896,7 +896,7 @@ def get_win_loss_streaks() -> Dict[str, int]:
             "max_loss_streak": max_loss,
         }
     except Exception as e:
-        print(f"Error loading win/loss streaks: {e}")
+        logger.error(f"Error loading win/loss streaks: {e}")
         return {"current_streak": 0, "max_win_streak": 0, "max_loss_streak": 0}
 
 
@@ -941,7 +941,7 @@ def get_confidence_calibration(buckets: int = 10) -> pd.DataFrame:
             )
         return df
     except Exception as e:
-        print(f"Error loading confidence calibration: {e}")
+        logger.error(f"Error loading confidence calibration: {e}")
         return pd.DataFrame()
 
 
@@ -979,7 +979,7 @@ def get_monthly_performance(months: int = 12) -> pd.DataFrame:
             df["month"] = pd.to_datetime(df["month"]).dt.strftime("%Y-%m")
         return df
     except Exception as e:
-        print(f"Error loading monthly performance: {e}")
+        logger.error(f"Error loading monthly performance: {e}")
         return pd.DataFrame()
 
 
@@ -1047,7 +1047,7 @@ def get_asset_price_history(symbol: str, days: int = 180) -> pd.DataFrame:
             df["date"] = pd.to_datetime(df["date"])
         return df
     except Exception as e:
-        print(f"Error loading price history for {symbol}: {e}")
+        logger.error(f"Error loading price history for {symbol}: {e}")
         return pd.DataFrame()
 
 
@@ -1108,7 +1108,7 @@ def get_asset_predictions(symbol: str, limit: int = 50) -> pd.DataFrame:
             df["timestamp"] = pd.to_datetime(df["timestamp"])
         return df
     except Exception as e:
-        print(f"Error loading predictions for {symbol}: {e}")
+        logger.error(f"Error loading predictions for {symbol}: {e}")
         return pd.DataFrame()
 
 
@@ -1216,7 +1216,7 @@ def get_asset_stats(symbol: str) -> Dict[str, Any]:
                 "overall_avg_return_t7": (round(float(row[14]), 2) if row[14] else 0.0),
             }
     except Exception as e:
-        print(f"Error loading asset stats for {symbol}: {e}")
+        logger.error(f"Error loading asset stats for {symbol}: {e}")
 
     return {
         "total_predictions": 0,
@@ -1287,7 +1287,7 @@ def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
         df = pd.DataFrame(rows, columns=columns)
         return df
     except Exception as e:
-        print(f"Error loading related assets for {symbol}: {e}")
+        logger.error(f"Error loading related assets for {symbol}: {e}")
         return pd.DataFrame()
 
 
@@ -1341,7 +1341,7 @@ def get_active_signals(min_confidence: float = 0.75, hours: int = 48) -> pd.Data
         df = pd.DataFrame(rows, columns=columns)
         return df
     except Exception as e:
-        print(f"Error loading active signals: {e}")
+        logger.error(f"Error loading active signals: {e}")
         return pd.DataFrame()
 
 
@@ -1366,7 +1366,7 @@ def get_weekly_signal_count() -> int:
         rows, columns = execute_query(query, params)
         return rows[0][0] if rows else 0
     except Exception as e:
-        print(f"Error loading weekly signal count: {e}")
+        logger.error(f"Error loading weekly signal count: {e}")
         return 0
 
 
@@ -1412,7 +1412,7 @@ def get_high_confidence_metrics(days: int = None) -> Dict[str, Any]:
                 "incorrect": rows[0][2] or 0,
             }
     except Exception as e:
-        print(f"Error loading high confidence metrics: {e}")
+        logger.error(f"Error loading high confidence metrics: {e}")
 
     return {"win_rate": 0.0, "total": 0, "correct": 0, "incorrect": 0}
 
@@ -1462,7 +1462,7 @@ def get_best_performing_asset(days: int = None) -> Dict[str, Any]:
                 "accuracy": round((correct / total * 100) if total > 0 else 0, 1),
             }
     except Exception as e:
-        print(f"Error loading best performing asset: {e}")
+        logger.error(f"Error loading best performing asset: {e}")
 
     return {"symbol": "N/A", "total_pnl": 0.0, "prediction_count": 0, "accuracy": 0.0}
 
@@ -1505,7 +1505,7 @@ def get_accuracy_over_time(days: int = None) -> pd.DataFrame:
             df["week"] = pd.to_datetime(df["week"])
         return df
     except Exception as e:
-        print(f"Error loading accuracy over time: {e}")
+        logger.error(f"Error loading accuracy over time: {e}")
         return pd.DataFrame()
 
 
@@ -1584,7 +1584,7 @@ def get_backtest_simulation(
             "win_rate": round(win_rate, 1),
         }
     except Exception as e:
-        print(f"Error running backtest simulation: {e}")
+        logger.error(f"Error running backtest simulation: {e}")
         return {
             "initial_capital": initial_capital,
             "final_value": initial_capital,
@@ -1633,7 +1633,7 @@ def get_sentiment_accuracy(days: int = None) -> pd.DataFrame:
             df["accuracy"] = (df["correct"] / df["total"] * 100).round(1)
         return df
     except Exception as e:
-        print(f"Error loading sentiment accuracy: {e}")
+        logger.error(f"Error loading sentiment accuracy: {e}")
         return pd.DataFrame()
 
 


### PR DESCRIPTION
## Summary
- **Finding #3**: `ShitpostAnalyzer.initialize()` now sets `db_ops`, `shitpost_ops`, `prediction_ops` — previously left as `None`, causing `AttributeError` on first use in production
- **Finding #9**: Changed `anthropic.Anthropic` → `anthropic.AsyncAnthropic` in `LLMClient.__init__()` so `await` calls work correctly
- **Finding #15**: Converted 26 `print(f"Error ...")` → `logger.error()` in `shitty_ui/data.py` for consistent structured logging
- **Findings #10, #18**: Already resolved (Plan 03) or accepted as-is per plan

Also fixed 6 analyzer tests mocking removed bypass methods, and removed 12 dead tests for methods that no longer exist (bypass logic is tested in `test_bypass_service.py`).

## Test plan
- [x] `pytest shit_tests/shitpost_ai/test_shitpost_analyzer.py` — 31 passed
- [x] `pytest shit_tests/shit/llm/test_llm_client.py` — 43 passed
- [x] `pytest shit_tests/shitty_ui/` — 210 passed
- [x] Full suite: 1348 passed, 10 pre-existing failures (config + prediction_operations)
- [x] Verification checklist: `AsyncAnthropic` present, no `sys.path`, no `print(Error)` in data.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)