### PR TITLE
feat: add /signals feed page with filtering, pagination, and CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Signal Feed Page** (`/signals`) - Chronological, filterable stream of all LLM-generated predictions
+  - Multi-filter bar: sentiment, confidence range slider, asset dropdown, outcome (correct/incorrect/pending)
+  - Paginated card feed with "Load More" button (20 signals per page)
+  - Real-time polling (2-minute interval) with "New Signals" banner
+  - CSV export of current filtered results
+  - Detailed signal cards: confidence bar, outcome badges, return/P&L metrics, thesis preview
+  - 45 new tests: 25 data layer tests + 20 layout/component tests
 - **Critical Test Coverage** - 85 new tests across 4 files for previously untested production-critical modules
   - `test_outcome_calculator.py` (29 tests) — init, context manager, `_extract_sentiment`, `calculate_outcome_for_prediction`, `_calculate_single_outcome`, `calculate_outcomes_for_all_predictions`, `get_accuracy_stats`; coverage 92%
   - `test_client.py` (22 tests) — init, context manager, `_get_existing_prices`, `fetch_price_history`, `get_price_on_date`, `get_latest_price`, `update_prices_for_symbols`, `get_price_stats`; coverage 76%

--- a/documentation/planning/05_SIGNAL_FEED.md
+++ b/documentation/planning/05_SIGNAL_FEED.md
@@ -1,6 +1,6 @@
-# Signal Feed Page Specification [PENDING]
+# Signal Feed Page Specification [COMPLETE]
 
-> **STATUS: 🔧 IN PROGRESS** — Started: 2026-02-10
+> **STATUS: ✅ COMPLETE** — Started: 2026-02-10 | Completed: 2026-02-10
 
 ### Implementation Notes (2026-02-10)
 

--- a/documentation/planning/05_SIGNAL_FEED.md
+++ b/documentation/planning/05_SIGNAL_FEED.md
@@ -1,6 +1,25 @@
 # Signal Feed Page Specification [PENDING]
 
-> **STATUS: PENDING** - Not yet implemented. Lower priority than Performance (03) and Asset Deep Dive (04).
+> **STATUS: 🔧 IN PROGRESS** — Started: 2026-02-10
+
+### Implementation Notes (2026-02-10)
+
+**Codebase has changed since this spec was written.** PR #47 decomposed the 3,862-line `layout.py` monolith into a modular structure. Key remapping:
+
+| Plan says | Actual location |
+|-----------|----------------|
+| Add components to `layout.py` | `components/cards.py` for cards, `pages/signals.py` for page |
+| Add callbacks to `layout.py` | `callbacks/signals.py` (new file) |
+| `COLORS` in `layout.py` | `constants.py` |
+| Add `dcc.Location` to `create_app()` | Already exists in `layout.py` |
+| Add routing callback | Already exists — just add `/signals` route |
+| Extract `create_main_dashboard_page()` | Already done as `create_dashboard_page()` in `pages/dashboard.py` |
+| Nav bar in `layout.py` | `components/header.py` |
+| `print()` for error logging | Use `logger.error()` (existing pattern) |
+
+**Polling design fix:** Remove poll interval from main feed loader inputs. Poll only triggers new-signals banner check. Separate `dcc.Store("signal-feed-refresh-trigger")` handles "Show New Signals" reload.
+
+---
 
 ## Implementation Context for Engineering Team
 

--- a/shitty_ui/components/header.py
+++ b/shitty_ui/components/header.py
@@ -53,6 +53,14 @@ def create_header():
                             ),
                             dcc.Link(
                                 [
+                                    html.I(className="fas fa-rss me-1"),
+                                    "Signals",
+                                ],
+                                href="/signals",
+                                className="nav-link-custom",
+                            ),
+                            dcc.Link(
+                                [
                                     html.I(className="fas fa-chart-pie me-1"),
                                     "Performance",
                                 ],

--- a/shitty_ui/layout.py
+++ b/shitty_ui/layout.py
@@ -16,8 +16,10 @@ from constants import COLORS
 from components.cards import (
     create_error_card,
     create_empty_chart,
+    create_feed_signal_card,
     create_hero_signal_card,
     create_metric_card,
+    create_new_signals_banner,
     create_signal_card,
     create_post_card,
     create_prediction_timeline_card,
@@ -32,6 +34,7 @@ from pages.dashboard import (
     register_dashboard_callbacks,
 )
 from pages.assets import create_asset_page, create_asset_header, register_asset_callbacks
+from pages.signals import create_signal_feed_page, register_signal_callbacks
 from callbacks.alerts import (
     create_alert_config_panel,
     create_alert_history_panel,
@@ -277,9 +280,13 @@ def register_callbacks(app: Dash):
         if pathname == "/performance":
             return create_performance_page()
 
+        if pathname == "/signals":
+            return create_signal_feed_page()
+
         return create_dashboard_page()
 
     # Delegate to page/callback modules
     register_dashboard_callbacks(app)
     register_asset_callbacks(app)
+    register_signal_callbacks(app)
     register_alert_callbacks(app)

--- a/shitty_ui/pages/signals.py
+++ b/shitty_ui/pages/signals.py
@@ -1,0 +1,568 @@
+"""Signal feed page layout and callbacks for the /signals route."""
+
+from datetime import datetime
+
+from dash import Dash, html, dcc, Input, Output, State
+from dash.exceptions import PreventUpdate
+import dash_bootstrap_components as dbc
+
+from constants import COLORS
+from components.cards import create_feed_signal_card, create_new_signals_banner
+
+PAGE_SIZE = 20
+
+
+def create_signal_feed_page() -> html.Div:
+    """
+    Create the full /signals feed page layout.
+
+    Structure:
+    - Header with "New signals" indicator
+    - Filter bar (sentiment, confidence, asset, outcome)
+    - Signal card feed (scrollable list)
+    - "Load More" button at the bottom
+    - Export CSV button
+    """
+    return html.Div(
+        [
+            # Page header
+            html.Div(
+                [
+                    html.H2(
+                        [
+                            html.I(className="fas fa-rss me-2"),
+                            "Signal Feed",
+                        ],
+                        style={"margin": 0, "fontWeight": "bold"},
+                    ),
+                    html.P(
+                        "Live predictions from Trump's Truth Social posts",
+                        style={
+                            "color": COLORS["text_muted"],
+                            "margin": 0,
+                            "fontSize": "0.9rem",
+                        },
+                    ),
+                ],
+                style={"marginBottom": "20px"},
+            ),
+            # New-signals banner (hidden by default)
+            html.Div(
+                id="new-signals-banner",
+                children=[],
+                style={"display": "none"},
+            ),
+            # Polling interval (2 minutes) — only for new-signals check
+            dcc.Interval(
+                id="signal-feed-poll-interval",
+                interval=2 * 60 * 1000,
+                n_intervals=0,
+            ),
+            # Client-side stores
+            dcc.Store(id="signal-feed-last-seen-ts", data=None),
+            dcc.Store(id="signal-feed-offset", data=0),
+            dcc.Store(id="signal-feed-refresh-trigger", data=0),
+            dcc.Download(id="signal-feed-csv-download"),
+            # Filter bar
+            dbc.Card(
+                [
+                    dbc.CardBody(
+                        [
+                            dbc.Row(
+                                [
+                                    # Sentiment filter
+                                    dbc.Col(
+                                        [
+                                            html.Label(
+                                                "Sentiment",
+                                                className="small",
+                                                style={
+                                                    "color": COLORS["text_muted"]
+                                                },
+                                            ),
+                                            dcc.Dropdown(
+                                                id="signal-feed-sentiment-filter",
+                                                options=[
+                                                    {
+                                                        "label": "All Sentiments",
+                                                        "value": "all",
+                                                    },
+                                                    {
+                                                        "label": "Bullish",
+                                                        "value": "bullish",
+                                                    },
+                                                    {
+                                                        "label": "Bearish",
+                                                        "value": "bearish",
+                                                    },
+                                                ],
+                                                value="all",
+                                                clearable=False,
+                                                style={"fontSize": "0.9rem"},
+                                            ),
+                                        ],
+                                        xs=12,
+                                        sm=6,
+                                        md=3,
+                                    ),
+                                    # Confidence slider
+                                    dbc.Col(
+                                        [
+                                            html.Label(
+                                                "Confidence Range",
+                                                className="small",
+                                                style={
+                                                    "color": COLORS["text_muted"]
+                                                },
+                                            ),
+                                            dcc.RangeSlider(
+                                                id="signal-feed-confidence-slider",
+                                                min=0,
+                                                max=1,
+                                                step=0.05,
+                                                value=[0, 1],
+                                                marks={
+                                                    0: {
+                                                        "label": "0%",
+                                                        "style": {
+                                                            "color": COLORS[
+                                                                "text_muted"
+                                                            ]
+                                                        },
+                                                    },
+                                                    0.5: {
+                                                        "label": "50%",
+                                                        "style": {
+                                                            "color": COLORS[
+                                                                "text_muted"
+                                                            ]
+                                                        },
+                                                    },
+                                                    1: {
+                                                        "label": "100%",
+                                                        "style": {
+                                                            "color": COLORS[
+                                                                "text_muted"
+                                                            ]
+                                                        },
+                                                    },
+                                                },
+                                                tooltip={
+                                                    "placement": "bottom",
+                                                    "always_visible": False,
+                                                },
+                                            ),
+                                        ],
+                                        xs=12,
+                                        sm=6,
+                                        md=3,
+                                    ),
+                                    # Asset filter
+                                    dbc.Col(
+                                        [
+                                            html.Label(
+                                                "Asset",
+                                                className="small",
+                                                style={
+                                                    "color": COLORS["text_muted"]
+                                                },
+                                            ),
+                                            dcc.Dropdown(
+                                                id="signal-feed-asset-filter",
+                                                options=[],
+                                                placeholder="All Assets",
+                                                style={"fontSize": "0.9rem"},
+                                            ),
+                                        ],
+                                        xs=12,
+                                        sm=6,
+                                        md=3,
+                                    ),
+                                    # Outcome filter
+                                    dbc.Col(
+                                        [
+                                            html.Label(
+                                                "Outcome",
+                                                className="small",
+                                                style={
+                                                    "color": COLORS["text_muted"]
+                                                },
+                                            ),
+                                            dcc.Dropdown(
+                                                id="signal-feed-outcome-filter",
+                                                options=[
+                                                    {
+                                                        "label": "All Outcomes",
+                                                        "value": "all",
+                                                    },
+                                                    {
+                                                        "label": "Correct",
+                                                        "value": "correct",
+                                                    },
+                                                    {
+                                                        "label": "Incorrect",
+                                                        "value": "incorrect",
+                                                    },
+                                                    {
+                                                        "label": "Pending",
+                                                        "value": "pending",
+                                                    },
+                                                ],
+                                                value="all",
+                                                clearable=False,
+                                                style={"fontSize": "0.9rem"},
+                                            ),
+                                        ],
+                                        xs=12,
+                                        sm=6,
+                                        md=3,
+                                    ),
+                                ],
+                                className="g-3",
+                            )
+                        ]
+                    )
+                ],
+                style={
+                    "backgroundColor": COLORS["secondary"],
+                    "border": f"1px solid {COLORS['border']}",
+                    "marginBottom": "20px",
+                },
+            ),
+            # Signal count + Export button row
+            html.Div(
+                [
+                    html.Span(
+                        id="signal-feed-count-label",
+                        children="Loading signals...",
+                        style={
+                            "color": COLORS["text_muted"],
+                            "fontSize": "0.85rem",
+                        },
+                    ),
+                    dbc.Button(
+                        [
+                            html.I(className="fas fa-download me-2"),
+                            "Export CSV",
+                        ],
+                        id="signal-feed-export-btn",
+                        color="secondary",
+                        size="sm",
+                        outline=True,
+                        style={"float": "right"},
+                    ),
+                ],
+                style={
+                    "marginBottom": "15px",
+                    "overflow": "hidden",
+                },
+            ),
+            # Signal cards container
+            dcc.Loading(
+                id="signal-feed-loading",
+                type="circle",
+                color=COLORS["accent"],
+                children=html.Div(
+                    id="signal-feed-cards-container",
+                    children=[],
+                ),
+            ),
+            # Load More button
+            html.Div(
+                id="signal-feed-load-more-container",
+                children=[
+                    dbc.Button(
+                        [
+                            html.I(className="fas fa-chevron-down me-2"),
+                            "Load More Signals",
+                        ],
+                        id="signal-feed-load-more-btn",
+                        color="secondary",
+                        outline=True,
+                        className="w-100 mt-3",
+                    ),
+                ],
+            ),
+        ],
+        style={
+            "padding": "20px",
+            "maxWidth": "900px",
+            "margin": "0 auto",
+        },
+    )
+
+
+def register_signal_callbacks(app: Dash):
+    """Register all callbacks for the signal feed page."""
+
+    # 3.1 Main Feed Loader — fires on filter changes and refresh trigger
+    @app.callback(
+        [
+            Output("signal-feed-cards-container", "children"),
+            Output("signal-feed-count-label", "children"),
+            Output("signal-feed-offset", "data"),
+            Output("signal-feed-last-seen-ts", "data"),
+            Output("signal-feed-load-more-container", "style"),
+        ],
+        [
+            Input("signal-feed-sentiment-filter", "value"),
+            Input("signal-feed-confidence-slider", "value"),
+            Input("signal-feed-asset-filter", "value"),
+            Input("signal-feed-outcome-filter", "value"),
+            Input("signal-feed-refresh-trigger", "data"),
+        ],
+    )
+    def update_signal_feed(
+        sentiment, confidence_range, asset, outcome, refresh_trigger
+    ):
+        """Load or reload the signal feed with current filter values."""
+        from data import get_signal_feed, get_signal_feed_count
+
+        # Normalize filter values
+        sentiment_val = sentiment if sentiment != "all" else None
+        outcome_val = outcome if outcome != "all" else None
+        conf_min = confidence_range[0] if confidence_range else None
+        conf_max = confidence_range[1] if confidence_range else None
+
+        if conf_min == 0 and conf_max == 1:
+            conf_min = None
+            conf_max = None
+
+        df = get_signal_feed(
+            limit=PAGE_SIZE,
+            offset=0,
+            sentiment_filter=sentiment_val,
+            confidence_min=conf_min,
+            confidence_max=conf_max,
+            asset_filter=asset,
+            outcome_filter=outcome_val,
+        )
+
+        total_count = get_signal_feed_count(
+            sentiment_filter=sentiment_val,
+            confidence_min=conf_min,
+            confidence_max=conf_max,
+            asset_filter=asset,
+            outcome_filter=outcome_val,
+        )
+
+        if df.empty:
+            cards = [
+                html.Div(
+                    [
+                        html.I(
+                            className="fas fa-inbox",
+                            style={
+                                "fontSize": "2rem",
+                                "color": COLORS["text_muted"],
+                            },
+                        ),
+                        html.P(
+                            "No signals match your filters.",
+                            style={
+                                "color": COLORS["text_muted"],
+                                "marginTop": "10px",
+                            },
+                        ),
+                    ],
+                    style={"textAlign": "center", "padding": "40px"},
+                )
+            ]
+            return cards, "No signals found", 0, None, {"display": "none"}
+
+        cards = [create_feed_signal_card(row) for _, row in df.iterrows()]
+        count_label = f"Showing {len(df)} of {total_count} signals"
+
+        newest_ts = df["timestamp"].iloc[0]
+        if isinstance(newest_ts, datetime):
+            last_seen_ts = newest_ts.isoformat()
+        else:
+            last_seen_ts = str(newest_ts)
+
+        load_more_style = (
+            {"display": "block"} if total_count > PAGE_SIZE else {"display": "none"}
+        )
+
+        return cards, count_label, PAGE_SIZE, last_seen_ts, load_more_style
+
+    # 3.2 Load More Button
+    @app.callback(
+        [
+            Output(
+                "signal-feed-cards-container", "children", allow_duplicate=True
+            ),
+            Output("signal-feed-offset", "data", allow_duplicate=True),
+            Output(
+                "signal-feed-count-label", "children", allow_duplicate=True
+            ),
+            Output(
+                "signal-feed-load-more-container", "style", allow_duplicate=True
+            ),
+        ],
+        [Input("signal-feed-load-more-btn", "n_clicks")],
+        [
+            State("signal-feed-cards-container", "children"),
+            State("signal-feed-offset", "data"),
+            State("signal-feed-sentiment-filter", "value"),
+            State("signal-feed-confidence-slider", "value"),
+            State("signal-feed-asset-filter", "value"),
+            State("signal-feed-outcome-filter", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def load_more_signals(
+        n_clicks,
+        existing_cards,
+        current_offset,
+        sentiment,
+        confidence_range,
+        asset,
+        outcome,
+    ):
+        """Append the next page of signal cards to the feed."""
+        from data import get_signal_feed, get_signal_feed_count
+
+        if not n_clicks:
+            raise PreventUpdate
+
+        sentiment_val = sentiment if sentiment != "all" else None
+        outcome_val = outcome if outcome != "all" else None
+        conf_min = confidence_range[0] if confidence_range else None
+        conf_max = confidence_range[1] if confidence_range else None
+
+        if conf_min == 0 and conf_max == 1:
+            conf_min = None
+            conf_max = None
+
+        df = get_signal_feed(
+            limit=PAGE_SIZE,
+            offset=current_offset,
+            sentiment_filter=sentiment_val,
+            confidence_min=conf_min,
+            confidence_max=conf_max,
+            asset_filter=asset,
+            outcome_filter=outcome_val,
+        )
+
+        total_count = get_signal_feed_count(
+            sentiment_filter=sentiment_val,
+            confidence_min=conf_min,
+            confidence_max=conf_max,
+            asset_filter=asset,
+            outcome_filter=outcome_val,
+        )
+
+        if df.empty:
+            return (
+                existing_cards,
+                current_offset,
+                f"Showing all {current_offset} signals",
+                {"display": "none"},
+            )
+
+        new_cards = [create_feed_signal_card(row) for _, row in df.iterrows()]
+        updated_cards = (existing_cards or []) + new_cards
+
+        new_offset = current_offset + len(df)
+        count_label = f"Showing {new_offset} of {total_count} signals"
+
+        load_more_style = (
+            {"display": "block"}
+            if new_offset < total_count
+            else {"display": "none"}
+        )
+
+        return updated_cards, new_offset, count_label, load_more_style
+
+    # 3.3 New-Signals Polling
+    @app.callback(
+        [
+            Output("new-signals-banner", "children"),
+            Output("new-signals-banner", "style"),
+        ],
+        [Input("signal-feed-poll-interval", "n_intervals")],
+        [State("signal-feed-last-seen-ts", "data")],
+    )
+    def check_for_new_signals(n_intervals, last_seen_ts):
+        """Poll for new signals and show/hide the banner."""
+        from data import get_new_signals_since
+
+        if not last_seen_ts:
+            return [], {"display": "none"}
+
+        new_count = get_new_signals_since(last_seen_ts)
+
+        if new_count > 0:
+            banner = create_new_signals_banner(new_count)
+            return [banner], {"display": "block"}
+        else:
+            return [], {"display": "none"}
+
+    # 3.4 Show New Signals Button — triggers feed reload via refresh store
+    @app.callback(
+        Output("signal-feed-refresh-trigger", "data"),
+        [Input("signal-feed-show-new-btn", "n_clicks")],
+        [State("signal-feed-refresh-trigger", "data")],
+        prevent_initial_call=True,
+    )
+    def trigger_feed_reload_on_show_new(n_clicks, current_value):
+        """Force a feed reload when user clicks 'Show New Signals'."""
+        if not n_clicks:
+            raise PreventUpdate
+        return (current_value or 0) + 1
+
+    # 3.5 CSV Export
+    @app.callback(
+        Output("signal-feed-csv-download", "data"),
+        [Input("signal-feed-export-btn", "n_clicks")],
+        [
+            State("signal-feed-sentiment-filter", "value"),
+            State("signal-feed-confidence-slider", "value"),
+            State("signal-feed-asset-filter", "value"),
+            State("signal-feed-outcome-filter", "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def export_signal_feed_csv(
+        n_clicks, sentiment, confidence_range, asset, outcome
+    ):
+        """Export the current filtered signal feed to a CSV file."""
+        from data import get_signal_feed_csv
+
+        if not n_clicks:
+            raise PreventUpdate
+
+        sentiment_val = sentiment if sentiment != "all" else None
+        outcome_val = outcome if outcome != "all" else None
+        conf_min = confidence_range[0] if confidence_range else None
+        conf_max = confidence_range[1] if confidence_range else None
+
+        if conf_min == 0 and conf_max == 1:
+            conf_min = None
+            conf_max = None
+
+        export_df = get_signal_feed_csv(
+            sentiment_filter=sentiment_val,
+            confidence_min=conf_min,
+            confidence_max=conf_max,
+            asset_filter=asset,
+            outcome_filter=outcome_val,
+        )
+
+        if export_df.empty:
+            return None
+
+        filename = f"shitpost_alpha_signals_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
+        return dcc.send_data_frame(export_df.to_csv, filename, index=False)
+
+    # 3.6 Asset Filter Dropdown Population
+    @app.callback(
+        Output("signal-feed-asset-filter", "options"),
+        [Input("signal-feed-poll-interval", "n_intervals")],
+    )
+    def populate_signal_feed_asset_filter(n_intervals):
+        """Populate the asset filter dropdown with assets from the database."""
+        from data import get_active_assets_from_db
+
+        assets = get_active_assets_from_db()
+        return [{"label": a, "value": a} for a in assets]


### PR DESCRIPTION
## Summary
- Adds a new `/signals` feed page — a chronological, filterable stream of all LLM-generated predictions
- Multi-filter bar: sentiment, confidence range slider, asset dropdown, outcome (correct/incorrect/pending)
- Paginated card feed with "Load More" button (20 signals per page)
- Real-time polling (2-minute interval) with "New Signals" banner and one-click refresh
- CSV export of current filtered results
- Detailed signal cards: confidence bar, outcome badges, return/P&L metrics, thesis preview

## Implementation
- **Data layer** (`data.py`): 4 new functions — `get_signal_feed`, `get_signal_feed_count`, `get_new_signals_since`, `get_signal_feed_csv`
- **Components** (`components/cards.py`): 2 new components — `create_feed_signal_card`, `create_new_signals_banner`
- **Page** (`pages/signals.py`): New file with full page layout and 6 callbacks
- **Routing** (`layout.py`, `components/header.py`): Added `/signals` route and nav link

## Test plan
- [x] 25 data layer tests (TestGetSignalFeed, TestGetSignalFeedCount, TestGetNewSignalsSince, TestGetSignalFeedCsv)
- [x] 20 layout/component tests (TestCreateFeedSignalCard, TestCreateNewSignalsBanner, TestCreateSignalFeedPage)
- [x] All 255 shitty_ui tests pass
- [x] No regressions in existing tests

Implements: `documentation/planning/05_SIGNAL_FEED.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)