### PR TITLE
feat: reactive ticker lifecycle with auto-backfill on prediction creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Reactive Ticker Lifecycle** - LLM analyzer now triggers market data backfill immediately when a prediction contains new tickers
+  - New `ticker_registry` database table tracks all ticker symbols the system has ever encountered
+  - `TickerRegistryService` manages ticker lifecycle (active/inactive/invalid status)
+  - `ShitpostAnalyzer._trigger_reactive_backfill()` runs backfill in a thread executor after each successful analysis
+  - `AutoBackfillService` integrates with ticker registry for registration and metadata updates
+  - Railway `market-data` cron reduced to 7-day lookback (reactive backfill handles new predictions immediately)
+  - New CLI commands: `ticker-registry` (view tracked tickers) and `register-tickers` (manually add tickers)
 - **Signal Feed Page** (`/signals`) - Chronological, filterable stream of all LLM-generated predictions
   - Multi-filter bar: sentiment, confidence range slider, asset dropdown, outcome (correct/incorrect/pending)
   - Paginated card feed with "Load More" button (20 signals per page)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,10 +287,18 @@ python -m shitposts --mode backfill --from 2024-01-01 --to 2024-12-31
 - P&L simulation: `pnl_t1`, `pnl_t3`, `pnl_t7`, `pnl_t30` ($1000 position)
 - `is_complete` (boolean) -- All timeframes tracked?
 
+**`ticker_registry`** - Registry of all tracked ticker symbols
+- `id`, `symbol` (unique), `first_seen_date`
+- `source_prediction_id` (FK → predictions.id)
+- `status` (active/inactive/invalid), `status_reason`
+- `last_price_update`, `price_data_start`, `price_data_end`, `total_price_records`
+- `asset_type`, `exchange`
+
 **`subscribers`** - SMS alert subscribers (schema defined, not yet active)
 **`llm_feedback`** - LLM performance feedback (schema defined, not yet active)
 
 **Indexes**:
+- `ticker_registry`: (`symbol` unique), (`status`), (`first_seen_date`)
 - `truth_social_shitposts`: (`shitpost_id` unique), (`timestamp`)
 - `predictions`: (`shitpost_id`)
 - `market_prices`: (`symbol`, `date` unique composite)

--- a/documentation/planning/phases/system-evolution_2026-02-11/00_OVERVIEW.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/00_OVERVIEW.md
@@ -1,0 +1,136 @@
+# System Evolution - Enhancement Session Overview
+
+## Session Context
+
+| Field | Value |
+|---|---|
+| **Session Name** | `system-evolution` |
+| **Date** | 2026-02-11 |
+| **Scope** | Whole system |
+| **User's Stated Goals** | Transform from single-source Truth Social pipeline into a generalizable multi-source signal feed: source → LLM → prediction → measurement → display |
+
+### Core User Intent
+
+1. **Reactive measurement**: When a ticker appears in a prediction, market data should auto-backfill immediately
+2. **Source-agnostic architecture**: Data model shouldn't be anchored to Truth Social; support future sources (Twitter/X, etc.)
+3. **Signal visualization**: Dashboard should juxtapose signals over market trend charts
+4. **Deploy existing code**: Alerts and market data cron exist but aren't deployed to production infra
+5. **LLM flexibility**: Evaluate Claude/Grok alongside OpenAI
+6. **Multi-source harvesting**: Abstract harvester layer to support pluggable data sources
+7. **Data resilience**: Fallback price providers, health checks, retry logic
+
+---
+
+## Phase Documents
+
+| # | Title | PR Title | Risk | Effort | Summary |
+|---|-------|----------|------|--------|---------|
+| 01 | [Reactive Ticker Lifecycle](01_reactive-ticker-lifecycle.md) | `feat: reactive ticker lifecycle with auto-backfill on prediction creation` | Low | Medium (3-5h) | Event-driven market data backfill triggered by LLM predictions. Creates TickerRegistry for tracking all tickers the system encounters. |
+| 02 | [Source-Agnostic Data Model](02_source-agnostic-data-model.md) | `feat: introduce source-agnostic Signal model for multi-platform support` | Medium | High (3-5d) | Generic `Signal` model replacing coupling to Truth Social. Dual-FK migration on Prediction, dual-write during transition. |
+| 03 | [Signal-Over-Trend View](03_signal-over-trend-view.md) | `feat(ui): add signal-over-trend chart view with price overlays` | Low | Medium (2-3d) | Plotly candlestick charts with prediction signal overlays. New `/trends` route with asset selector and time range controls. |
+| 04 | [Deploy Alerts to Production](04_deploy-alerts-production.md) | `fix+feat: deploy Telegram alerts to production with MarkdownV2 fix` | Low | Low (2-3h) | Fix MarkdownV2 parse_mode bug, add notifications cron to Railway, add health check endpoint, BotFather setup guide. |
+| 05 | [LLM Provider Switch](05_llm-provider-switch.md) | `feat: add Grok/xAI as third LLM provider with comparison CLI` | Low | Medium (3-5h) | Grok/xAI via OpenAI-compatible API. Provider config module, comparison CLI for side-by-side analysis across providers. |
+| 06 | [Harvester Abstraction Layer](06_harvester-abstraction-layer.md) | `feat: abstract harvester layer for multi-source signal collection` | Medium | Medium (3-5h) | Abstract `SignalHarvester` base class, `HarvesterRegistry` with config-driven source management, skeleton TwitterHarvester template. |
+| 07 | [Market Data Resilience](07_market-data-resilience.md) | `feat: multi-provider price fetching with fallback and health monitoring` | Low | Medium (3-5h) | Alpha Vantage as fallback provider, retry with exponential backoff, data freshness monitoring, health-check CLI. |
+
+---
+
+## Dependency Graph
+
+```
+Phase 01: Reactive Ticker Lifecycle
+  ├── (no dependencies - start here)
+  │
+  ├──→ Phase 02: Source-Agnostic Data Model (depends on 01)
+  │     └──→ Phase 06: Harvester Abstraction Layer (depends on 02)
+  │
+  ├──→ Phase 03: Signal-Over-Trend View (depends on 01)
+  │
+  └──→ Phase 07: Market Data Resilience (depends on 01)
+
+Phase 04: Deploy Alerts to Production
+  ├── (no dependencies - can run in parallel with 01)
+
+Phase 05: LLM Provider Switch
+  ├── (no dependencies - can run in parallel with 01)
+```
+
+### Implementation Order (recommended)
+
+1. **Phase 01** - Foundation: everything else builds on ticker tracking
+2. **Phase 04** - Independent: can start immediately (parallel with 01)
+3. **Phase 05** - Independent: can start immediately (parallel with 01)
+4. **Phase 02** - After Phase 01 merges (modifies analyzer that 01 also touches)
+5. **Phase 03** - After Phase 01 merges (needs ticker data for charts)
+6. **Phase 07** - After Phase 01 merges (extends market data client from 01)
+7. **Phase 06** - After Phase 02 merges (builds on source-agnostic model)
+
+### Parallel-Safe Phases
+
+These phase pairs touch **completely disjoint files** and can safely run in parallel:
+
+- **01 + 04**: Ticker lifecycle vs. Telegram alerts (no shared files)
+- **01 + 05**: Ticker lifecycle vs. LLM provider switch (both touch `shitpost_analyzer.py` but different functions -- use caution)
+- **04 + 05**: Deploy alerts vs. LLM provider switch (no shared files)
+- **03 + 07**: Signal-over-trend view vs. market data resilience (no shared files after 01 merges)
+
+### Sequential Requirements
+
+These phases **must not run in parallel** due to shared file modifications:
+
+- **01 → 02**: Both modify `shitpost_ai/shitpost_analyzer.py` and `shit/db/sync_session.py`
+- **02 → 06**: Phase 06 builds on the source-agnostic model from Phase 02
+- **01 → 07**: Both modify `shit/market_data/client.py` and market data infrastructure
+
+---
+
+## Total Estimated Effort
+
+| Category | Estimate |
+|----------|----------|
+| **Implementation** | ~20-30 hours |
+| **Testing** | ~8-12 hours |
+| **Total** | ~28-42 hours |
+| **New tests** | ~250+ across all phases |
+| **PRs** | 7 |
+
+---
+
+## Key Architectural Decisions
+
+1. **Dual-write migration** (Phase 02): Write to both `truth_social_shitposts` and new `signals` table during transition. No big-bang migration.
+2. **Thread executor pattern** (Phase 01): Run sync backfill code from async analyzer via `loop.run_in_executor` to avoid blocking the event loop.
+3. **OpenAI SDK reuse** (Phase 05): Grok uses the `openai` Python package with a custom `base_url` -- no new dependencies.
+4. **Registry pattern** (Phase 06): Config-driven harvester registration with lazy imports to avoid circular dependencies.
+5. **Provider chain** (Phase 07): Ordered list of price providers with automatic fallback. yfinance remains primary; Alpha Vantage is backup.
+
+---
+
+## Files Index
+
+Quick reference of all files created/modified across all phases:
+
+### New Files Created
+- `shit/market_data/ticker_registry.py` (Phase 01)
+- `shitvault/signal_models.py` (Phase 02)
+- `shitvault/signal_operations.py` (Phase 02)
+- `shit/db/signal_utils.py` (Phase 02)
+- `shitty_ui/pages/trends.py` (Phase 03)
+- `shitty_ui/components/charts.py` (Phase 03)
+- `shit/llm/provider_config.py` (Phase 05)
+- `shit/llm/compare_providers.py` (Phase 05)
+- `shitposts/base_harvester.py` (Phase 06)
+- `shitposts/harvester_registry.py` (Phase 06)
+- `shitposts/harvester_models.py` (Phase 06)
+- `shitposts/twitter_harvester.py` (Phase 06 - skeleton)
+- `shit/market_data/price_provider.py` (Phase 07)
+- `shit/market_data/alphavantage_provider.py` (Phase 07)
+- `shit/market_data/health.py` (Phase 07)
+
+### Most-Modified Files (touch count)
+- `shitpost_ai/shitpost_analyzer.py` (Phases 01, 02)
+- `shit/db/sync_session.py` (Phases 01, 02)
+- `shit/config/shitpost_settings.py` (Phases 05, 07)
+- `shit/market_data/client.py` (Phases 01, 07)
+- `railway.json` (Phases 01, 04)
+- `CHANGELOG.md` (all phases)

--- a/documentation/planning/phases/system-evolution_2026-02-11/01_reactive-ticker-lifecycle.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/01_reactive-ticker-lifecycle.md
@@ -1,0 +1,916 @@
+# Phase 01: Reactive Ticker Lifecycle & Market Data Pipeline
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: reactive ticker lifecycle with auto-backfill on prediction creation` |
+| **Risk Level** | Low |
+| **Estimated Effort** | Medium (3-5 hours implementation, 1-2 hours testing) |
+| **Files Created** | `shit/market_data/ticker_registry.py`, `shit_tests/shit/market_data/test_ticker_registry.py`, `shit_tests/shit/market_data/test_auto_backfill_service.py`, `shit_tests/shitpost_ai/test_reactive_backfill.py` |
+| **Files Modified** | `shit/market_data/models.py`, `shit/market_data/__init__.py`, `shit/market_data/auto_backfill_service.py`, `shit/market_data/cli.py`, `shitpost_ai/shitpost_analyzer.py`, `shit/db/sync_session.py`, `railway.json`, `CHANGELOG.md`, `CLAUDE.md` |
+| **Files Deleted** | None |
+
+---
+
+## Context: Why This Matters
+
+Currently the Shitpost Alpha pipeline has a critical gap in its measurement lifecycle:
+
+1. **The analyzer creates predictions with ticker symbols** (e.g., `["AAPL", "TSLA"]`) but does nothing to ensure market data exists for those tickers.
+2. **The `auto_backfill_service.py` exists** and is fully implemented, but it is never called from the analyzer. It sits idle.
+3. **The Railway `market-data` cron service is defined in `railway.json`** but is reportedly not deployed. Even if it were deployed, it only catches tickers on a 15-minute lag via batch processing of recent predictions.
+4. **The dashboard (`shitty_ui`) cannot show prediction outcomes** because `prediction_outcomes` rows are never created -- they depend on market price data that is never backfilled.
+5. **No ticker tracking exists.** There is no way to know which tickers the system has ever seen, when they were first encountered, or whether their price data is current.
+
+This phase closes the loop: when the LLM says "this post affects AAPL," the system immediately fetches AAPL's price history, registers the ticker for ongoing tracking, and calculates the initial outcome record. The dashboard becomes self-sustaining.
+
+---
+
+## Dependencies
+
+- **Phase 01 has no dependencies.** It is the first phase in the system-evolution session.
+- **Phases 03 and 07 depend on this phase.** Phase 03 (Signal-Over-Trend Dashboard View) requires `prediction_outcomes` to be populated automatically. Phase 07 (Market Data Resilience) requires the market data pipeline to be deployed first.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Add `TickerRegistry` SQLAlchemy Model
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/market_data/models.py`
+
+**What:** Add a new SQLAlchemy model at the end of the file (before the `Index` lines at line 151) that tracks every unique ticker symbol the system has ever encountered.
+
+**Why:** Without a registry, the system has no memory of which tickers it has seen. Every cron run re-discovers tickers from scratch by scanning all predictions. A registry enables: (a) instant "is this ticker new?" checks, (b) status tracking (active/inactive/invalid), (c) auditing when a ticker was first seen.
+
+Add this model after the `PredictionOutcome` class (after line 148, before line 150):
+
+```python
+class TickerRegistry(Base, IDMixin, TimestampMixin):
+    """Registry of all ticker symbols the system tracks.
+
+    Once a ticker appears in an LLM prediction, it is registered here
+    and tracked for ongoing price updates. This provides:
+    - Instant lookup of whether a ticker is already known
+    - Status tracking (active, inactive, invalid)
+    - Audit trail of when each ticker was first seen
+    - Source prediction linkage for debugging
+    """
+
+    __tablename__ = "ticker_registry"
+
+    # Ticker identification
+    symbol = Column(String(20), unique=True, nullable=False, index=True)
+
+    # Lifecycle tracking
+    first_seen_date = Column(Date, nullable=False, index=True)
+    source_prediction_id = Column(Integer, ForeignKey("predictions.id"), nullable=True)
+
+    # Status: active (tracked), inactive (manually disabled), invalid (yfinance can't find it)
+    status = Column(String(20), nullable=False, default="active", index=True)
+    status_reason = Column(String(255), nullable=True)
+
+    # Price data tracking
+    last_price_update = Column(DateTime, nullable=True)
+    price_data_start = Column(Date, nullable=True)
+    price_data_end = Column(Date, nullable=True)
+    total_price_records = Column(Integer, default=0)
+
+    # Metadata
+    asset_type = Column(String(20), nullable=True)  # stock, crypto, etf, commodity, index
+    exchange = Column(String(20), nullable=True)  # NYSE, NASDAQ, etc.
+
+    def __repr__(self):
+        return f"<TickerRegistry(symbol='{self.symbol}', status='{self.status}', first_seen={self.first_seen_date})>"
+```
+
+Also add indexes after the existing index declarations (after line 156):
+
+```python
+Index('idx_ticker_registry_symbol', TickerRegistry.symbol, unique=True)
+Index('idx_ticker_registry_status', TickerRegistry.status)
+```
+
+---
+
+### Step 2: Create `TickerRegistryService`
+
+**File to create:** `/Users/chris/Projects/shitpost-alpha/shit/market_data/ticker_registry.py`
+
+**What:** A service class that manages the ticker registry. It provides methods to register new tickers, check if tickers are already known, list active tickers, and update ticker metadata.
+
+**Why:** This encapsulates all registry logic in one place, following the project's pattern of having service classes (like `AutoBackfillService`, `BypassService`).
+
+```python
+"""
+Ticker Registry Service
+Manages the lifecycle of tracked ticker symbols.
+
+When the LLM analyzer identifies tickers in a prediction, this service:
+1. Checks if the ticker is already registered
+2. Registers new tickers with source_prediction_id
+3. Marks invalid tickers (ones yfinance cannot find)
+4. Provides the list of active tickers for the cron service to update
+"""
+
+from datetime import date, datetime
+from typing import List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+
+from shit.market_data.models import TickerRegistry, MarketPrice
+from shit.db.sync_session import get_session
+from shit.logging import get_service_logger
+
+logger = get_service_logger("ticker_registry")
+
+
+class TickerRegistryService:
+    """Manages the ticker registry for ongoing price tracking."""
+
+    def register_tickers(
+        self,
+        symbols: List[str],
+        source_prediction_id: Optional[int] = None,
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Register new tickers in the registry.
+
+        Args:
+            symbols: List of ticker symbols to register
+            source_prediction_id: ID of the prediction that introduced these tickers
+
+        Returns:
+            Tuple of (newly_registered, already_known) symbol lists
+        """
+        if not symbols:
+            return ([], [])
+
+        newly_registered = []
+        already_known = []
+
+        with get_session() as session:
+            for symbol in symbols:
+                symbol = symbol.strip().upper()
+
+                # Validate symbol format
+                if not symbol or len(symbol) > 20 or " " in symbol:
+                    logger.warning(f"Skipping invalid symbol format: '{symbol}'")
+                    continue
+
+                # Check if already registered
+                existing = (
+                    session.query(TickerRegistry)
+                    .filter(TickerRegistry.symbol == symbol)
+                    .first()
+                )
+
+                if existing:
+                    already_known.append(symbol)
+                    logger.debug(f"Ticker {symbol} already registered (status={existing.status})")
+                    continue
+
+                # Register new ticker
+                registry_entry = TickerRegistry(
+                    symbol=symbol,
+                    first_seen_date=date.today(),
+                    source_prediction_id=source_prediction_id,
+                    status="active",
+                    last_price_update=None,
+                    total_price_records=0,
+                )
+                session.add(registry_entry)
+                newly_registered.append(symbol)
+                logger.info(
+                    f"Registered new ticker: {symbol}",
+                    extra={"symbol": symbol, "source_prediction_id": source_prediction_id},
+                )
+
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                logger.info("IntegrityError during ticker registration, handling concurrent insert")
+
+        return (newly_registered, already_known)
+
+    def get_new_tickers(self, symbols: List[str]) -> List[str]:
+        """
+        Identify which tickers from a list are NOT yet registered.
+
+        Args:
+            symbols: List of ticker symbols to check
+
+        Returns:
+            List of symbols not yet in the registry
+        """
+        if not symbols:
+            return []
+
+        with get_session() as session:
+            existing = (
+                session.query(TickerRegistry.symbol)
+                .filter(TickerRegistry.symbol.in_([s.strip().upper() for s in symbols]))
+                .all()
+            )
+            existing_set = {row[0] for row in existing}
+
+        return [s for s in symbols if s.strip().upper() not in existing_set]
+
+    def get_active_tickers(self) -> List[str]:
+        """
+        Get all active tickers that should have prices updated.
+
+        Returns:
+            List of active ticker symbols
+        """
+        with get_session() as session:
+            results = (
+                session.query(TickerRegistry.symbol)
+                .filter(TickerRegistry.status == "active")
+                .all()
+            )
+            return [row[0] for row in results]
+
+    def mark_ticker_invalid(self, symbol: str, reason: str) -> None:
+        """
+        Mark a ticker as invalid (e.g., yfinance cannot find it).
+
+        Args:
+            symbol: Ticker symbol
+            reason: Why it is being marked invalid
+        """
+        with get_session() as session:
+            entry = (
+                session.query(TickerRegistry)
+                .filter(TickerRegistry.symbol == symbol.strip().upper())
+                .first()
+            )
+
+            if entry:
+                entry.status = "invalid"
+                entry.status_reason = reason[:255]
+                session.commit()
+                logger.info(f"Marked ticker {symbol} as invalid: {reason}")
+
+    def update_price_metadata(self, symbol: str) -> None:
+        """
+        Update a ticker's price metadata from the market_prices table.
+
+        Args:
+            symbol: Ticker symbol to update
+        """
+        from sqlalchemy import func
+
+        with get_session() as session:
+            entry = (
+                session.query(TickerRegistry)
+                .filter(TickerRegistry.symbol == symbol.strip().upper())
+                .first()
+            )
+
+            if not entry:
+                return
+
+            stats = (
+                session.query(
+                    func.min(MarketPrice.date).label("earliest"),
+                    func.max(MarketPrice.date).label("latest"),
+                    func.count(MarketPrice.id).label("count"),
+                )
+                .filter(MarketPrice.symbol == symbol)
+                .first()
+            )
+
+            if stats and stats.count > 0:
+                entry.price_data_start = stats.earliest
+                entry.price_data_end = stats.latest
+                entry.total_price_records = stats.count
+                entry.last_price_update = datetime.utcnow()
+                session.commit()
+
+    def get_registry_stats(self) -> dict:
+        """Get summary statistics about the ticker registry."""
+        from sqlalchemy import func
+
+        with get_session() as session:
+            total = session.query(func.count(TickerRegistry.id)).scalar() or 0
+            active = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "active")
+                .scalar()
+                or 0
+            )
+            invalid = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "invalid")
+                .scalar()
+                or 0
+            )
+            inactive = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "inactive")
+                .scalar()
+                or 0
+            )
+
+            return {
+                "total": total,
+                "active": active,
+                "invalid": invalid,
+                "inactive": inactive,
+            }
+```
+
+---
+
+### Step 3: Update `AutoBackfillService` to Use Ticker Registry
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/market_data/auto_backfill_service.py`
+
+**Change 1 -- Add import (after line 11):**
+
+```python
+from shit.market_data.ticker_registry import TickerRegistryService
+```
+
+**Change 2 -- Add registry to `__init__` (line 39-47):**
+
+Currently:
+```python
+def __init__(self, backfill_days: int = 365):
+    self.backfill_days = backfill_days
+    self.logger = logger
+```
+
+After:
+```python
+def __init__(self, backfill_days: int = 365):
+    self.backfill_days = backfill_days
+    self.logger = logger
+    self.registry = TickerRegistryService()
+```
+
+**Change 3 -- Update `backfill_ticker` method (line 95-147):**
+
+After a successful backfill (after line 133, inside the `if len(prices) > 0:` block), add:
+
+```python
+                    # Update ticker registry metadata
+                    try:
+                        self.registry.update_price_metadata(symbol)
+                    except Exception as reg_err:
+                        self.logger.warning(
+                            f"Failed to update registry metadata for {symbol}: {reg_err}",
+                            extra={"symbol": symbol}
+                        )
+```
+
+After an unsuccessful backfill where no price data is available (after line 138, inside the `else:` block for `len(prices) == 0`), add:
+
+```python
+                    # Mark as invalid in ticker registry if no data found
+                    try:
+                        self.registry.mark_ticker_invalid(symbol, "yfinance returned no price data")
+                    except Exception as reg_err:
+                        self.logger.warning(
+                            f"Failed to mark {symbol} invalid in registry: {reg_err}",
+                            extra={"symbol": symbol}
+                        )
+```
+
+**Change 4 -- Update `process_single_prediction` (line 149-201):**
+
+Inside the method, before the missing tickers check (after line 177 / before line 178), add:
+
+```python
+            # Register any new tickers in the ticker registry
+            try:
+                newly_registered, _ = self.registry.register_tickers(
+                    prediction.assets,
+                    source_prediction_id=prediction.id,
+                )
+                if newly_registered:
+                    self.logger.info(
+                        f"Registered {len(newly_registered)} new tickers: {newly_registered}",
+                        extra={"tickers": newly_registered, "prediction_id": prediction.id},
+                    )
+            except Exception as reg_err:
+                self.logger.warning(
+                    f"Failed to register tickers for prediction {prediction_id}: {reg_err}",
+                    extra={"prediction_id": prediction_id},
+                )
+```
+
+---
+
+### Step 4: Add Reactive Backfill Call in the Analyzer
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shitpost_ai/shitpost_analyzer.py`
+
+**Why:** Currently the analyzer stores a prediction and moves on. By adding one call here, we close the loop: prediction creation immediately triggers market data availability.
+
+**Important design decision:** The backfill uses synchronous code (via `get_session` and `MarketDataClient`). The analyzer is async. We must run the backfill in a thread executor to avoid blocking the event loop.
+
+**Change 1 -- Add import at the top of the file (after line 17):**
+
+```python
+import concurrent.futures
+from shit.market_data.auto_backfill_service import auto_backfill_prediction
+```
+
+**Change 2 -- Modify `_analyze_shitpost` method (around lines 381-394):**
+
+Currently (lines 381-394):
+```python
+            if not dry_run:
+                # Store analysis in database
+                analysis_id = await self.prediction_ops.store_analysis(
+                    shitpost_id,
+                    enhanced_analysis,
+                    shitpost
+                )
+
+                if analysis_id:
+                    logger.debug(f"Stored analysis for shitpost {shitpost_id}")
+                else:
+                    logger.warning(f"Failed to store analysis for shitpost {shitpost_id}")
+
+            return enhanced_analysis
+```
+
+After modification:
+```python
+            if not dry_run:
+                # Store analysis in database
+                analysis_id = await self.prediction_ops.store_analysis(
+                    shitpost_id,
+                    enhanced_analysis,
+                    shitpost
+                )
+
+                if analysis_id:
+                    logger.debug(f"Stored analysis for shitpost {shitpost_id}")
+
+                    # Reactively trigger market data backfill for new tickers
+                    assets = enhanced_analysis.get("assets", [])
+                    if assets:
+                        await self._trigger_reactive_backfill(int(analysis_id), assets)
+                else:
+                    logger.warning(f"Failed to store analysis for shitpost {shitpost_id}")
+
+            return enhanced_analysis
+```
+
+**Change 3 -- Add the `_trigger_reactive_backfill` method** (add after `_enhance_analysis_with_shitpost_data`, before `cleanup`, around line 472):
+
+```python
+    async def _trigger_reactive_backfill(self, prediction_id: int, assets: list) -> None:
+        """Trigger market data backfill for new tickers found in a prediction.
+
+        Runs the synchronous backfill service in a thread executor to avoid
+        blocking the async event loop. Failures are logged but do not
+        propagate -- the prediction was already stored successfully.
+
+        Args:
+            prediction_id: ID of the newly created prediction
+            assets: List of ticker symbols from the prediction
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                result = await loop.run_in_executor(
+                    executor,
+                    auto_backfill_prediction,
+                    prediction_id,
+                )
+
+            if result:
+                logger.info(
+                    f"Reactive backfill completed for prediction {prediction_id}, assets: {assets}",
+                    extra={"prediction_id": prediction_id, "assets": assets},
+                )
+            else:
+                logger.debug(
+                    f"Reactive backfill: no new data needed for prediction {prediction_id}",
+                    extra={"prediction_id": prediction_id, "assets": assets},
+                )
+
+        except Exception as e:
+            # Never let backfill failure break the analysis pipeline
+            logger.warning(
+                f"Reactive backfill failed for prediction {prediction_id}: {e}",
+                extra={"prediction_id": prediction_id, "assets": assets, "error": str(e)},
+            )
+```
+
+---
+
+### Step 5: Update Module Exports and Table Registration
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/market_data/__init__.py`
+
+Update imports and `__all__`:
+
+```python
+from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
+from shit.market_data.client import MarketDataClient
+from shit.market_data.outcome_calculator import OutcomeCalculator
+
+__all__ = [
+    "MarketPrice",
+    "PredictionOutcome",
+    "TickerRegistry",
+    "MarketDataClient",
+    "OutcomeCalculator",
+]
+```
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/db/sync_session.py`
+
+Update `create_tables()` (line 79) to import `TickerRegistry`:
+
+Currently:
+```python
+    from shit.market_data.models import MarketPrice, PredictionOutcome
+```
+
+After:
+```python
+    from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
+```
+
+---
+
+### Step 6: Verify Railway Cron Service Configuration
+
+**File:** `/Users/chris/Projects/shitpost-alpha/railway.json`
+
+The current configuration at lines 28-33 already defines the `market-data` service. Reduce `--days-back` from 30 to 7 since the reactive backfill handles new predictions immediately. The cron job now handles: (a) re-running outcome calculations as new trading days pass, (b) catching edge cases where reactive backfill failed.
+
+```json
+"market-data": {
+    "source": ".",
+    "startCommand": "python -m shit.market_data auto-pipeline --days-back 7",
+    "cronSchedule": "*/15 * * * *"
+}
+```
+
+**Post-merge:** Verify on Railway that the service is actually deployed and running.
+
+---
+
+### Step 7: Add Ticker Registry CLI Commands
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/market_data/cli.py`
+
+Add after the `backfill_all_missing` command (after line 491, before `if __name__`):
+
+```python
+@cli.command(name="ticker-registry")
+@click.option(
+    "--status",
+    "-s",
+    type=click.Choice(["active", "inactive", "invalid", "all"]),
+    default="all",
+    help="Filter by ticker status",
+)
+def ticker_registry_cmd(status: str):
+    """Show all tracked tickers in the registry."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+    from shit.market_data.models import TickerRegistry
+
+    try:
+        service = TickerRegistryService()
+        stats = service.get_registry_stats()
+
+        rprint(f"\n[bold]Ticker Registry Stats:[/bold]")
+        rprint(f"  Total: {stats['total']}")
+        rprint(f"  Active: [green]{stats['active']}[/green]")
+        rprint(f"  Invalid: [red]{stats['invalid']}[/red]")
+        rprint(f"  Inactive: [yellow]{stats['inactive']}[/yellow]")
+
+        with get_session() as session:
+            query = session.query(TickerRegistry)
+            if status != "all":
+                query = query.filter(TickerRegistry.status == status)
+            query = query.order_by(TickerRegistry.first_seen_date.desc())
+            tickers = query.all()
+
+            if not tickers:
+                print_info("No tickers found matching filter")
+                return
+
+            table = Table(title=f"Ticker Registry ({status})")
+            table.add_column("Symbol", style="cyan")
+            table.add_column("Status", style="green")
+            table.add_column("First Seen", style="yellow")
+            table.add_column("Last Update", style="white")
+            table.add_column("Records", style="magenta", justify="right")
+
+            for t in tickers:
+                table.add_row(
+                    t.symbol,
+                    t.status,
+                    str(t.first_seen_date),
+                    str(t.last_price_update.date()) if t.last_price_update else "Never",
+                    str(t.total_price_records),
+                )
+
+            console.print(table)
+
+    except Exception as e:
+        print_error(f"Error reading ticker registry: {e}")
+        raise click.Abort()
+
+
+@cli.command(name="register-tickers")
+@click.argument("symbols", nargs=-1, required=True)
+def register_tickers_cmd(symbols: tuple):
+    """Manually register tickers for tracking (e.g., register-tickers AAPL TSLA BTC-USD)."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+
+    try:
+        service = TickerRegistryService()
+        newly_registered, already_known = service.register_tickers(list(symbols))
+
+        if newly_registered:
+            print_success(
+                f"Registered {len(newly_registered)} new tickers: {', '.join(newly_registered)}"
+            )
+        if already_known:
+            print_info(f"Already registered: {', '.join(already_known)}")
+
+    except Exception as e:
+        print_error(f"Error registering tickers: {e}")
+        raise click.Abort()
+```
+
+---
+
+## Test Plan
+
+### New Test File 1: `shit_tests/shit/market_data/test_ticker_registry.py`
+
+Tests for `TickerRegistryService`. All tests use mocked `get_session` to avoid database dependencies.
+
+```
+class TestRegisterTickers:
+    test_registers_new_ticker_successfully
+    test_skips_already_registered_ticker
+    test_returns_newly_registered_and_already_known_lists
+    test_handles_empty_symbol_list
+    test_skips_invalid_symbol_format_space
+    test_skips_invalid_symbol_format_too_long
+    test_skips_empty_string_symbol
+    test_uppercases_symbols
+    test_sets_source_prediction_id
+    test_sets_first_seen_date_to_today
+    test_default_status_is_active
+
+class TestGetNewTickers:
+    test_returns_unknown_tickers
+    test_returns_empty_when_all_known
+    test_handles_empty_input
+    test_uppercases_before_comparison
+
+class TestGetActiveTickers:
+    test_returns_only_active_tickers
+    test_returns_empty_when_no_active
+
+class TestMarkTickerInvalid:
+    test_marks_existing_ticker_invalid
+    test_sets_status_reason
+    test_handles_nonexistent_ticker_gracefully
+    test_truncates_long_reason
+
+class TestUpdatePriceMetadata:
+    test_updates_metadata_from_market_prices
+    test_handles_nonexistent_ticker
+    test_handles_zero_price_records
+
+class TestGetRegistryStats:
+    test_returns_correct_counts
+    test_returns_zeros_when_empty
+```
+
+**Approximate count: 25 tests**
+
+### New Test File 2: `shit_tests/shit/market_data/test_auto_backfill_service.py`
+
+Tests for `AutoBackfillService` with registry integration. Mock `get_session`, `MarketDataClient`, `OutcomeCalculator`, and `TickerRegistryService`.
+
+```
+class TestBackfillTicker:
+    test_successful_backfill_returns_true
+    test_returns_false_for_no_data
+    test_skips_invalid_symbols
+    test_skips_krx_symbols
+    test_handles_yfinance_exception
+    test_updates_registry_on_success
+    test_marks_invalid_on_no_data
+
+class TestProcessSinglePrediction:
+    test_backfills_missing_tickers_and_calculates_outcome
+    test_registers_tickers_in_registry
+    test_handles_prediction_not_found
+    test_handles_prediction_with_no_assets
+    test_handles_outcome_calculation_failure
+
+class TestProcessNewPredictions:
+    test_processes_recent_predictions
+    test_respects_limit_parameter
+    test_handles_errors_gracefully
+
+class TestConvenienceFunctions:
+    test_auto_backfill_prediction_calls_service
+    test_auto_backfill_recent_calls_service
+    test_auto_backfill_all_calls_service
+```
+
+**Approximate count: 22 tests**
+
+### New Test File 3: `shit_tests/shitpost_ai/test_reactive_backfill.py`
+
+Tests for the reactive backfill integration in the analyzer.
+
+```
+class TestTriggerReactiveBackfill:
+    test_calls_auto_backfill_prediction_with_correct_id
+    test_logs_success_on_backfill
+    test_logs_debug_when_no_new_data_needed
+    test_catches_exception_and_logs_warning
+    test_does_not_propagate_backfill_errors
+
+class TestAnalyzeShitpostReactiveIntegration:
+    test_triggers_backfill_after_successful_analysis
+    test_does_not_trigger_backfill_on_dry_run
+    test_does_not_trigger_backfill_when_no_assets
+    test_does_not_trigger_backfill_when_store_fails
+    test_does_not_trigger_backfill_for_bypassed_posts
+```
+
+**Approximate count: 10 tests**
+
+### Existing Tests to Update
+
+Add new test cases for the two new CLI commands to `shit_tests/shit/market_data/test_market_data_cli.py`:
+
+```
+class TestTickerRegistryCommand:
+    test_ticker_registry_command_exists
+    test_ticker_registry_shows_stats
+    test_ticker_registry_filters_by_status
+
+class TestRegisterTickersCommand:
+    test_register_tickers_command_exists
+    test_registers_new_symbols
+    test_shows_already_known_symbols
+```
+
+**Approximate count: 5 additional tests**
+
+**Total new tests: ~62**
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]` / `### Added`:
+
+```markdown
+- **Reactive Ticker Lifecycle** - LLM analyzer now triggers market data backfill immediately when a prediction contains new tickers
+  - New `ticker_registry` database table tracks all ticker symbols the system has ever encountered
+  - `TickerRegistryService` manages ticker lifecycle (active/inactive/invalid status)
+  - `ShitpostAnalyzer._trigger_reactive_backfill()` runs backfill in a thread executor after each successful analysis
+  - `AutoBackfillService` integrates with ticker registry for registration and metadata updates
+  - Railway `market-data` cron service verified for 15-minute auto-pipeline execution
+  - New CLI commands: `ticker-registry` (view tracked tickers) and `register-tickers` (manually add tickers)
+```
+
+### CLAUDE.md (Database Architecture Section)
+
+Add the new table to the "Key Tables" section:
+
+```markdown
+**`ticker_registry`** - Registry of all tracked ticker symbols
+- `id`, `symbol` (unique), `first_seen_date`
+- `source_prediction_id` (FK -> predictions.id)
+- `status` (active/inactive/invalid), `status_reason`
+- `last_price_update`, `price_data_start`, `price_data_end`, `total_price_records`
+- `asset_type`, `exchange`
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+### Invalid Tickers
+- **Scenario:** LLM produces a ticker like `"FAKE123"` or `"THE ECONOMY"`.
+- **Handling:** `backfill_ticker` validates symbol format (line 107): `len(symbol) > 10 or ' ' in symbol`. Invalid symbols are skipped. `TickerRegistryService.register_tickers` adds the same validation. If a valid-format-but-nonexistent ticker passes validation, yfinance will return empty data, and `mark_ticker_invalid` will flag it.
+
+### yfinance Failures
+- **Scenario:** yfinance API is rate-limited or returns an error.
+- **Handling:** `backfill_ticker` catches all exceptions (line 141) and logs them. The reactive backfill in `_trigger_reactive_backfill` wraps the call in a try/except and logs a warning but never crashes. The 15-minute cron job will retry on the next cycle.
+
+### Duplicate Tickers Across Predictions
+- **Scenario:** AAPL appears in prediction 1 and prediction 5.
+- **Handling:** `TickerRegistryService.register_tickers` checks for existing entries before inserting. The `symbol` column has a unique constraint. The `source_prediction_id` records only the FIRST prediction that introduced the ticker.
+
+### Race Conditions
+- **Scenario:** Two concurrent predictions both mention a new ticker NVDA. Both call `register_tickers` simultaneously.
+- **Handling:** The `symbol` column has a `unique=True` constraint. If both try to insert at the same time, one will get a database `IntegrityError`. The service catches this with `except IntegrityError: session.rollback()` and logs it gracefully.
+
+### Async/Sync Boundary
+- **Scenario:** The analyzer is async. The backfill service is sync.
+- **Handling:** `_trigger_reactive_backfill` uses `loop.run_in_executor` with a `ThreadPoolExecutor(max_workers=1)` to run sync code in a separate thread. The sync session uses its own connection pool. No shared state between async and sync sessions. No deadlock risk.
+
+### Korean Exchange Symbols
+- **Scenario:** LLM produces `KRX:005930` (Samsung on Korean exchange).
+- **Handling:** Already handled in `backfill_ticker` at line 112-114. The symbol is registered in the registry but backfill is skipped and marked invalid.
+
+### Empty Assets List
+- **Scenario:** LLM analysis returns `assets: []` (no financial implications).
+- **Handling:** The reactive backfill check `if assets:` skips the call entirely. No registry entries created, no backfill attempted.
+
+---
+
+## Verification Checklist
+
+```bash
+# 1. Activate virtual environment
+source venv/bin/activate
+
+# 2. Run the full test suite to ensure no regressions
+pytest -v
+
+# 3. Run only the new tests
+pytest -v shit_tests/shit/market_data/test_ticker_registry.py
+pytest -v shit_tests/shit/market_data/test_auto_backfill_service.py
+pytest -v shit_tests/shitpost_ai/test_reactive_backfill.py
+
+# 4. Run the existing market data tests to check for regressions
+pytest -v shit_tests/shit/market_data/
+
+# 5. Verify new CLI commands exist
+python3 -m shit.market_data ticker-registry --help
+python3 -m shit.market_data register-tickers --help
+
+# 6. Verify the auto-pipeline still works
+python3 -m shit.market_data auto-pipeline --help
+
+# 7. Check code style
+python3 -m ruff check shit/market_data/ticker_registry.py
+python3 -m ruff check shit/market_data/models.py
+python3 -m ruff check shit/market_data/auto_backfill_service.py
+python3 -m ruff check shitpost_ai/shitpost_analyzer.py
+
+# 8. Verify database table creation works
+python3 -c "from shit.market_data.models import TickerRegistry; print('TickerRegistry model OK')"
+python3 -c "from shit.market_data.ticker_registry import TickerRegistryService; print('TickerRegistryService OK')"
+
+# 9. Verify imports are clean
+python3 -c "from shit.market_data import TickerRegistry; print('Export OK')"
+
+# 10. Show database stats (safe -- read-only)
+python3 -m shitvault stats
+```
+
+**Post-merge Railway verification:**
+- Confirm the `market-data` service appears in Railway dashboard
+- Confirm cron schedule shows `*/15 * * * *`
+- Check Railway logs after first cron execution for successful pipeline run
+
+---
+
+## What NOT To Do
+
+### DO NOT run `auto_backfill_prediction` synchronously inside the async analyzer
+The analyzer runs in an async event loop. The backfill service uses synchronous SQLAlchemy sessions. Calling sync code directly from async code will block the event loop. Always use `loop.run_in_executor()` as shown in Step 4.
+
+### DO NOT make reactive backfill failures crash the analyzer
+The prediction was already stored successfully. If backfill fails, the 15-minute cron job will catch it. Wrap the backfill call in try/except and log a warning. Never re-raise.
+
+### DO NOT create a new async version of the backfill service
+The sync backfill service works correctly. Converting it to async would require rewriting `MarketDataClient` and `OutcomeCalculator`. The `run_in_executor` approach is the correct pattern.
+
+### DO NOT skip the `TickerRegistry` and rely only on `market_prices` table
+The `market_prices` table stores raw OHLCV data. Querying `SELECT DISTINCT symbol FROM market_prices` is expensive on large tables and provides no metadata about when a ticker was first seen, what prediction introduced it, or whether it is still active.
+
+### DO NOT register bypassed/error predictions' tickers
+Only predictions with `analysis_status == 'completed'` and a non-empty `assets` list should trigger backfill. Bypassed posts have `assets: []` by design.
+
+### DO NOT change the `store_analysis` return type
+`store_analysis` returns `str(prediction.id)` or `None`. The reactive backfill consumes this as `int(analysis_id)`. Do not change the return type -- just cast it.
+
+### DO NOT use Alembic for the database migration
+This project does not use Alembic. Tables are created via `Base.metadata.create_all(engine)` in `sync_session.py:create_tables()`. The new `TickerRegistry` model will be picked up automatically. For the production Neon database, a manual `CREATE TABLE` SQL statement will be needed before first deployment. Document this in the PR description.
+
+### DO NOT hardcode the backfill_days value
+The `AutoBackfillService` constructor accepts `backfill_days` as a parameter (default 365). Let the default handle it.
+
+### DO NOT modify `prediction_operations.py`
+The `store_analysis` method already returns the prediction ID. Adding backfill logic inside `store_analysis` would violate separation of concerns.

--- a/documentation/planning/phases/system-evolution_2026-02-11/02_source-agnostic-data-model.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/02_source-agnostic-data-model.md
@@ -1,0 +1,1073 @@
+# Phase 02: Source-Agnostic Data Model
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: introduce source-agnostic Signal model for multi-platform support` |
+| **Risk Level** | Medium |
+| **Estimated Effort** | High (3-5 days) |
+| **Files Created** | `shitvault/signal_models.py`, `shitvault/signal_operations.py`, `shit/db/signal_utils.py`, `shit_tests/shitvault/test_signal_models.py`, `shit_tests/shitvault/test_signal_operations.py`, `shit_tests/shit/db/test_signal_utils.py` |
+| **Files Modified** | `shitvault/shitpost_models.py`, `shitvault/shitpost_operations.py`, `shitvault/prediction_operations.py`, `shitvault/s3_processor.py`, `shitvault/statistics.py`, `shit/db/database_utils.py`, `shit/s3/s3_data_lake.py`, `shit/s3/s3_config.py`, `shit/s3/s3_models.py`, `shit/content/bypass_service.py`, `shitpost_ai/shitpost_analyzer.py`, `shitty_ui/data.py`, `notifications/db.py`, `notifications/alert_engine.py`, `shit/db/sync_session.py`, `CHANGELOG.md`, `CLAUDE.md` |
+| **Files Deleted** | None |
+
+---
+
+## Context: Why This Matters
+
+The current data model is deeply coupled to Truth Social's API structure. Every layer -- from S3 storage to database models to the analyzer to the dashboard -- uses Truth Social-specific terminology: `reblogs_count`, `upvotes_count`, `account_verified`, `reblog` (for retweets). This coupling means:
+
+1. **Adding a new source (Twitter/X, RSS, etc.) requires touching 15+ files** rather than just writing a new adapter.
+2. **The `TruthSocialShitpost` table has 40+ columns**, most of which are platform-specific metadata that should be stored as a JSON blob.
+3. **Field mapping in `database_utils.py` and `shitpost_operations.py`** manually maps 40+ fields from the Truth Social API, a pattern that does not scale.
+4. **The `predictions` table has a foreign key to `truth_social_shitposts.shitpost_id`**, making it impossible to create predictions for signals from other sources.
+5. **S3 paths are hardcoded** to `truth-social/raw/YYYY/MM/DD/`.
+
+A source-agnostic `Signal` model decouples the content layer from any specific platform, enabling the multi-source vision described in the project roadmap.
+
+### ScrapeCreators Cost Removal
+
+The ScrapeCreators API that powers Truth Social harvesting charges per request. A generic model allows the system to ingest from free or cheaper sources (RSS feeds, public APIs) with zero code changes to the analysis and prediction layers.
+
+---
+
+## Dependencies
+
+### Phase 01: Ticker Registry (MUST complete first)
+Phase 01 introduces a canonical asset registry. The `Signal` model's `assets` field in predictions should reference tickers from that registry.
+
+### Phases That Depend on This
+- **Phase 03: Signal-Over-Trend Dashboard View** -- Queries may reference signal table fields.
+- **Phase 06: Harvester Abstraction Layer** -- Requires the generic `Signal` model as the ingestion target.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Create the Signal SQLAlchemy Model
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/signal_models.py` (NEW)
+
+This model captures the universal fields every signal source must provide, plus a JSON column for platform-specific data. The table is named `signals` (not `shitposts`) to be source-neutral.
+
+```python
+"""
+Source-Agnostic Signal Model
+SQLAlchemy model for signals from ANY social media or news source.
+Platform-specific data is stored in a JSON blob.
+"""
+
+from typing import Dict, Any
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    Boolean,
+    Float,
+    JSON,
+    Index,
+)
+from sqlalchemy.orm import relationship
+
+from shit.db.data_models import Base, TimestampMixin, IDMixin, model_to_dict
+
+
+class Signal(Base, IDMixin, TimestampMixin):
+    """
+    Source-agnostic signal model.
+
+    Represents a content signal from ANY platform (Truth Social, Twitter/X,
+    RSS, news feeds, etc.). Platform-specific fields are stored in the
+    `platform_data` JSON column.
+
+    Universal fields capture the data every downstream consumer needs:
+    text, author, timestamp, source, and normalized engagement metrics.
+    """
+
+    __tablename__ = "signals"
+
+    # --- Universal Identifiers ---
+    signal_id = Column(String(255), unique=True, index=True, nullable=False)
+    source = Column(String(50), nullable=False, index=True)
+    source_url = Column(String(1000), nullable=True)
+
+    # --- Universal Content ---
+    text = Column(Text, nullable=True)
+    content_html = Column(Text, nullable=True)
+    title = Column(String(500), nullable=True)
+    language = Column(String(10), nullable=True)
+
+    # --- Universal Author ---
+    author_id = Column(String(255), nullable=True)
+    author_username = Column(String(200), nullable=False)
+    author_display_name = Column(String(200), nullable=True)
+    author_verified = Column(Boolean, default=False)
+    author_followers = Column(Integer, default=0)
+
+    # --- Universal Timestamps ---
+    published_at = Column(DateTime, nullable=False, index=True)
+
+    # --- Normalized Engagement (source-agnostic names) ---
+    likes_count = Column(Integer, default=0)
+    shares_count = Column(Integer, default=0)
+    replies_count = Column(Integer, default=0)
+    views_count = Column(Integer, default=0)
+
+    # --- Content Flags ---
+    has_media = Column(Boolean, default=False)
+    is_repost = Column(Boolean, default=False)
+    is_reply = Column(Boolean, default=False)
+    is_quote = Column(Boolean, default=False)
+
+    # --- Platform-Specific Data (JSON blob) ---
+    platform_data = Column(JSON, default=dict)
+    # Example for Truth Social:
+    # {
+    #     "upvotes_count": 250,
+    #     "downvotes_count": 25,
+    #     "visibility": "public",
+    #     "sensitive": false,
+    #     "media_attachments": [...],
+    #     "mentions": [...],
+    #     "tags": [...],
+    #     "reblog": {...}
+    # }
+
+    # --- Raw API Response ---
+    raw_api_data = Column(JSON, nullable=True)
+
+    # --- Relationships ---
+    predictions = relationship(
+        "Prediction", back_populates="signal", foreign_keys="Prediction.signal_id"
+    )
+
+    # --- Indexes ---
+    __table_args__ = (
+        Index("ix_signals_source_published", "source", "published_at"),
+        Index("ix_signals_author", "author_username"),
+    )
+
+    def __repr__(self):
+        text_preview = (self.text or "")[:50]
+        return f"<Signal(id={self.id}, source='{self.source}', author='{self.author_username}', text='{text_preview}...')>"
+
+    @property
+    def total_engagement(self) -> int:
+        """Sum of all engagement metrics."""
+        return (self.likes_count or 0) + (self.shares_count or 0) + (self.replies_count or 0)
+
+    @property
+    def engagement_rate(self) -> float:
+        """Engagement rate relative to author followers."""
+        if not self.author_followers or self.author_followers == 0:
+            return 0.0
+        return self.total_engagement / self.author_followers
+
+
+def signal_to_dict(signal: Signal) -> Dict[str, Any]:
+    """Convert Signal to dictionary."""
+    return model_to_dict(signal)
+```
+
+**Rationale for field choices**:
+- `signal_id` replaces `shitpost_id` -- universally identifies content from any platform.
+- `source` replaces the hardcoded `platform = "truth_social"` -- an indexed column for filtering.
+- `likes_count` normalizes `favourites_count` (Truth Social) and `likes` (Twitter) into one column.
+- `shares_count` normalizes `reblogs_count` (Truth Social) and `retweets` (Twitter).
+- `is_repost` replaces checking `reblog IS NOT NULL` -- a boolean flag that works across platforms.
+- `platform_data` JSON column holds all 30+ Truth Social-specific fields that do not need their own columns.
+- `published_at` replaces `timestamp` for clarity.
+
+---
+
+### Step 2: Update the Prediction Model to Support Both Tables
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/shitpost_models.py`
+
+The `Prediction` model currently has a foreign key to `truth_social_shitposts.shitpost_id`. During the transition, it needs to support both the legacy table and the new `signals` table via a **dual-FK** strategy.
+
+**Changes to lines 107-108:**
+
+```python
+# BEFORE:
+shitpost_id = Column(
+    String(255), ForeignKey("truth_social_shitposts.shitpost_id"), nullable=False
+)
+
+# AFTER:
+# Legacy FK -- nullable now, will be removed after full migration
+shitpost_id = Column(
+    String(255), ForeignKey("truth_social_shitposts.shitpost_id"), nullable=True
+)
+# New FK -- points to the source-agnostic signals table
+signal_id = Column(
+    String(255), ForeignKey("signals.signal_id"), nullable=True
+)
+```
+
+Add a new relationship (after line 155):
+
+```python
+signal = relationship("Signal", back_populates="predictions", foreign_keys=[signal_id])
+```
+
+Add a property for backward compatibility:
+
+```python
+@property
+def content_id(self) -> str:
+    """Return the signal or shitpost ID, whichever is set."""
+    return self.signal_id or self.shitpost_id
+```
+
+**Important constraint**: At least one of `shitpost_id` or `signal_id` must be non-null. This is enforced at the application layer.
+
+---
+
+### Step 3: Create the Truth Social Source Adapter (Field Mapping)
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/db/signal_utils.py` (NEW)
+
+This module provides a pluggable transformer framework. Each source gets a `transform_*_to_signal()` function.
+
+```python
+"""
+Signal Transformation Utilities
+Transforms raw API data from any source into the generic Signal format.
+"""
+
+import logging
+from typing import Dict, Any
+
+from shit.db.database_utils import DatabaseUtils
+from shit.logging.service_loggers import DatabaseLogger
+
+db_logger = DatabaseLogger("signal_utils")
+logger = db_logger.logger
+
+
+class SignalTransformer:
+    """Transforms raw API data from various sources into Signal format."""
+
+    @staticmethod
+    def transform_truth_social(s3_data: Dict) -> Dict[str, Any]:
+        """
+        Transform Truth Social S3 data into Signal format.
+
+        Maps Truth Social API fields to universal Signal fields.
+        Platform-specific fields are stored in platform_data JSON.
+
+        Args:
+            s3_data: Raw S3 storage data (contains raw_api_data key)
+
+        Returns:
+            Dictionary matching Signal model fields
+        """
+        raw_api_data = s3_data.get("raw_api_data", {})
+        account_data = raw_api_data.get("account", {})
+
+        # Determine content flags
+        reblog_data = raw_api_data.get("reblog")
+        is_repost = reblog_data is not None
+        is_reply = raw_api_data.get("in_reply_to_id") is not None
+        is_quote = raw_api_data.get("quote_id") is not None
+
+        # Build platform_data with all Truth Social-specific fields
+        platform_data = {
+            "upvotes_count": raw_api_data.get("upvotes_count", 0),
+            "downvotes_count": raw_api_data.get("downvotes_count", 0),
+            "account_following_count": account_data.get("following_count", 0),
+            "account_statuses_count": account_data.get("statuses_count", 0),
+            "account_website": account_data.get("website", ""),
+            "visibility": raw_api_data.get("visibility", "public"),
+            "sensitive": raw_api_data.get("sensitive", False),
+            "spoiler_text": raw_api_data.get("spoiler_text", ""),
+            "uri": raw_api_data.get("uri", ""),
+            "card": raw_api_data.get("card"),
+            "group": raw_api_data.get("group"),
+            "quote": raw_api_data.get("quote"),
+            "in_reply_to": raw_api_data.get("in_reply_to"),
+            "reblog": raw_api_data.get("reblog"),
+            "sponsored": raw_api_data.get("sponsored", False),
+            "reaction": raw_api_data.get("reaction"),
+            "favourited": raw_api_data.get("favourited", False),
+            "reblogged": raw_api_data.get("reblogged", False),
+            "muted": raw_api_data.get("muted", False),
+            "pinned": raw_api_data.get("pinned", False),
+            "bookmarked": raw_api_data.get("bookmarked", False),
+            "poll": raw_api_data.get("poll"),
+            "emojis": raw_api_data.get("emojis", []),
+            "votable": raw_api_data.get("votable", False),
+            "editable": raw_api_data.get("editable", False),
+            "version": raw_api_data.get("version", ""),
+            "media_attachments": raw_api_data.get("media_attachments", []),
+            "mentions": raw_api_data.get("mentions", []),
+            "tags": raw_api_data.get("tags", []),
+            "in_reply_to_id": raw_api_data.get("in_reply_to_id"),
+            "quote_id": raw_api_data.get("quote_id"),
+            "in_reply_to_account_id": raw_api_data.get("in_reply_to_account_id"),
+            "edited_at": raw_api_data.get("edited_at"),
+        }
+
+        return {
+            # Universal identifiers
+            "signal_id": str(raw_api_data.get("id")),
+            "source": "truth_social",
+            "source_url": raw_api_data.get("url", ""),
+            # Universal content
+            "text": raw_api_data.get("text", ""),
+            "content_html": raw_api_data.get("content", ""),
+            "title": raw_api_data.get("title", ""),
+            "language": raw_api_data.get("language", ""),
+            # Universal author
+            "author_id": str(account_data.get("id", "")),
+            "author_username": account_data.get("username", ""),
+            "author_display_name": account_data.get("display_name", ""),
+            "author_verified": account_data.get("verified", False),
+            "author_followers": account_data.get("followers_count", 0),
+            # Universal timestamp
+            "published_at": DatabaseUtils.parse_timestamp(raw_api_data.get("created_at", "")),
+            # Normalized engagement
+            "likes_count": raw_api_data.get("favourites_count", 0),
+            "shares_count": raw_api_data.get("reblogs_count", 0),
+            "replies_count": raw_api_data.get("replies_count", 0),
+            "views_count": 0,  # Truth Social does not expose views
+            # Content flags
+            "has_media": len(raw_api_data.get("media_attachments", [])) > 0,
+            "is_repost": is_repost,
+            "is_reply": is_reply,
+            "is_quote": is_quote,
+            # Platform-specific data
+            "platform_data": platform_data,
+            "raw_api_data": raw_api_data,
+        }
+
+    @staticmethod
+    def get_transformer(source: str):
+        """
+        Get the appropriate transformer function for a given source.
+
+        Args:
+            source: Source platform name ("truth_social", "twitter", "rss", etc.)
+
+        Returns:
+            Transformer function
+
+        Raises:
+            ValueError: If source is not supported
+        """
+        transformers = {
+            "truth_social": SignalTransformer.transform_truth_social,
+            # Future sources:
+            # "twitter": SignalTransformer.transform_twitter,
+            # "rss": SignalTransformer.transform_rss,
+        }
+
+        transformer = transformers.get(source)
+        if transformer is None:
+            raise ValueError(
+                f"Unsupported source: {source}. "
+                f"Supported sources: {list(transformers.keys())}"
+            )
+        return transformer
+```
+
+---
+
+### Step 4: Create Signal Operations
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/signal_operations.py` (NEW)
+
+This replaces `shitpost_operations.py` as the primary operations class. The API is similar but uses generic field names. **Key design decision**: The `get_unprocessed_signals` method returns dictionaries that include backward-compatible aliases (`shitpost_id`, `timestamp`, `username`, `reblogs_count`, etc.). This means the `ShitpostAnalyzer`, `PredictionOperations`, and `BypassService` can consume this data with ZERO changes initially.
+
+```python
+"""
+Signal Operations
+Source-agnostic operations for managing signals from any platform.
+"""
+
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+from sqlalchemy import select, and_, not_, exists
+from sqlalchemy.exc import IntegrityError
+
+from shit.db.database_operations import DatabaseOperations
+from shitvault.signal_models import Signal
+from shitvault.shitpost_models import Prediction
+
+from shit.logging.service_loggers import DatabaseLogger
+
+db_logger = DatabaseLogger("signal_operations")
+logger = db_logger.logger
+
+
+class SignalOperations:
+    """CRUD operations for source-agnostic signals."""
+
+    def __init__(self, db_ops: DatabaseOperations):
+        self.db_ops = db_ops
+
+    async def store_signal(self, signal_data: Dict[str, Any]) -> Optional[str]:
+        """Store a signal in the database.
+
+        Args:
+            signal_data: Dictionary matching Signal model fields.
+
+        Returns:
+            String ID of stored signal, or None on integrity error.
+        """
+        try:
+            signal_id = signal_data.get("signal_id")
+
+            existing = await self.db_ops.read_one(Signal, {"signal_id": signal_id})
+            if existing:
+                logger.debug(f"Signal {signal_id} already exists, skipping")
+                return str(existing.id)
+
+            signal = Signal(**signal_data)
+            self.db_ops.session.add(signal)
+            await self.db_ops.session.commit()
+            await self.db_ops.session.refresh(signal)
+
+            logger.info(
+                f"Stored signal {signal.signal_id} (source={signal.source}) with ID: {signal.id}"
+            )
+            return str(signal.id)
+
+        except IntegrityError as e:
+            await self.db_ops.session.rollback()
+            logger.warning(f"Integrity error storing signal {signal_data.get('signal_id')}: {e}")
+            return None
+        except Exception as e:
+            await self.db_ops.session.rollback()
+            logger.error(f"Error storing signal {signal_data.get('signal_id')}: {e}")
+            raise
+
+    async def get_unprocessed_signals(
+        self, launch_date: str, limit: int = 10, source: Optional[str] = None
+    ) -> List[Dict]:
+        """
+        Get signals that need LLM analysis.
+
+        Criteria:
+        1. Signal published_at is after launch date
+        2. No existing prediction for this signal
+        3. Optionally filtered by source
+
+        Args:
+            launch_date: ISO date string for minimum timestamp
+            limit: Maximum signals to return
+            source: Optional source filter
+
+        Returns:
+            List of signal dictionaries (includes backward-compatible aliases)
+        """
+        try:
+            launch_datetime = datetime.fromisoformat(launch_date.replace("Z", "+00:00"))
+
+            prediction_exists = select(Prediction.id).where(
+                Prediction.signal_id == Signal.signal_id
+            )
+
+            conditions = [
+                Signal.published_at >= launch_datetime,
+                not_(exists(prediction_exists)),
+            ]
+
+            if source:
+                conditions.append(Signal.source == source)
+
+            stmt = (
+                select(Signal)
+                .where(and_(*conditions))
+                .order_by(Signal.published_at.desc())
+                .limit(limit)
+            )
+
+            result = await self.db_ops.session.execute(stmt)
+            signals = result.scalars().all()
+
+            signal_dicts = []
+            for sig in signals:
+                signal_dict = {
+                    # Universal fields
+                    "id": sig.id,
+                    "signal_id": sig.signal_id,
+                    "source": sig.source,
+                    "source_url": sig.source_url,
+                    "text": sig.text,
+                    "content_html": sig.content_html,
+                    "title": sig.title,
+                    "language": sig.language,
+                    "author_id": sig.author_id,
+                    "author_username": sig.author_username,
+                    "author_display_name": sig.author_display_name,
+                    "author_verified": sig.author_verified,
+                    "author_followers": sig.author_followers,
+                    "published_at": sig.published_at,
+                    "likes_count": sig.likes_count,
+                    "shares_count": sig.shares_count,
+                    "replies_count": sig.replies_count,
+                    "views_count": sig.views_count,
+                    "has_media": sig.has_media,
+                    "is_repost": sig.is_repost,
+                    "is_reply": sig.is_reply,
+                    "is_quote": sig.is_quote,
+                    "platform_data": sig.platform_data,
+                    "raw_api_data": sig.raw_api_data,
+                    "created_at": sig.created_at,
+                    "updated_at": sig.updated_at,
+                    # Backward-compatible aliases (for analyzer, bypass service, etc.)
+                    "shitpost_id": sig.signal_id,
+                    "timestamp": sig.published_at,
+                    "username": sig.author_username,
+                    "platform": sig.source,
+                    "content": sig.content_html,
+                    "reblog": sig.platform_data.get("reblog") if sig.platform_data else None,
+                    "mentions": sig.platform_data.get("mentions", []) if sig.platform_data else [],
+                    "tags": sig.platform_data.get("tags", []) if sig.platform_data else [],
+                    "reblogs_count": sig.shares_count,
+                    "favourites_count": sig.likes_count,
+                    "upvotes_count": (
+                        sig.platform_data.get("upvotes_count", 0) if sig.platform_data else 0
+                    ),
+                    "downvotes_count": (
+                        sig.platform_data.get("downvotes_count", 0) if sig.platform_data else 0
+                    ),
+                    "account_verified": sig.author_verified,
+                    "account_followers_count": sig.author_followers,
+                    "account_display_name": sig.author_display_name,
+                }
+                signal_dicts.append(signal_dict)
+
+            logger.info(f"Retrieved {len(signal_dicts)} unprocessed signals")
+            return signal_dicts
+
+        except Exception as e:
+            logger.error(f"Error retrieving unprocessed signals: {e}")
+            raise
+```
+
+---
+
+### Step 5: Update the S3 Processor (Dual-Write Strategy)
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/s3_processor.py`
+
+The S3 processor needs to accept a `source` parameter and use `SignalTransformer`. During the transition, it **dual-writes** to both `signals` and `truth_social_shitposts`.
+
+**Changes at line 14** (add imports):
+```python
+from shitvault.signal_operations import SignalOperations
+from shit.db.signal_utils import SignalTransformer
+```
+
+**Changes at line 27-30** (constructor):
+```python
+# BEFORE:
+def __init__(self, db_ops: DatabaseOperations, s3_data_lake: S3DataLake):
+    self.db_ops = db_ops
+    self.s3_data_lake = s3_data_lake
+    self.shitpost_ops = ShitpostOperations(db_ops)
+
+# AFTER:
+def __init__(self, db_ops: DatabaseOperations, s3_data_lake: S3DataLake, source: str = "truth_social"):
+    self.db_ops = db_ops
+    self.s3_data_lake = s3_data_lake
+    self.source = source
+    self.signal_ops = SignalOperations(db_ops)
+    self.shitpost_ops = ShitpostOperations(db_ops)  # Keep for backward compat
+    self._transformer = SignalTransformer.get_transformer(source)
+```
+
+**Changes at lines 174-200** (`_process_single_s3_data`):
+```python
+# BEFORE:
+async def _process_single_s3_data(self, s3_data: Dict, stats: Dict, dry_run: bool):
+    try:
+        if dry_run:
+            stats['successful'] += 1
+        else:
+            transformed_data = DatabaseUtils.transform_s3_data_to_shitpost(s3_data)
+            result = await self.shitpost_ops.store_shitpost(transformed_data)
+            ...
+
+# AFTER:
+async def _process_single_s3_data(self, s3_data: Dict, stats: Dict, dry_run: bool):
+    try:
+        if dry_run:
+            stats['successful'] += 1
+        else:
+            # Transform using source-specific transformer
+            signal_data = self._transformer(s3_data)
+            result = await self.signal_ops.store_signal(signal_data)
+
+            # Also store in legacy table for backward compatibility
+            # TODO: Remove after full migration is complete
+            legacy_data = DatabaseUtils.transform_s3_data_to_shitpost(s3_data)
+            await self.shitpost_ops.store_shitpost(legacy_data)
+
+            if result:
+                stats['successful'] += 1
+            else:
+                stats['skipped'] += 1
+    except Exception as e:
+        logger.error(f"Error processing S3 data: {e}")
+        stats['failed'] += 1
+```
+
+**Dual-write strategy**: During the transition period, every new signal is written to BOTH `signals` and `truth_social_shitposts`. This ensures zero downtime -- the dashboard, alert engine, and outcome calculator continue to work against the legacy table while consumers are migrated one at a time.
+
+---
+
+### Step 6: Update the Prediction Operations
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/prediction_operations.py`
+
+**Changes at line 31** (method signature):
+```python
+# BEFORE:
+async def store_analysis(self, shitpost_id: str, analysis_data: Dict[str, Any], shitpost_data: Dict[str, Any] = None) -> Optional[str]:
+
+# AFTER:
+async def store_analysis(self, content_id: str, analysis_data: Dict[str, Any], content_data: Dict[str, Any] = None, *, use_signal: bool = False) -> Optional[str]:
+```
+
+**Changes at lines 36-50** (engagement score calculation -- use generic names with fallback):
+```python
+# Use generic field names (backward-compatible aliases present in both dicts)
+replies = content_data.get('replies_count', 0)
+shares = content_data.get('shares_count', content_data.get('reblogs_count', 0))
+likes = content_data.get('likes_count', content_data.get('favourites_count', 0))
+followers = content_data.get('author_followers', content_data.get('account_followers_count', 0))
+```
+
+**Changes at lines 52-85** (Prediction creation):
+```python
+prediction = Prediction(
+    # Dual-FK: set whichever is appropriate
+    shitpost_id=content_id if not use_signal else None,
+    signal_id=content_id if use_signal else None,
+    ...
+)
+```
+
+The same pattern is applied to `handle_no_text_prediction`.
+
+---
+
+### Step 7: Update the Bypass Service
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/content/bypass_service.py`
+
+**Changes at lines 131-143** (`_is_retruth` method):
+```python
+# BEFORE:
+def _is_retruth(self, post_data: Dict[str, Any]) -> bool:
+    reblog_data = post_data.get('reblog')
+    if reblog_data is not None:
+        return True
+    text_content = post_data.get('text', '').strip()
+    if text_content.startswith('RT ') or text_content.startswith('RT:'):
+        return True
+    return False
+
+# AFTER:
+def _is_retruth(self, post_data: Dict[str, Any]) -> bool:
+    # Check source-agnostic flag first (Signal model)
+    if post_data.get('is_repost', False):
+        return True
+
+    # Legacy: check reblog field (Truth Social API)
+    reblog_data = post_data.get('reblog')
+    if reblog_data is not None:
+        return True
+
+    # Fallback: check text prefix (works for any platform)
+    text_content = post_data.get('text', '').strip()
+    if text_content.startswith('RT ') or text_content.startswith('RT:'):
+        return True
+
+    return False
+```
+
+---
+
+### Step 8: Update the Analyzer
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitpost_ai/shitpost_analyzer.py`
+
+**Changes at lines 13-14** (imports):
+```python
+from shitvault.signal_operations import SignalOperations
+```
+
+**Changes at lines 76-77** (in `initialize`):
+```python
+self.signal_ops = SignalOperations(self.db_client)
+```
+
+**Changes at line 400** (`_prepare_enhanced_content` -- use fallback pattern for both old and new field names):
+```python
+def _prepare_enhanced_content(self, signal_data: Dict) -> str:
+    content = signal_data.get('text', '')
+    username = signal_data.get('author_username', signal_data.get('username', ''))
+    timestamp = signal_data.get('published_at', signal_data.get('timestamp', ''))
+    source = signal_data.get('source', signal_data.get('platform', 'unknown'))
+
+    replies = signal_data.get('replies_count', 0)
+    shares = signal_data.get('shares_count', signal_data.get('reblogs_count', 0))
+    likes = signal_data.get('likes_count', signal_data.get('favourites_count', 0))
+
+    verified = signal_data.get('author_verified', signal_data.get('account_verified', False))
+    followers = signal_data.get('author_followers', signal_data.get('account_followers_count', 0))
+
+    has_media = signal_data.get('has_media', False)
+    mentions = signal_data.get('mentions', [])
+    mentions_count = len(mentions) if isinstance(mentions, list) else 0
+    tags = signal_data.get('tags', [])
+    tags_count = len(tags) if isinstance(tags, list) else 0
+
+    enhanced_content = f"Content: {content}\n"
+    enhanced_content += f"Source: {source}\n"
+    enhanced_content += f"Author: {username} (Verified: {verified}, Followers: {followers:,})\n"
+    enhanced_content += f"Timestamp: {timestamp}\n"
+    enhanced_content += f"Engagement: {replies} replies, {shares} shares, {likes} likes\n"
+    enhanced_content += f"Media: {'Yes' if has_media else 'No'}, Mentions: {mentions_count}, Tags: {tags_count}"
+
+    return enhanced_content
+```
+
+---
+
+### Step 9: Update Dashboard Data Queries (Configurable Table Reference)
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/data.py`
+
+Rather than updating all 20+ raw SQL queries immediately, add a configurable table reference that makes the cutover a single-line edit later:
+
+At the top of `data.py`, add:
+```python
+# Table reference -- will be changed to "signals" after full migration
+SIGNALS_TABLE = "truth_social_shitposts"
+```
+
+Then update `FROM truth_social_shitposts tss` references to use `FROM {SIGNALS_TABLE} tss` via f-strings.
+
+---
+
+### Step 10: Update S3 Config for Source-Agnostic Paths
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/s3/s3_config.py`
+
+The default prefix `"truth-social"` is already a parameter. No code change needed. A new source would pass `prefix="twitter"` or `prefix="rss"`.
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/s3/s3_data_lake.py`
+
+**Changes at lines 93-103** (store_raw_data metadata):
+```python
+# BEFORE:
+metadata={
+    'stored_at': datetime.now().isoformat(),
+    'source': 'truth_social_api',
+    'version': '1.0',
+    'harvester': 'truth_social_s3_harvester'
+}
+
+# AFTER:
+metadata={
+    'stored_at': datetime.now().isoformat(),
+    'source': self.config.prefix,  # Dynamic based on config
+    'version': '1.0',
+    'harvester': f'{self.config.prefix}_harvester'
+}
+```
+
+---
+
+### Step 11: Update sync_session.py
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/db/sync_session.py`
+
+**Changes at lines 72-78** (import the new model):
+```python
+from shitvault.signal_models import Signal
+```
+
+---
+
+### Step 12: Data Migration Plan
+
+The migration is performed as a one-time backfill script, NOT an Alembic migration (the project does not use Alembic).
+
+**Migration script** -- add to `shitvault/cli.py` as a new subcommand `migrate-to-signals`:
+
+```python
+async def migrate_to_signals(limit: int = None, dry_run: bool = False):
+    """Backfill the signals table from truth_social_shitposts."""
+    from shitvault.signal_models import Signal
+    from shitvault.shitpost_models import TruthSocialShitpost
+
+    stmt = select(TruthSocialShitpost).where(
+        not_(exists(
+            select(Signal.id).where(Signal.signal_id == TruthSocialShitpost.shitpost_id)
+        ))
+    ).order_by(TruthSocialShitpost.timestamp.asc())
+
+    if limit:
+        stmt = stmt.limit(limit)
+
+    result = await db_ops.session.execute(stmt)
+    shitposts = result.scalars().all()
+
+    migrated = 0
+    for sp in shitposts:
+        signal = Signal(
+            signal_id=sp.shitpost_id,
+            source="truth_social",
+            source_url=sp.url,
+            text=sp.text,
+            content_html=sp.content,
+            title=sp.title,
+            language=sp.language,
+            author_id=sp.account_id,
+            author_username=sp.username,
+            author_display_name=sp.account_display_name,
+            author_verified=sp.account_verified or False,
+            author_followers=sp.account_followers_count or 0,
+            published_at=sp.timestamp,
+            likes_count=sp.favourites_count or 0,
+            shares_count=sp.reblogs_count or 0,
+            replies_count=sp.replies_count or 0,
+            views_count=0,
+            has_media=sp.has_media or False,
+            is_repost=sp.reblog is not None,
+            is_reply=getattr(sp, 'in_reply_to_id', None) is not None,
+            is_quote=getattr(sp, 'quote_id', None) is not None,
+            platform_data={
+                "upvotes_count": sp.upvotes_count or 0,
+                "downvotes_count": sp.downvotes_count or 0,
+                "visibility": sp.visibility,
+                "sensitive": sp.sensitive,
+                "spoiler_text": sp.spoiler_text,
+                "uri": sp.uri,
+                "mentions": sp.mentions,
+                "tags": sp.tags,
+                "media_attachments": sp.media_attachments,
+                "card": sp.card,
+                "reblog": sp.reblog,
+                "poll": sp.poll,
+                "emojis": sp.emojis,
+            },
+            raw_api_data=sp.raw_api_data,
+            created_at=sp.created_at,
+            updated_at=sp.updated_at,
+        )
+        if not dry_run:
+            db_ops.session.add(signal)
+        migrated += 1
+
+    if not dry_run:
+        await db_ops.session.commit()
+
+    print(f"{'[DRY RUN] ' if dry_run else ''}Migrated {migrated} shitposts to signals")
+```
+
+**Also backfill Prediction.signal_id** for existing predictions:
+
+```sql
+UPDATE predictions p
+SET signal_id = p.shitpost_id
+WHERE p.shitpost_id IS NOT NULL
+  AND p.signal_id IS NULL
+  AND EXISTS (SELECT 1 FROM signals s WHERE s.signal_id = p.shitpost_id);
+```
+
+---
+
+### Step 13: Deprecate ShitpostOperations
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/shitpost_operations.py`
+
+The existing `ShitpostOperations` class is NOT deleted. A deprecation notice is added:
+
+**Add at line 23:**
+```python
+import warnings
+
+_DEPRECATION_MSG = (
+    "ShitpostOperations is deprecated. Use SignalOperations for new code. "
+    "ShitpostOperations will be removed once all consumers are migrated."
+)
+```
+
+**Add at line 26** (in `__init__`):
+```python
+def __init__(self, db_ops: DatabaseOperations):
+    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    self.db_ops = db_ops
+```
+
+---
+
+## Test Plan
+
+### New Test Files
+
+**`shit_tests/shitvault/test_signal_models.py`** (~10 tests):
+- `test_signal_creation_minimal`
+- `test_signal_creation_all_fields`
+- `test_signal_default_values`
+- `test_signal_to_dict`
+- `test_signal_total_engagement`
+- `test_signal_engagement_rate`
+- `test_signal_engagement_rate_zero_followers`
+- `test_signal_repr`
+- `test_signal_table_name`
+- `test_signal_platform_data_json`
+
+**`shit_tests/shitvault/test_signal_operations.py`** (~8 tests):
+- `test_store_signal_success`
+- `test_store_signal_duplicate`
+- `test_store_signal_integrity_error`
+- `test_get_unprocessed_signals_basic`
+- `test_get_unprocessed_signals_filters_by_date`
+- `test_get_unprocessed_signals_filters_by_source`
+- `test_get_unprocessed_signals_excludes_predicted`
+- `test_get_unprocessed_signals_backward_compat_aliases`
+
+**`shit_tests/shit/db/test_signal_utils.py`** (~10 tests):
+- `test_transform_truth_social_basic`
+- `test_transform_truth_social_full`
+- `test_transform_truth_social_repost`
+- `test_transform_truth_social_reply`
+- `test_transform_truth_social_quote`
+- `test_transform_truth_social_platform_data`
+- `test_transform_truth_social_engagement_mapping`
+- `test_get_transformer_valid_source`
+- `test_get_transformer_invalid_source`
+- `test_transform_truth_social_null_fields`
+
+### Existing Tests to Update
+
+| Test File | Changes Needed |
+|---|---|
+| `test_shitpost_models.py` | Add tests for `Prediction.signal_id`, `Prediction.content_id` |
+| `test_shitpost_operations.py` | Verify deprecation warning; tests still pass |
+| `test_prediction_operations.py` | Add tests for `use_signal=True` path |
+| `test_s3_processor.py` | Test dual-write behavior; test `source` parameter |
+
+**Total new tests: ~28**
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Source-Agnostic Signal Model** - New `signals` table that can represent content from any platform
+  - Universal fields: text, author, timestamp, normalized engagement metrics
+  - Platform-specific data stored as JSON (`platform_data` column)
+  - Content flags: `is_repost`, `is_reply`, `is_quote` for cross-platform bypass logic
+- **Signal Operations** - New `SignalOperations` class for source-agnostic CRUD
+- **Signal Transformer** - `SignalTransformer` with pluggable per-source field mapping
+- **Dual-FK on Predictions** - `Prediction.signal_id` added alongside legacy `shitpost_id`
+- **Data migration CLI** - `migrate-to-signals` subcommand for backfilling signals table
+
+### Changed
+- **S3 Processor** - Now supports `source` parameter and writes to both tables (dual-write)
+- **Bypass Service** - `_is_retruth()` now checks `is_repost` flag before legacy `reblog` field
+- **Analyzer** - `_prepare_enhanced_content()` uses generic field names with fallback
+
+### Deprecated
+- **ShitpostOperations** - Deprecated in favor of `SignalOperations`
+- **TruthSocialShitpost model** - Retained for backward compatibility
+```
+
+### CLAUDE.md Updates
+
+Add to "Key Tables":
+
+```markdown
+**`signals`** - Source-agnostic content signals (NEW - replaces truth_social_shitposts)
+- `id` (integer, auto-increment primary key)
+- `signal_id` (string, unique) -- Platform-specific content ID
+- `source` (string) -- Platform: "truth_social", "twitter", "rss"
+- `text` (text) -- Plain text content
+- `published_at` (datetime) -- When content was published
+- `author_username` (string) -- Author display name
+- `likes_count`, `shares_count`, `replies_count` (integer) -- Normalized engagement
+- `is_repost`, `is_reply`, `is_quote` (boolean) -- Content flags
+- `platform_data` (JSON) -- All platform-specific fields
+- `raw_api_data` (JSON) -- Complete API response
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| **Null `shitpost_id` during migration** | Migration skips records where `shitpost_id IS NULL` and logs them |
+| **Duplicate IDs across sources** | `signal_id` includes source prefix if needed, or use composite uniqueness |
+| **JSON double-serialization** | SQLAlchemy `JSON` column auto-serializes; never call `json.dumps()` |
+| **Partial migration crash** | Re-running is safe -- `store_signal` checks existing `signal_id` |
+| **`text` is NULL** | Signal model allows nullable text; bypass service handles it |
+| **`published_at` is NULL** | Migration falls back to `created_at` |
+| **`platform_data` is NULL** | Model defaults to `{}`; all access uses `.get()` with defaults |
+| **Existing predictions still work** | `Prediction.shitpost_id` FK retained; legacy queries unchanged |
+| **Dual-write overhead** | Negligible at current throughput (few posts per 5 min) |
+
+---
+
+## Verification Checklist
+
+- [ ] `source venv/bin/activate && pytest -v` passes (27 pre-existing failures acceptable)
+- [ ] New test files created and passing:
+  - [ ] `test_signal_models.py` (10+ tests)
+  - [ ] `test_signal_operations.py` (8+ tests)
+  - [ ] `test_signal_utils.py` (10+ tests)
+- [ ] `python3 -m ruff check .` passes
+- [ ] `python3 -m ruff format .` applies no changes
+- [ ] `Signal` model can be instantiated with Truth Social data
+- [ ] `SignalTransformer.transform_truth_social()` produces valid Signal dicts
+- [ ] `SignalOperations.store_signal()` stores and deduplicates correctly
+- [ ] `SignalOperations.get_unprocessed_signals()` returns backward-compatible dicts
+- [ ] `Prediction` model accepts both `shitpost_id` and `signal_id`
+- [ ] `BypassService._is_retruth()` works with `is_repost` flag
+- [ ] Analyzer `_prepare_enhanced_content()` works with both old and new field names
+- [ ] `S3Processor` dual-writes to both tables
+- [ ] Legacy `ShitpostOperations` still works (emits deprecation warning)
+- [ ] Dashboard queries still work against legacy table
+- [ ] Notification queries still work against legacy table
+- [ ] CHANGELOG.md and CLAUDE.md updated
+
+---
+
+## What NOT To Do
+
+1. **DO NOT delete `TruthSocialShitpost` model or `truth_social_shitposts` table.** The legacy table must remain during transition.
+
+2. **DO NOT change `Prediction.shitpost_id` to NOT NULL -> nullable in a single step without dual-write.** The dual-write ensures both columns are populated.
+
+3. **DO NOT update all 20+ SQL queries in `shitty_ui/data.py` in this PR.** Use the configurable `SIGNALS_TABLE` variable and flip it after migration backfill completes.
+
+4. **DO NOT create an Alembic migration framework.** The project does not use Alembic. Follow existing `Base.metadata.create_all()` pattern.
+
+5. **DO NOT remove backward-compatible aliases from `get_unprocessed_signals()`.** The aliases are critical for the analyzer and prediction operations.
+
+6. **DO NOT hardcode `"truth_social"` in the Signal model or operations classes.** The `source` field should always come from data or constructor parameter.
+
+7. **DO NOT run the migration script in production without `--dry-run` first.**
+
+8. **DO NOT modify `shitpost_alpha.py` (the orchestrator).** It delegates to sub-CLIs and does not need to know about the data model.
+
+9. **DO NOT skip writing tests for the transformer.** The field mapping is the most error-prone part.
+
+10. **DO NOT use `json.dumps()` when storing `platform_data`.** SQLAlchemy's `JSON` column handles serialization automatically.

--- a/documentation/planning/phases/system-evolution_2026-02-11/03_signal-over-trend-view.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/03_signal-over-trend-view.md
@@ -1,0 +1,1058 @@
+# Phase 03: Signal-Over-Trend Dashboard View
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat(ui): add signal-over-trend chart view with price overlays` |
+| **Risk Level** | Low |
+| **Estimated Effort** | Medium (2-3 days) |
+| **Files Created** | `shitty_ui/pages/trends.py`, `shitty_ui/components/charts.py`, `shit_tests/shitty_ui/test_trends.py`, `shit_tests/shitty_ui/test_charts.py` |
+| **Files Modified** | `shitty_ui/data.py`, `shitty_ui/layout.py`, `shitty_ui/pages/assets.py`, `shitty_ui/components/header.py`, `shitty_ui/constants.py`, `CHANGELOG.md` |
+| **Files Deleted** | None |
+
+---
+
+## Context: Why This Matters
+
+Currently, the asset page at `/assets/{symbol}` has a candlestick chart with basic prediction markers and a separate prediction timeline below it. However:
+
+1. **No combined query** -- The price chart callback queries prices and predictions separately, then matches them by date. It does not pull confidence, thesis, or timeframe window data.
+2. **Marker design is basic** -- Markers use correctness (green/red/yellow) as color, not sentiment. Marker size is fixed at 12px. Tooltips show only date, sentiment, and result -- no thesis or confidence.
+3. **No timeframe visualization** -- The t1/t3/t7/t30 evaluation windows are not shown. Users cannot see when a prediction "expires."
+4. **No standalone route** -- There is no `/trends` page for viewing signals overlaid on price charts with full controls.
+
+This phase delivers a visual proof layer: "here is what the model predicted, here is what the market did." This is the core value prop for any user evaluating system quality.
+
+---
+
+## Dependencies
+
+| Dependency | Status | Required? |
+|---|---|---|
+| Phase 01: Market Data Pipeline | Must be running (price data in `market_prices` table) | **Required** |
+| Phase 02: Source-Agnostic Data Model | Nice-to-have (field names may change) | Optional |
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Add New Constants to `constants.py`
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/constants.py`
+
+After the existing `COLORS` dict (currently ends at line 15), add:
+
+```python
+# Sentiment-specific color mapping for chart overlays
+SENTIMENT_COLORS = {
+    "bullish": "#10b981",   # Emerald 500 (same as COLORS["success"])
+    "bearish": "#ef4444",   # Red 500 (same as COLORS["danger"])
+    "neutral": "#94a3b8",   # Slate 400 (same as COLORS["text_muted"])
+}
+
+# Marker configuration for signal overlays
+MARKER_CONFIG = {
+    "min_size": 8,          # Minimum marker size (pixels)
+    "max_size": 22,         # Maximum marker size (pixels)
+    "opacity": 0.85,        # Default marker opacity
+    "border_width": 1.5,    # Marker border width
+    "symbols": {
+        "bullish": "triangle-up",
+        "bearish": "triangle-down",
+        "neutral": "circle",
+    },
+}
+
+# Timeframe window colors (for shaded regions)
+TIMEFRAME_COLORS = {
+    "t1": "rgba(59, 130, 246, 0.06)",   # Blue, very light
+    "t3": "rgba(59, 130, 246, 0.04)",
+    "t7": "rgba(245, 158, 11, 0.04)",   # Amber, very light
+    "t30": "rgba(245, 158, 11, 0.02)",
+}
+```
+
+---
+
+### Step 2: Add New Data Query Functions to `data.py`
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/data.py`
+
+Add two new functions at the end of the file (after `get_sentiment_accuracy` which ends at line 1907):
+
+#### Function 2a: `get_price_with_signals`
+
+Core combined query that returns price data and signal data for a symbol within a date range.
+
+```python
+def get_price_with_signals(
+    symbol: str,
+    days: int = 90,
+) -> Dict[str, pd.DataFrame]:
+    """
+    Get combined price history and prediction signals for a symbol.
+
+    Returns two DataFrames in a dict:
+    - 'prices': OHLCV data from market_prices table
+    - 'signals': Prediction signals with sentiment, confidence, thesis, outcomes
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL')
+        days: Number of days of history
+
+    Returns:
+        Dict with 'prices' and 'signals' DataFrames.
+        Both may be empty if no data exists.
+    """
+    start_date = (datetime.now() - timedelta(days=days)).date()
+
+    price_query = text("""
+        SELECT
+            date,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            adjusted_close
+        FROM market_prices
+        WHERE symbol = :symbol
+            AND date >= :start_date
+        ORDER BY date ASC
+    """)
+
+    signal_query = text("""
+        SELECT
+            po.prediction_date,
+            tss.timestamp AS post_timestamp,
+            po.prediction_sentiment,
+            po.prediction_confidence,
+            po.price_at_prediction,
+            po.return_t1,
+            po.return_t3,
+            po.return_t7,
+            po.return_t30,
+            po.correct_t1,
+            po.correct_t3,
+            po.correct_t7,
+            po.correct_t30,
+            po.pnl_t7,
+            po.is_complete,
+            p.thesis,
+            p.assets,
+            tss.text AS post_text
+        FROM prediction_outcomes po
+        INNER JOIN predictions p ON po.prediction_id = p.id
+        INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
+        WHERE po.symbol = :symbol
+            AND po.prediction_date >= :start_date
+        ORDER BY po.prediction_date ASC
+    """)
+
+    params = {"symbol": symbol.upper(), "start_date": start_date}
+
+    result = {"prices": pd.DataFrame(), "signals": pd.DataFrame()}
+
+    try:
+        rows, columns = execute_query(price_query, params)
+        price_df = pd.DataFrame(rows, columns=columns)
+        if not price_df.empty:
+            price_df["date"] = pd.to_datetime(price_df["date"])
+        result["prices"] = price_df
+    except Exception as e:
+        logger.error(f"Error loading prices for {symbol}: {e}")
+
+    try:
+        rows, columns = execute_query(signal_query, params)
+        signal_df = pd.DataFrame(rows, columns=columns)
+        if not signal_df.empty:
+            signal_df["prediction_date"] = pd.to_datetime(signal_df["prediction_date"])
+            signal_df["post_timestamp"] = pd.to_datetime(signal_df["post_timestamp"])
+        result["signals"] = signal_df
+    except Exception as e:
+        logger.error(f"Error loading signals for {symbol}: {e}")
+
+    return result
+```
+
+#### Function 2b: `get_multi_asset_signals`
+
+For cross-asset signal overview:
+
+```python
+def get_multi_asset_signals(
+    days: int = 90,
+    limit: int = 200,
+) -> pd.DataFrame:
+    """
+    Get recent prediction signals across all assets for the trend overview.
+
+    Args:
+        days: Number of days to look back
+        limit: Maximum signals to return
+
+    Returns:
+        DataFrame with signal data, or empty DataFrame on error.
+    """
+    start_date = (datetime.now() - timedelta(days=days)).date()
+
+    query = text("""
+        SELECT
+            po.symbol,
+            po.prediction_date,
+            tss.timestamp AS post_timestamp,
+            po.prediction_sentiment,
+            po.prediction_confidence,
+            po.price_at_prediction,
+            po.return_t7,
+            po.correct_t7,
+            po.pnl_t7,
+            po.is_complete,
+            p.thesis,
+            tss.text AS post_text
+        FROM prediction_outcomes po
+        INNER JOIN predictions p ON po.prediction_id = p.id
+        INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
+        WHERE po.prediction_date >= :start_date
+        ORDER BY po.prediction_date DESC
+        LIMIT :limit
+    """)
+
+    try:
+        rows, columns = execute_query(query, {"start_date": start_date, "limit": limit})
+        df = pd.DataFrame(rows, columns=columns)
+        if not df.empty:
+            df["prediction_date"] = pd.to_datetime(df["prediction_date"])
+        return df
+    except Exception as e:
+        logger.error(f"Error loading multi-asset signals: {e}")
+        return pd.DataFrame()
+```
+
+---
+
+### Step 3: Create New Chart Component
+
+**File to create**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/components/charts.py`
+
+A reusable Plotly figure builder that takes price data and signal data and returns a `go.Figure` with:
+- Candlestick trace for price
+- Scatter traces for signal markers (color = sentiment, size = confidence, shape = sentiment direction)
+- Optional shaded rectangles for prediction timeframe windows
+- Rich tooltips with thesis, confidence, outcome
+
+```python
+"""Reusable Plotly chart builders for the Shitty UI dashboard."""
+
+from datetime import timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from constants import COLORS, SENTIMENT_COLORS, MARKER_CONFIG, TIMEFRAME_COLORS
+
+
+def build_signal_over_trend_chart(
+    prices_df: pd.DataFrame,
+    signals_df: pd.DataFrame,
+    symbol: str = "",
+    show_timeframe_windows: bool = False,
+    chart_height: int = 500,
+) -> go.Figure:
+    """
+    Build a candlestick chart with prediction signal markers overlaid.
+
+    Args:
+        prices_df: DataFrame with columns: date, open, high, low, close, volume
+        signals_df: DataFrame with columns: prediction_date, prediction_sentiment,
+                    prediction_confidence, thesis, correct_t7, return_t7, pnl_t7,
+                    post_text, price_at_prediction
+        symbol: Ticker symbol for chart title
+        show_timeframe_windows: If True, draw shaded regions for t7 windows
+        chart_height: Height of the chart in pixels
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph
+    """
+    fig = go.Figure()
+
+    # --- Trace 1: Candlestick ---
+    if not prices_df.empty:
+        fig.add_trace(
+            go.Candlestick(
+                x=prices_df["date"],
+                open=prices_df["open"],
+                high=prices_df["high"],
+                low=prices_df["low"],
+                close=prices_df["close"],
+                name=symbol or "Price",
+                increasing_line_color=COLORS["success"],
+                decreasing_line_color=COLORS["danger"],
+                showlegend=False,
+            )
+        )
+
+    # --- Trace 2: Signal Markers ---
+    if not signals_df.empty and not prices_df.empty:
+        for _, signal in signals_df.iterrows():
+            pred_date = signal["prediction_date"]
+            sentiment = (signal.get("prediction_sentiment") or "neutral").lower()
+            confidence = signal.get("prediction_confidence") or 0.5
+            thesis = signal.get("thesis") or ""
+            correct_t7 = signal.get("correct_t7")
+            return_t7 = signal.get("return_t7")
+            pnl_t7 = signal.get("pnl_t7")
+            post_text = signal.get("post_text") or ""
+
+            # Find the price at this date for y-placement
+            price_row = prices_df[prices_df["date"].dt.date == pred_date.date()]
+            if price_row.empty:
+                continue
+
+            y_val = float(price_row.iloc[0]["high"]) * 1.03
+
+            # Color from sentiment
+            marker_color = SENTIMENT_COLORS.get(sentiment, SENTIMENT_COLORS["neutral"])
+
+            # Size from confidence (scale min_size to max_size)
+            size_range = MARKER_CONFIG["max_size"] - MARKER_CONFIG["min_size"]
+            marker_size = MARKER_CONFIG["min_size"] + (confidence * size_range)
+
+            # Shape from sentiment
+            marker_symbol = MARKER_CONFIG["symbols"].get(
+                sentiment, MARKER_CONFIG["symbols"]["neutral"]
+            )
+
+            # Outcome text for tooltip
+            if correct_t7 is True:
+                outcome_text = "CORRECT"
+            elif correct_t7 is False:
+                outcome_text = "INCORRECT"
+            else:
+                outcome_text = "PENDING"
+
+            # Build hover text
+            thesis_preview = (thesis[:100] + "...") if len(thesis) > 100 else thesis
+            post_preview = (post_text[:80] + "...") if len(post_text) > 80 else post_text
+
+            hover_parts = [
+                f"<b>{pred_date.strftime('%Y-%m-%d')}</b>",
+                f"Sentiment: <b>{sentiment.upper()}</b>",
+                f"Confidence: <b>{confidence:.0%}</b>",
+                f"Outcome: <b>{outcome_text}</b>",
+            ]
+            if return_t7 is not None:
+                hover_parts.append(f"7d Return: <b>{return_t7:+.2f}%</b>")
+            if pnl_t7 is not None:
+                hover_parts.append(f"P&L: <b>${pnl_t7:+,.0f}</b>")
+            if thesis_preview:
+                hover_parts.append(f"<br><i>{thesis_preview}</i>")
+
+            hover_text = "<br>".join(hover_parts)
+
+            fig.add_trace(
+                go.Scatter(
+                    x=[pred_date],
+                    y=[y_val],
+                    mode="markers",
+                    marker=dict(
+                        size=marker_size,
+                        color=marker_color,
+                        symbol=marker_symbol,
+                        opacity=MARKER_CONFIG["opacity"],
+                        line=dict(
+                            width=MARKER_CONFIG["border_width"],
+                            color=COLORS["text"],
+                        ),
+                    ),
+                    hovertemplate=hover_text + "<extra></extra>",
+                    showlegend=False,
+                    name=f"{sentiment} signal",
+                )
+            )
+
+            # --- Optional: Timeframe windows ---
+            if show_timeframe_windows and not price_row.empty:
+                _add_timeframe_window(fig, pred_date, y_val)
+
+    # --- Layout ---
+    fig.update_layout(
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font_color=COLORS["text"],
+        margin=dict(l=50, r=20, t=30, b=40),
+        xaxis=dict(
+            gridcolor=COLORS["border"],
+            rangeslider=dict(visible=False),
+        ),
+        yaxis=dict(
+            gridcolor=COLORS["border"],
+            title="Price ($)",
+        ),
+        height=chart_height,
+        showlegend=False,
+        hovermode="closest",
+    )
+
+    # Add a custom legend for sentiment markers
+    _add_sentiment_legend(fig)
+
+    return fig
+
+
+def _add_timeframe_window(
+    fig: go.Figure,
+    pred_date: pd.Timestamp,
+    y_val: float,
+) -> None:
+    """Add a shaded rectangle for the 7-day evaluation window."""
+    t7_end = pred_date + timedelta(days=7)
+    fig.add_vrect(
+        x0=pred_date,
+        x1=t7_end,
+        fillcolor=TIMEFRAME_COLORS["t7"],
+        layer="below",
+        line_width=0,
+    )
+
+
+def _add_sentiment_legend(fig: go.Figure) -> None:
+    """Add invisible traces to serve as a sentiment color legend."""
+    for sentiment, color in SENTIMENT_COLORS.items():
+        symbol = MARKER_CONFIG["symbols"][sentiment]
+        fig.add_trace(
+            go.Scatter(
+                x=[None],
+                y=[None],
+                mode="markers",
+                marker=dict(size=10, color=color, symbol=symbol),
+                name=sentiment.capitalize(),
+                showlegend=True,
+            )
+        )
+
+    fig.update_layout(
+        showlegend=True,
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+            font=dict(color=COLORS["text_muted"], size=11),
+        ),
+    )
+
+
+def build_empty_signal_chart(message: str = "No data available") -> go.Figure:
+    """Build an empty chart with a centered message."""
+    fig = go.Figure()
+    fig.add_annotation(
+        text=message,
+        showarrow=False,
+        font=dict(color=COLORS["text_muted"], size=14),
+    )
+    fig.update_layout(
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font_color=COLORS["text_muted"],
+        height=400,
+        xaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+        yaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+    )
+    return fig
+```
+
+---
+
+### Step 4: Create Standalone `/trends` Page
+
+**File to create**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/pages/trends.py`
+
+A new page at route `/trends` with:
+- An asset selector dropdown
+- Time range selector (30D, 90D, 180D, 1Y)
+- Toggle for timeframe window overlays
+- The signal-over-trend chart from Step 3
+- A summary panel below the chart showing signal statistics
+
+```python
+"""Signal-over-trend page layout and callbacks for /trends route."""
+
+import traceback
+
+from dash import Dash, html, dcc, Input, Output, State, callback_context, no_update
+import dash_bootstrap_components as dbc
+
+from constants import COLORS
+from components.cards import create_error_card
+from components.charts import build_signal_over_trend_chart, build_empty_signal_chart
+from data import get_price_with_signals, get_active_assets_from_db
+
+
+def create_trends_page() -> html.Div:
+    """Create the /trends page layout."""
+    return html.Div(
+        [
+            # Page header
+            html.Div(
+                [
+                    html.H2(
+                        [
+                            html.I(className="fas fa-chart-area me-2"),
+                            "Signal Over Trend",
+                        ],
+                        style={"margin": 0, "fontWeight": "bold"},
+                    ),
+                    html.P(
+                        "Prediction signals overlaid on market price charts",
+                        style={
+                            "color": COLORS["text_muted"],
+                            "margin": 0,
+                            "fontSize": "0.9rem",
+                        },
+                    ),
+                ],
+                style={"marginBottom": "20px"},
+            ),
+            # Controls row
+            dbc.Card(
+                dbc.CardBody(
+                    dbc.Row(
+                        [
+                            # Asset selector
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Asset",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    dcc.Dropdown(
+                                        id="trends-asset-selector",
+                                        options=[],
+                                        placeholder="Select an asset...",
+                                        style={"fontSize": "0.9rem"},
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                            # Time range buttons
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Time Range",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    html.Div(
+                                        dbc.ButtonGroup(
+                                            [
+                                                dbc.Button("30D", id="trends-range-30d", color="secondary", outline=True, size="sm"),
+                                                dbc.Button("90D", id="trends-range-90d", color="primary", size="sm"),
+                                                dbc.Button("180D", id="trends-range-180d", color="secondary", outline=True, size="sm"),
+                                                dbc.Button("1Y", id="trends-range-1y", color="secondary", outline=True, size="sm"),
+                                            ],
+                                            size="sm",
+                                        ),
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                            # Timeframe window toggle
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Options",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    dbc.Checklist(
+                                        options=[{"label": " Show 7-day windows", "value": "show_windows"}],
+                                        value=[],
+                                        id="trends-options-checklist",
+                                        switch=True,
+                                        style={"fontSize": "0.85rem"},
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                        ],
+                        className="g-3",
+                    ),
+                ),
+                style={
+                    "backgroundColor": COLORS["secondary"],
+                    "border": f"1px solid {COLORS['border']}",
+                    "marginBottom": "20px",
+                },
+            ),
+            # Chart card
+            dbc.Card(
+                [
+                    dbc.CardHeader(
+                        [
+                            html.I(className="fas fa-chart-area me-2"),
+                            html.Span(id="trends-chart-title", children="Select an asset to view chart"),
+                        ],
+                        className="fw-bold",
+                    ),
+                    dbc.CardBody(
+                        dcc.Loading(
+                            type="circle",
+                            color=COLORS["accent"],
+                            children=dcc.Graph(
+                                id="trends-signal-chart",
+                                config={"displayModeBar": True, "displaylogo": False},
+                            ),
+                        ),
+                    ),
+                ],
+                style={"backgroundColor": COLORS["secondary"]},
+                className="mb-4",
+            ),
+            # Signal summary stats row
+            dcc.Loading(
+                type="default",
+                color=COLORS["accent"],
+                children=html.Div(id="trends-signal-summary", className="mb-4"),
+            ),
+        ],
+        style={"padding": "20px", "maxWidth": "1400px", "margin": "0 auto"},
+    )
+
+
+def register_trends_callbacks(app: Dash):
+    """Register all /trends page callbacks."""
+
+    @app.callback(
+        Output("trends-asset-selector", "options"),
+        [Input("url", "pathname")],
+    )
+    def populate_trends_assets(pathname):
+        if pathname != "/trends":
+            return no_update
+        assets = get_active_assets_from_db()
+        return [{"label": a, "value": a} for a in assets]
+
+    @app.callback(
+        [
+            Output("trends-signal-chart", "figure"),
+            Output("trends-chart-title", "children"),
+            Output("trends-signal-summary", "children"),
+        ],
+        [
+            Input("trends-asset-selector", "value"),
+            Input("trends-range-30d", "n_clicks"),
+            Input("trends-range-90d", "n_clicks"),
+            Input("trends-range-180d", "n_clicks"),
+            Input("trends-range-1y", "n_clicks"),
+            Input("trends-options-checklist", "value"),
+        ],
+    )
+    def update_trends_chart(symbol, n30, n90, n180, n1y, options):
+        if not symbol:
+            return (
+                build_empty_signal_chart("Select an asset to view the chart"),
+                "Select an asset to view chart",
+                html.Div(),
+            )
+
+        ctx = callback_context
+        days = 90
+        if ctx.triggered:
+            button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+            if button_id == "trends-range-30d":
+                days = 30
+            elif button_id == "trends-range-90d":
+                days = 90
+            elif button_id == "trends-range-180d":
+                days = 180
+            elif button_id == "trends-range-1y":
+                days = 365
+
+        show_windows = "show_windows" in (options or [])
+
+        try:
+            data = get_price_with_signals(symbol, days=days)
+            prices_df = data["prices"]
+            signals_df = data["signals"]
+
+            if prices_df.empty:
+                return (
+                    build_empty_signal_chart(f"No price data for {symbol}"),
+                    f"{symbol} - No Price Data",
+                    html.Div(),
+                )
+
+            fig = build_signal_over_trend_chart(
+                prices_df=prices_df,
+                signals_df=signals_df,
+                symbol=symbol,
+                show_timeframe_windows=show_windows,
+                chart_height=500,
+            )
+
+            title = f"{symbol} Price with Prediction Signals"
+            summary = _build_signal_summary(symbol, signals_df)
+
+            return fig, title, summary
+
+        except Exception as e:
+            print(f"Error in trends chart: {traceback.format_exc()}")
+            return (
+                build_empty_signal_chart(f"Error: {str(e)[:60]}"),
+                f"{symbol} - Error",
+                create_error_card(f"Error loading data for {symbol}", str(e)),
+            )
+
+    @app.callback(
+        [
+            Output("trends-range-30d", "color"),
+            Output("trends-range-30d", "outline"),
+            Output("trends-range-90d", "color"),
+            Output("trends-range-90d", "outline"),
+            Output("trends-range-180d", "color"),
+            Output("trends-range-180d", "outline"),
+            Output("trends-range-1y", "color"),
+            Output("trends-range-1y", "outline"),
+        ],
+        [
+            Input("trends-range-30d", "n_clicks"),
+            Input("trends-range-90d", "n_clicks"),
+            Input("trends-range-180d", "n_clicks"),
+            Input("trends-range-1y", "n_clicks"),
+        ],
+    )
+    def update_trends_range_buttons(n30, n90, n180, n1y):
+        ctx = callback_context
+        if not ctx.triggered:
+            return "secondary", True, "primary", False, "secondary", True, "secondary", True
+
+        button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+        styles = ["secondary", True, "secondary", True, "secondary", True, "secondary", True]
+        if button_id == "trends-range-30d":
+            styles[0:2] = ["primary", False]
+        elif button_id == "trends-range-90d":
+            styles[2:4] = ["primary", False]
+        elif button_id == "trends-range-180d":
+            styles[4:6] = ["primary", False]
+        elif button_id == "trends-range-1y":
+            styles[6:8] = ["primary", False]
+        else:
+            styles[2:4] = ["primary", False]
+        return tuple(styles)
+
+
+def _build_signal_summary(symbol: str, signals_df) -> html.Div:
+    """Build a summary stats row for the signals shown on the chart."""
+    if signals_df.empty:
+        return html.Div(
+            html.P(
+                f"No prediction signals found for {symbol} in this period.",
+                style={"color": COLORS["text_muted"], "textAlign": "center", "padding": "15px"},
+            )
+        )
+
+    total = len(signals_df)
+    bullish = (signals_df["prediction_sentiment"].str.lower() == "bullish").sum()
+    bearish = (signals_df["prediction_sentiment"].str.lower() == "bearish").sum()
+    avg_conf = signals_df["prediction_confidence"].mean() if "prediction_confidence" in signals_df.columns else 0
+
+    correct_col = signals_df.get("correct_t7")
+    if correct_col is not None:
+        evaluated = correct_col.notna().sum()
+        correct = (correct_col == True).sum()  # noqa: E712
+        accuracy = (correct / evaluated * 100) if evaluated > 0 else 0
+    else:
+        evaluated = 0
+        correct = 0
+        accuracy = 0
+
+    return dbc.Row(
+        [
+            dbc.Col(_mini_stat("Total Signals", str(total), COLORS["accent"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Bullish", str(bullish), COLORS["success"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Bearish", str(bearish), COLORS["danger"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Avg Confidence", f"{avg_conf:.0%}", COLORS["warning"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Evaluated", str(evaluated), COLORS["text_muted"]), md=2, xs=4),
+            dbc.Col(
+                _mini_stat(
+                    "Accuracy",
+                    f"{accuracy:.0f}%",
+                    COLORS["success"] if accuracy > 50 else COLORS["danger"],
+                ),
+                md=2, xs=4,
+            ),
+        ],
+        className="g-2",
+    )
+
+
+def _mini_stat(label: str, value: str, color: str) -> html.Div:
+    """Small stat display for the summary row."""
+    return html.Div(
+        [
+            html.Div(value, style={"fontSize": "1.2rem", "fontWeight": "bold", "color": color}),
+            html.Div(label, style={"fontSize": "0.75rem", "color": COLORS["text_muted"]}),
+        ],
+        style={
+            "textAlign": "center",
+            "padding": "10px",
+            "backgroundColor": COLORS["secondary"],
+            "borderRadius": "8px",
+            "border": f"1px solid {COLORS['border']}",
+        },
+    )
+```
+
+---
+
+### Step 5: Enhance the Existing Asset Page Chart
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/pages/assets.py`
+
+Replace the `update_asset_price_chart` callback (lines 445-577) to use the new chart component.
+
+**Add new imports at top of file (after line 8):**
+
+```python
+from components.charts import build_signal_over_trend_chart, build_empty_signal_chart
+from data import get_price_with_signals
+```
+
+**Replace the `update_asset_price_chart` callback body (lines 455-577) with:**
+
+```python
+    @app.callback(
+        Output("asset-price-chart", "figure"),
+        [
+            Input("asset-page-symbol", "data"),
+            Input("asset-range-30d", "n_clicks"),
+            Input("asset-range-90d", "n_clicks"),
+            Input("asset-range-180d", "n_clicks"),
+            Input("asset-range-1y", "n_clicks"),
+        ],
+    )
+    def update_asset_price_chart(symbol, n30, n90, n180, n1y):
+        """Update the price chart with prediction signal overlays."""
+        if not symbol:
+            return build_empty_signal_chart("No asset selected")
+
+        ctx = callback_context
+        days = 90
+        if ctx.triggered:
+            button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+            if button_id == "asset-range-30d":
+                days = 30
+            elif button_id == "asset-range-90d":
+                days = 90
+            elif button_id == "asset-range-180d":
+                days = 180
+            elif button_id == "asset-range-1y":
+                days = 365
+
+        try:
+            data = get_price_with_signals(symbol, days=days)
+
+            if data["prices"].empty:
+                return build_empty_signal_chart(f"No price data available for {symbol}")
+
+            return build_signal_over_trend_chart(
+                prices_df=data["prices"],
+                signals_df=data["signals"],
+                symbol=symbol,
+                show_timeframe_windows=False,
+                chart_height=400,
+            )
+
+        except Exception as e:
+            print(f"Error loading price chart for {symbol}: {traceback.format_exc()}")
+            return build_empty_signal_chart(f"Error: {str(e)[:50]}")
+```
+
+**Note:** Do NOT remove `get_asset_price_history` or `get_asset_predictions` imports -- they are still used by other callbacks on the asset page.
+
+---
+
+### Step 6: Register the New Route and Callbacks
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/layout.py`
+
+1. **Add imports** (after line 37):
+```python
+from pages.trends import create_trends_page, register_trends_callbacks
+```
+
+2. **Add route** in `route_page` callback (after line 283, before the dashboard default return):
+```python
+        if pathname == "/trends":
+            return create_trends_page()
+```
+
+3. **Register callbacks** in `register_callbacks` function (after line 292):
+```python
+    register_trends_callbacks(app)
+```
+
+---
+
+### Step 7: Add Navigation Link
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/components/header.py`
+
+Add a "Trends" link to the navigation bar. Currently there are three links: Dashboard, Signals, Performance (lines 49-69). Add after "Signals" (after line 61):
+
+```python
+                            dcc.Link(
+                                [
+                                    html.I(className="fas fa-chart-area me-1"),
+                                    "Trends",
+                                ],
+                                href="/trends",
+                                className="nav-link-custom",
+                            ),
+```
+
+---
+
+## Test Plan
+
+### New Test File: `shit_tests/shitty_ui/test_trends.py`
+
+#### Data Layer Tests (additions to `test_data.py`)
+
+```
+TestGetPriceWithSignals:
+    test_returns_dict_with_prices_and_signals_keys
+    test_prices_df_has_expected_columns
+    test_signals_df_has_expected_columns
+    test_handles_empty_prices
+    test_handles_empty_signals
+    test_handles_both_empty
+    test_handles_database_error_gracefully
+    test_date_columns_are_datetime_type
+    test_respects_days_parameter
+
+TestGetMultiAssetSignals:
+    test_returns_dataframe
+    test_handles_empty_result
+    test_handles_database_error
+    test_respects_limit_parameter
+```
+
+#### Chart Component Tests (`test_charts.py`)
+
+```
+TestBuildSignalOverTrendChart:
+    test_returns_figure_with_valid_data
+    test_returns_figure_with_empty_signals
+    test_returns_figure_with_empty_prices
+    test_marker_color_matches_sentiment
+    test_marker_size_scales_with_confidence
+    test_timeframe_windows_added_when_enabled
+    test_timeframe_windows_not_added_when_disabled
+    test_hover_template_contains_thesis
+    test_hover_template_contains_confidence
+    test_sentiment_legend_traces_added
+
+TestBuildEmptySignalChart:
+    test_returns_figure
+    test_contains_annotation_message
+```
+
+#### Page Layout Tests (`test_trends.py`)
+
+```
+TestCreateTrendsPage:
+    test_returns_html_div
+    test_contains_asset_dropdown
+    test_contains_range_buttons
+    test_contains_chart_graph
+    test_contains_options_checklist
+
+TestRegisterTrendsCallbacks:
+    test_callbacks_registered_without_error
+```
+
+**Total new tests: ~25**
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Signal-Over-Trend Chart View** - New `/trends` page showing prediction signals overlaid on candlestick price charts
+  - Sentiment-colored markers (green=bullish, red=bearish, gray=neutral)
+  - Marker size scales with prediction confidence
+  - Rich tooltips with thesis text, confidence score, and outcome
+  - Optional 7-day evaluation window overlays
+  - Asset selector and time range controls (30D/90D/180D/1Y)
+  - Signal summary statistics panel below chart
+- **Enhanced Asset Page Chart** - Existing asset page now uses the improved signal overlay component
+- **New navigation link** - "Trends" added to top navigation bar
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+| Scenario | Expected Behavior |
+|---|---|
+| **No market price data for symbol** | Show "No price data for {symbol}" empty chart |
+| **No predictions for symbol** | Show candlestick chart only, no markers. Summary says "No prediction signals found" |
+| **Many overlapping signals (10+ on same day)** | Markers stack vertically. `hovermode="closest"` ensures individual selection |
+| **Signal date on weekend/holiday** | Marker is skipped (no matching price date) |
+| **Confidence is None** | Default to 0.5, marker rendered at medium size |
+| **Thesis is None or empty** | Tooltip omits thesis line |
+| **Database connection error** | Error card shown, chart shows error message |
+| **Very long date range (1Y)** | ~365 trading days + ~100 signals. Plotly handles this fine |
+| **Prediction outcome not yet evaluated** | Outcome shown as "PENDING" in tooltip |
+
+---
+
+## Verification Checklist
+
+- [ ] `source venv/bin/activate && pytest shit_tests/shitty_ui/ -v` passes with all new tests
+- [ ] `python3 -m ruff check shitty_ui/` returns no errors
+- [ ] `python3 -m ruff format shitty_ui/` applies no changes
+- [ ] Navigate to `/trends` in browser -- page loads without errors
+- [ ] Select an asset with known price + signal data -- chart renders with markers
+- [ ] Hover over a marker -- tooltip shows sentiment, confidence, thesis, outcome
+- [ ] Click 30D/90D/180D/1Y buttons -- chart re-renders with correct date range
+- [ ] Toggle "Show 7-day windows" -- shaded regions appear/disappear
+- [ ] Navigate to `/assets/AAPL` -- enhanced chart shows signal overlays
+- [ ] Test with a symbol that has no price data -- empty chart message shown
+- [ ] Test with a symbol that has prices but no predictions -- candlestick only
+- [ ] Console shows no JavaScript errors
+- [ ] CHANGELOG.md updated
+
+---
+
+## What NOT To Do
+
+1. **Do NOT add a new database table.** This feature reads from existing `market_prices`, `predictions`, `prediction_outcomes`, and `truth_social_shitposts` tables.
+
+2. **Do NOT use `go.Candlestick` with `rangeslider=True`.** The rangeslider consumes too much vertical space. Keep `rangeslider=dict(visible=False)`.
+
+3. **Do NOT create separate callbacks for each signal marker.** Build all markers in a single callback pass. One `go.Scatter` per signal is fine for up to ~200 signals.
+
+4. **Do NOT add real-time WebSocket or live streaming.** The existing refresh interval is sufficient.
+
+5. **Do NOT modify the database session management.** Continue using `execute_query()` from `data.py` with `SessionLocal()`.
+
+6. **Do NOT add `@ttl_cache` to `get_price_with_signals`.** The function takes variable parameters, making the cache key matrix too large.
+
+7. **Do NOT remove existing `get_asset_price_history` or `get_asset_predictions` functions.** They are still used by other callbacks.
+
+8. **Do NOT use Plotly Express (`px`).** The codebase consistently uses `plotly.graph_objects` (`go`).
+
+9. **Do NOT create a `__main__.py` for the trends page.** It is a Dash page, not a CLI module.
+
+10. **Do NOT forget `suppress_callback_exceptions=True`.** It is already set in `create_app()` at line 67 of `layout.py` and covers dynamically rendered component IDs.

--- a/documentation/planning/phases/system-evolution_2026-02-11/04_deploy-alerts-production.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/04_deploy-alerts-production.md
@@ -1,0 +1,754 @@
+# Phase 04: Deploy Alerts to Production
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: deploy Telegram alert system to production (bot + cron + webhook)` |
+| **Risk Level** | Low -- No existing functionality is modified. Deployment of already-tested code with configuration changes. |
+| **Estimated Effort** | Low (~2-4 hours of work. Most effort is Railway/BotFather configuration, not code.) |
+| **Files Created** | None |
+| **Files Modified** | `notifications/telegram_sender.py`, `notifications/telegram_bot.py`, `shitty_ui/app.py`, `railway.json`, `shit/db/sync_session.py`, `CHANGELOG.md` |
+| **Files Deleted** | None |
+
+---
+
+## Context: Why This Matters
+
+The Shitpost Alpha notification system code is fully implemented and tested (7 test files under `shit_tests/notifications/`), but none of it is deployed to production. The pipeline currently runs end-to-end: Truth Social posts are harvested, stored in S3, loaded to PostgreSQL, and analyzed by GPT-4 to produce predictions. However, those predictions sit silently in the database. Nobody receives real-time alerts when a high-confidence trading signal is detected.
+
+This phase bridges the gap between "predictions exist in the database" and "subscribers get notified in real-time via Telegram." Without this, the entire analysis pipeline produces value that nobody sees unless they manually check the dashboard.
+
+The existing code is well-structured:
+- `notifications/alert_engine.py` -- Queries for new predictions, filters by subscriber preferences, dispatches alerts
+- `notifications/telegram_bot.py` -- Handles all bot commands (`/start`, `/stop`, `/settings`, etc.)
+- `notifications/telegram_sender.py` -- Low-level Telegram API calls (sendMessage, setWebhook)
+- `notifications/db.py` -- Subscription CRUD, prediction queries, error tracking
+- `notifications/__main__.py` -- CLI with `check-alerts`, `set-webhook`, `test-alert`, `list-subscribers`, `stats`
+- `shitty_ui/app.py` -- Already has webhook endpoint at `/telegram/webhook`
+- `shitvault/shitpost_models.py` -- Already has `TelegramSubscription` SQLAlchemy model
+
+A comprehensive setup guide already exists at `/Users/chris/Projects/shitpost-alpha/documentation/TELEGRAM_SETUP_GUIDE.md`.
+
+---
+
+## Dependencies
+
+- **No code dependencies on other phases.** This phase deploys existing code.
+- **Phase 01 (nice-to-have):** Better predictions mean better alerts, but the alert system works regardless of prediction quality.
+- **External requirements:** A Telegram account to create the bot via BotFather, and access to the Railway project dashboard to add environment variables and a new service.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Create the Telegram Bot via BotFather
+
+This is a manual step performed in the Telegram app. No code changes needed.
+
+1. Open Telegram (mobile or desktop) and search for `@BotFather`
+2. Send `/newbot`
+3. When prompted for a display name, enter: `Shitpost Alpha Alerts`
+4. When prompted for a username, enter: `shitpost_alpha_bot` (must end in `bot`, must be unique -- if taken, try `shitpostalpha_alerts_bot` or similar)
+5. BotFather responds with the **bot token**. It looks like: `7123456789:AAH1234567890abcdef-GHIJKLMN_opqrstuv`. Save this immediately and securely -- it is the only credential needed.
+6. Configure the bot profile with BotFather:
+   - Send `/setdescription` and enter: `Real-time AI trading signal alerts from Trump's Truth Social posts. Not financial advice.`
+   - Send `/setabouttext` and enter: `Shitpost Alpha monitors Trump's Truth Social and uses GPT-4 to predict market movements. Get alerts when high-confidence signals are detected.`
+   - Send `/setcommands` and enter:
+     ```
+     start - Subscribe to alerts
+     stop - Unsubscribe from alerts
+     status - Check subscription status
+     settings - View/change alert preferences
+     stats - View prediction accuracy
+     latest - Show recent predictions
+     help - Show all commands
+     ```
+   - Optionally send `/setuserpic` and upload a bot avatar
+7. If the bot will be used in groups, send `/setprivacy` and select `Disable` so the bot can read messages without being @mentioned
+
+### Step 2: Fix the Markdown Parse Mode Bug (CRITICAL)
+
+Before deploying, there is a production bug that must be fixed. The bot command responses in `telegram_bot.py` use **MarkdownV2** escape syntax (e.g., `\\!`, `\\.`, `\\-`) but `send_telegram_message()` in `telegram_sender.py` defaults to `parse_mode="Markdown"` (v1). Telegram's v1 Markdown does not recognize these escape sequences, causing garbled output with visible backslashes.
+
+**File:** `/Users/chris/Projects/shitpost-alpha/notifications/telegram_sender.py`
+
+**Change 1:** Update the default `parse_mode` from `"Markdown"` to `"MarkdownV2"` on line 29.
+
+Before (line 26-32):
+```python
+def send_telegram_message(
+    chat_id: str,
+    text: str,
+    parse_mode: str = "Markdown",
+    disable_notification: bool = False,
+    reply_markup: Optional[Dict] = None,
+) -> Tuple[bool, Optional[str]]:
+```
+
+After (line 26-32):
+```python
+def send_telegram_message(
+    chat_id: str,
+    text: str,
+    parse_mode: str = "MarkdownV2",
+    disable_notification: bool = False,
+    reply_markup: Optional[Dict] = None,
+) -> Tuple[bool, Optional[str]]:
+```
+
+**Change 2:** Update the docstring on line 39 to match.
+
+Before (line 39):
+```python
+        parse_mode: "Markdown" or "HTML".
+```
+
+After (line 39):
+```python
+        parse_mode: "MarkdownV2", "Markdown", or "HTML".
+```
+
+**Change 3:** The `format_telegram_alert()` function (lines 116-155) formats alert messages using `escape_markdown()` which escapes all MarkdownV2 special characters. However, the message template itself on lines 141-154 uses `*` for bold and `_` for italic, which would also be escaped by the caller if the text fields go through `escape_markdown`. Review reveals that `escape_markdown` is only called on `text` and `thesis` fields (user-generated content), while the structural markdown (`*`, `_`) is in the template itself -- this is correct. The template will work with MarkdownV2 parse mode because the structural characters are intentional formatting, not user data.
+
+However, line 153 contains an unescaped `.` in `_This is NOT financial advice. For entertainment only._`. Under MarkdownV2, the `.` inside an italic block needs to be escaped. Fix this:
+
+Before (lines 141-155):
+```python
+    message = f"""
+{emoji} *SHITPOST ALPHA ALERT*
+
+*Sentiment:* {sentiment} ({confidence_pct} confidence)
+*Assets:* {assets_str}
+
+\U0001f4dd *Post:*
+_{escape_markdown(text)}_
+
+\U0001f4a1 *Thesis:*
+{escape_markdown(thesis)}
+
+\u26a0\ufe0f _This is NOT financial advice. For entertainment only._
+"""
+    return message.strip()
+```
+
+After (lines 141-155):
+```python
+    message = f"""
+{emoji} *SHITPOST ALPHA ALERT*
+
+*Sentiment:* {sentiment} \\({confidence_pct} confidence\\)
+*Assets:* {assets_str}
+
+\U0001f4dd *Post:*
+_{escape_markdown(text)}_
+
+\U0001f4a1 *Thesis:*
+{escape_markdown(thesis)}
+
+\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
+"""
+    return message.strip()
+```
+
+Note: The parentheses around `({confidence_pct} confidence)` also need to be escaped for MarkdownV2 since `(` and `)` are special characters. The `assets_str` variable contains ticker symbols which may contain `-` (e.g., `BTC-USD`) -- these are already handled because `escape_markdown` is not called on the template variables that go into `assets_str` (it is constructed from a list join). However, since `assets_str` could contain special chars from user tickers, we should escape it too. Add an `escape_markdown` call for `assets_str`:
+
+Before (line 130):
+```python
+    assets_str = ", ".join(assets[:5]) if assets else "None specified"
+```
+
+After (line 130):
+```python
+    assets_str = escape_markdown(", ".join(assets[:5])) if assets else "None specified"
+```
+
+And escape `confidence_pct`:
+
+Before (line 128):
+```python
+    confidence_pct = f"{confidence:.0%}" if confidence else "N/A"
+```
+
+After (line 128):
+```python
+    confidence_pct = escape_markdown(f"{confidence:.0%}") if confidence else "N/A"
+```
+
+### Step 3: Add TelegramSubscription to create_tables
+
+The `create_tables()` function in `sync_session.py` does not import `TelegramSubscription`, which means the table will not be auto-created when the function is called. While the table may already exist in production (if created via manual SQL), this import should be added for consistency and for any fresh database setup.
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shit/db/sync_session.py`
+
+Before (lines 68-81):
+```python
+def create_tables():
+    """Create all tables in the database."""
+    from shit.db.data_models import Base
+    # Import all models to ensure they're registered
+    from shitvault.shitpost_models import (
+        TruthSocialShitpost,
+        Prediction,
+        MarketMovement,
+        Subscriber,
+        LLMFeedback
+    )
+    from shit.market_data.models import MarketPrice, PredictionOutcome
+
+    Base.metadata.create_all(engine)
+```
+
+After (lines 68-83):
+```python
+def create_tables():
+    """Create all tables in the database."""
+    from shit.db.data_models import Base
+    # Import all models to ensure they're registered
+    from shitvault.shitpost_models import (
+        TruthSocialShitpost,
+        Prediction,
+        MarketMovement,
+        Subscriber,
+        LLMFeedback,
+        TelegramSubscription,
+    )
+    from shit.market_data.models import MarketPrice, PredictionOutcome
+
+    Base.metadata.create_all(engine)
+```
+
+### Step 4: Ensure the telegram_subscriptions Table Exists in Production
+
+Before deploying, verify the table exists in the production Neon database. Run from a local machine with `.env` loaded:
+
+```bash
+source venv/bin/activate
+python3 -c "
+from shit.db.sync_session import get_session
+from sqlalchemy import text
+
+with get_session() as session:
+    result = session.execute(text(\"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'telegram_subscriptions'\"))
+    exists = result.scalar()
+    print(f'telegram_subscriptions table exists: {bool(exists)}')
+"
+```
+
+If the table does NOT exist, create it using the SQL from the setup guide:
+
+```sql
+CREATE TABLE telegram_subscriptions (
+    id SERIAL PRIMARY KEY,
+    chat_id VARCHAR(50) UNIQUE NOT NULL,
+    chat_type VARCHAR(20) NOT NULL DEFAULT 'private',
+    username VARCHAR(100),
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    title VARCHAR(200),
+    is_active BOOLEAN DEFAULT true,
+    subscribed_at TIMESTAMP DEFAULT NOW(),
+    unsubscribed_at TIMESTAMP,
+    alert_preferences JSON DEFAULT '{"min_confidence": 0.7, "assets_of_interest": [], "sentiment_filter": "all", "quiet_hours_enabled": false, "quiet_hours_start": "22:00", "quiet_hours_end": "08:00"}',
+    last_alert_at TIMESTAMP,
+    alerts_sent_count INTEGER DEFAULT 0,
+    last_interaction_at TIMESTAMP DEFAULT NOW(),
+    consecutive_errors INTEGER DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX idx_telegram_subscriptions_chat_id ON telegram_subscriptions(chat_id);
+CREATE INDEX idx_telegram_subscriptions_is_active ON telegram_subscriptions(is_active);
+```
+
+### Step 5: Configure Railway Environment Variables
+
+In the Railway project dashboard, add the following environment variables. These apply to BOTH the dashboard service (`shitpost-alpha-dash`) and the new notifications cron service.
+
+| Variable | Value | Where |
+|----------|-------|-------|
+| `TELEGRAM_BOT_TOKEN` | The token from BotFather (e.g., `7123456789:AAH...`) | Both `shitpost-alpha-dash` and `notifications` services |
+| `TELEGRAM_BOT_USERNAME` | The bot's username without `@` (e.g., `shitpost_alpha_bot`) | Both services (optional, for display) |
+| `TELEGRAM_WEBHOOK_URL` | `https://<dashboard-domain>.railway.app/telegram/webhook` | `shitpost-alpha-dash` only (informational) |
+
+**How to add Railway env vars:**
+1. Go to the Railway project dashboard
+2. Click on the `shitpost-alpha-dash` service
+3. Go to the "Variables" tab
+4. Click "New Variable"
+5. Add `TELEGRAM_BOT_TOKEN` with the bot token value
+6. Repeat for `TELEGRAM_BOT_USERNAME`
+7. Railway will automatically redeploy the service
+
+These variables are already defined in the Pydantic settings model at `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py` (lines 83-89) with `Optional[str]` defaults of `None`, so no code changes are needed to read them.
+
+### Step 6: Add the Notifications Cron Service to railway.json
+
+**File:** `/Users/chris/Projects/shitpost-alpha/railway.json`
+
+Before:
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK"
+  },
+  "deploy": {
+    "runtime": "V2",
+    "numReplicas": 1,
+    "sleepApplication": false,
+    "useLegacyStacker": false,
+    "multiRegionConfig": {
+      "us-east4-eqdc4a": {
+        "numReplicas": 1
+      }
+    },
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  },
+  "services": {
+    "shitpost-alpha": {
+      "source": ".",
+      "startCommand": "python shitpost_alpha.py --mode incremental"
+    },
+    "shitpost-alpha-dash": {
+      "source": ".",
+      "startCommand": "cd shitty_ui && python app.py"
+    },
+    "market-data": {
+      "source": ".",
+      "startCommand": "python -m shit.market_data auto-pipeline --days-back 30",
+      "cronSchedule": "*/15 * * * *"
+    }
+  }
+}
+```
+
+After:
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK"
+  },
+  "deploy": {
+    "runtime": "V2",
+    "numReplicas": 1,
+    "sleepApplication": false,
+    "useLegacyStacker": false,
+    "multiRegionConfig": {
+      "us-east4-eqdc4a": {
+        "numReplicas": 1
+      }
+    },
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  },
+  "services": {
+    "shitpost-alpha": {
+      "source": ".",
+      "startCommand": "python shitpost_alpha.py --mode incremental"
+    },
+    "shitpost-alpha-dash": {
+      "source": ".",
+      "startCommand": "cd shitty_ui && python app.py"
+    },
+    "market-data": {
+      "source": ".",
+      "startCommand": "python -m shit.market_data auto-pipeline --days-back 30",
+      "cronSchedule": "*/15 * * * *"
+    },
+    "notifications": {
+      "source": ".",
+      "startCommand": "python -m notifications check-alerts",
+      "cronSchedule": "*/2 * * * *"
+    }
+  }
+}
+```
+
+The cron schedule `*/2 * * * *` runs every 2 minutes, matching the alert engine's design (see `alert_engine.py` module docstring: "Designed to run via Railway cron every 2 minutes").
+
+### Step 7: Add a Health Check / Monitoring Endpoint
+
+Add a `/telegram/health` endpoint to the dashboard Flask server for monitoring alert system status.
+
+**File:** `/Users/chris/Projects/shitpost-alpha/shitty_ui/app.py`
+
+Before (lines 20-44):
+```python
+def register_webhook_route(app):
+    """
+    Register the Telegram webhook endpoint on the Dash app's Flask server.
+
+    This is a thin passthrough that receives Telegram updates and delegates
+    to the standalone notifications module for processing.
+    """
+    server = app.server
+
+    @server.route("/telegram/webhook", methods=["POST"])
+    def telegram_webhook():
+        try:
+            update = request.get_json(force=True)
+        except Exception:
+            return jsonify({"ok": False, "error": "Invalid JSON"}), 400
+
+        try:
+            from notifications.telegram_bot import process_update
+
+            process_update(update)
+        except Exception as e:
+            logger.error(f"Error processing Telegram webhook: {e}")
+
+        # Always return 200 to Telegram so it doesn't retry
+        return jsonify({"ok": True})
+```
+
+After (lines 20-68):
+```python
+def register_webhook_route(app):
+    """
+    Register the Telegram webhook and health check endpoints on the Dash app's Flask server.
+
+    Endpoints:
+        POST /telegram/webhook - Receives Telegram updates
+        GET  /telegram/health  - Alert system health check
+    """
+    server = app.server
+
+    @server.route("/telegram/webhook", methods=["POST"])
+    def telegram_webhook():
+        try:
+            update = request.get_json(force=True)
+        except Exception:
+            return jsonify({"ok": False, "error": "Invalid JSON"}), 400
+
+        try:
+            from notifications.telegram_bot import process_update
+
+            process_update(update)
+        except Exception as e:
+            logger.error(f"Error processing Telegram webhook: {e}")
+
+        # Always return 200 to Telegram so it doesn't retry
+        return jsonify({"ok": True})
+
+    @server.route("/telegram/health", methods=["GET"])
+    def telegram_health():
+        """Health check endpoint for the alert system."""
+        health = {"ok": True, "service": "telegram_alerts"}
+        try:
+            from notifications.db import get_subscription_stats, get_last_alert_check
+            from notifications.telegram_sender import get_bot_token
+
+            stats = get_subscription_stats()
+            last_check = get_last_alert_check()
+            has_token = bool(get_bot_token())
+
+            health["bot_configured"] = has_token
+            health["subscribers"] = {
+                "total": stats.get("total", 0),
+                "active": stats.get("active", 0),
+            }
+            health["last_alert_check"] = last_check.isoformat() if last_check else None
+            health["total_alerts_sent"] = stats.get("total_alerts_sent", 0)
+        except Exception as e:
+            health["ok"] = False
+            health["error"] = str(e)
+            logger.error(f"Health check failed: {e}")
+
+        status_code = 200 if health["ok"] else 503
+        return jsonify(health), status_code
+```
+
+### Step 8: Deploy to Railway and Register the Webhook
+
+After all code changes are merged:
+
+1. **Push to main** -- Railway auto-deploys from the main branch.
+
+2. **Wait for deployment** -- The dashboard service (`shitpost-alpha-dash`) will redeploy with the new health check endpoint and the `TELEGRAM_BOT_TOKEN` env var.
+
+3. **Verify the dashboard is running** by visiting the Railway-provided URL.
+
+4. **Register the webhook** from your local machine:
+   ```bash
+   source venv/bin/activate
+   python3 -m notifications set-webhook https://<dashboard-domain>.railway.app/telegram/webhook
+   ```
+
+   Expected output: `Webhook set successfully: https://<dashboard-domain>.railway.app/telegram/webhook`
+
+5. **Verify the webhook** by checking with the Telegram API directly:
+   ```bash
+   curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
+   ```
+
+   Expected response includes: `"url": "https://<dashboard-domain>.railway.app/telegram/webhook"` and `"has_custom_certificate": false`.
+
+6. **Verify the notifications cron service** is running in the Railway dashboard. It should appear as a new service named `notifications` with a `*/2 * * * *` cron schedule.
+
+### Step 9: End-to-End Verification
+
+1. **Subscribe yourself to the bot:**
+   - Open Telegram and search for the bot by username (e.g., `@shitpost_alpha_bot`)
+   - Send `/start`
+   - Expected: Welcome message with subscription confirmation
+
+2. **Verify subscription was created:**
+   ```bash
+   source venv/bin/activate
+   python3 -m notifications list-subscribers
+   ```
+   Expected: Your chat ID appears in the subscriber list.
+
+3. **Send a test alert:**
+   ```bash
+   python3 -m notifications test-alert --chat-id YOUR_CHAT_ID
+   ```
+   Expected: Test alert message arrives in Telegram.
+
+4. **Test bot commands:**
+   - `/status` -- Shows your subscription details
+   - `/settings` -- Shows current preferences
+   - `/settings confidence 80` -- Changes min confidence to 80%
+   - `/stats` -- Shows prediction statistics
+   - `/latest` -- Shows recent predictions
+   - `/help` -- Shows command list
+   - `/stop` -- Unsubscribes
+
+5. **Check the health endpoint:**
+   ```bash
+   curl https://<dashboard-domain>.railway.app/telegram/health
+   ```
+   Expected: JSON with `"ok": true`, `"bot_configured": true`, subscriber counts.
+
+6. **Wait for a real prediction** (or trigger the pipeline manually with `python3 shitpost_alpha.py --mode incremental` and confirm user approval first) and verify the cron picks it up and sends an alert.
+
+---
+
+## Test Plan
+
+### Automated Tests (run before merging)
+
+```bash
+source venv/bin/activate && pytest shit_tests/notifications/ -v
+```
+
+All 7 existing test files should pass. Specific tests affected by the parse_mode change:
+
+- `test_telegram_sender.py::TestSendTelegramMessage` -- Verify the `parse_mode` default is now `MarkdownV2` in the POST payload
+- `test_telegram_sender.py::TestFormatTelegramAlert` -- Verify escaped parentheses and dots in formatted output
+
+Additional tests to add (optional, but recommended):
+
+1. In `test_telegram_sender.py`, add a test that verifies the default parse_mode:
+   ```python
+   @patch("notifications.telegram_sender.get_bot_token")
+   @patch("notifications.telegram_sender.requests.post")
+   def test_default_parse_mode_is_markdownv2(self, mock_post, mock_token):
+       """Default parse_mode should be MarkdownV2."""
+       mock_token.return_value = "test_token"
+       mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+
+       send_telegram_message("123456", "Test")
+       call_kwargs = mock_post.call_args
+       payload = call_kwargs[1]["json"]  # json= kwarg
+       assert payload["parse_mode"] == "MarkdownV2"
+   ```
+
+2. In `test_telegram_sender.py`, verify `format_telegram_alert` escapes parentheses:
+   ```python
+   def test_format_alert_escapes_special_chars(self):
+       """Alert formatting should escape MarkdownV2 special characters."""
+       alert = {
+           "sentiment": "bullish",
+           "confidence": 0.85,
+           "assets": ["AAPL"],
+           "text": "Test post.",
+           "thesis": "Test thesis.",
+       }
+       message = format_telegram_alert(alert)
+       assert "\\(" in message  # Parentheses escaped
+       assert "\\." in message  # Dots in disclaimer escaped
+   ```
+
+### Manual Verification Steps
+
+1. **Local test (before Railway):** Set `TELEGRAM_BOT_TOKEN` in `.env`, run `python3 -m notifications test-alert --chat-id YOUR_ID`, verify message renders correctly without garbled backslashes
+2. **Webhook test:** After setting the webhook, message the bot and verify all commands respond correctly
+3. **Cron test:** Run `python3 -m notifications check-alerts` locally and verify it queries the database and reports results
+4. **Health check test:** After deployment, hit `/telegram/health` and verify the JSON response
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Telegram Alert Deployment** - Deployed notification system to production
+  - Notifications cron service in Railway (`*/2 * * * *`) for automated alert dispatch
+  - Health check endpoint at `/telegram/health` for monitoring alert system status
+  - Bot registration with BotFather including command autocomplete
+
+### Fixed
+- **Telegram Markdown Parsing** - Changed default `parse_mode` from `Markdown` (v1) to `MarkdownV2` in `send_telegram_message()` to match bot response escaping
+- **Table Creation** - Added `TelegramSubscription` to `create_tables()` import list in `sync_session.py`
+```
+
+### TELEGRAM_SETUP_GUIDE.md
+
+The existing guide at `/Users/chris/Projects/shitpost-alpha/documentation/TELEGRAM_SETUP_GUIDE.md` is already comprehensive. After deployment, update the note on line 181:
+
+Before (line 181):
+```markdown
+> **Note (2026-02-10)**: This cron service is not yet added to `railway.json`. The webhook endpoint works (commands are processed when users message the bot), but automated alert dispatch requires adding this cron service to Railway.
+```
+
+After:
+```markdown
+> **Deployed (2026-02-11)**: The notifications cron service is active in `railway.json` running every 2 minutes. The health check endpoint is available at `/telegram/health`.
+```
+
+Also add a health check section after the Troubleshooting section:
+
+```markdown
+## Health Check
+
+Monitor the alert system status:
+
+```bash
+curl https://<dashboard-domain>.railway.app/telegram/health
+```
+
+Response:
+```json
+{
+  "ok": true,
+  "service": "telegram_alerts",
+  "bot_configured": true,
+  "subscribers": {"total": 5, "active": 3},
+  "last_alert_check": "2026-02-11T10:30:00",
+  "total_alerts_sent": 42
+}
+```
+
+A `200` status with `"ok": true` means the system is healthy. A `503` status indicates a problem (database unreachable, missing token, etc.).
+```
+
+---
+
+## Stress Testing and Edge Cases
+
+### Telegram Rate Limits
+
+Telegram imposes rate limits on bot messages:
+- **Individual chats:** ~30 messages per second
+- **Groups:** ~20 messages per minute per group
+- **Broadcast to many users:** ~30 messages per second total, with occasional `429 Too Many Requests` responses
+
+The current alert engine (`alert_engine.py` lines 82-112) sends messages sequentially in a loop with no rate limiting between sends. For the current expected subscriber count (fewer than 100), this is fine. If the subscriber base grows significantly, the following improvements would be needed:
+
+- Add a `time.sleep(0.05)` between sends (20 messages/second, well under limits)
+- Handle HTTP 429 responses with `Retry-After` header parsing
+- Batch subscribers and process in chunks
+
+**Current risk:** LOW. The system handles `send_telegram_message` failures gracefully (records error, increments `consecutive_errors`, continues to next subscriber).
+
+### Webhook Failures
+
+The webhook endpoint in `shitty_ui/app.py` (line 44) always returns HTTP 200 to Telegram, regardless of whether processing succeeded. This is correct -- Telegram retries on non-200 responses, and we want to avoid retry storms. Errors are logged server-side.
+
+**Edge case:** If the dashboard service goes down, Telegram will retry webhook deliveries for up to 24 hours. When the service comes back, it will process the queued updates. Bot command responses may be delayed but will not be lost.
+
+### Duplicate Alerts
+
+The alert engine uses `get_last_alert_check()` to determine the time window for new predictions. This function (in `notifications/db.py`, lines 439-461) uses `MAX(last_alert_at)` from active subscriptions as the cutoff.
+
+**Potential issue:** If a cron run fails partway through (sent to some subscribers but not all), the `last_alert_at` for the subscribers who received the alert gets updated, moving the window forward. Subscribers who did NOT receive the alert will miss it on the next run.
+
+**Mitigation:** This is acceptable for the current scale. A more robust solution would use a dedicated `notification_state` table to track the global last-processed prediction timestamp independently of per-subscriber state. The code already references this concept (see `db.py` line 444 comment about `notification_state` table) but falls back to the simpler approach. This can be improved in a future phase if needed.
+
+### Dashboard Restart During Webhook Processing
+
+If the Railway dashboard restarts while processing a Telegram webhook, the in-flight request is lost. Telegram will retry because it did not receive a 200 response. The retry will be processed on the restarted service. No data loss occurs.
+
+### Missing Bot Token at Startup
+
+If `TELEGRAM_BOT_TOKEN` is not set, all operations fail gracefully:
+- `send_telegram_message` returns `(False, "Telegram bot token not configured")` (line 47-48 of `telegram_sender.py`)
+- `set_webhook` returns `(False, "Telegram bot token not configured")` (line 97-98)
+- The health check endpoint returns `"bot_configured": false`
+- No crashes, no exceptions
+
+### Subscriber With 5+ Consecutive Errors
+
+The `get_active_subscriptions()` query (line 106 of `db.py`) filters out subscribers with `consecutive_errors >= 5`. This prevents wasting API calls on permanently broken chats (blocked users, deleted accounts). To re-enable a subscriber after fixing the issue:
+
+```sql
+UPDATE telegram_subscriptions SET consecutive_errors = 0 WHERE chat_id = 'xxx';
+```
+
+---
+
+## Verification Checklist
+
+Before merging:
+- [ ] `parse_mode` default changed to `"MarkdownV2"` in `send_telegram_message()`
+- [ ] `format_telegram_alert()` escapes parentheses and dots for MarkdownV2
+- [ ] `TelegramSubscription` imported in `create_tables()`
+- [ ] `notifications` cron service added to `railway.json`
+- [ ] Health check endpoint added to `shitty_ui/app.py`
+- [ ] All existing tests pass: `source venv/bin/activate && pytest shit_tests/notifications/ -v`
+- [ ] CHANGELOG.md updated
+
+After merging and deploying:
+- [ ] Bot created via BotFather with commands registered
+- [ ] `TELEGRAM_BOT_TOKEN` set in Railway env vars for both dashboard and notifications services
+- [ ] `telegram_subscriptions` table exists in production database
+- [ ] Webhook registered: `python3 -m notifications set-webhook https://<url>/telegram/webhook`
+- [ ] Webhook verified: `curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"` shows correct URL
+- [ ] Bot responds to `/start` command in Telegram
+- [ ] Test alert sent successfully: `python3 -m notifications test-alert --chat-id YOUR_ID`
+- [ ] Health endpoint returns `"ok": true`: `curl https://<url>/telegram/health`
+- [ ] Notifications cron service visible and running in Railway dashboard
+- [ ] TELEGRAM_SETUP_GUIDE.md note updated from "not yet added" to "deployed"
+
+---
+
+## What NOT To Do
+
+1. **Do NOT use long polling instead of webhooks.** The code is designed for webhook mode. Long polling would require a persistent process and conflict with the cron-based alert dispatch architecture.
+
+2. **Do NOT hardcode the bot token anywhere in the codebase.** The token is read from the `TELEGRAM_BOT_TOKEN` environment variable via Pydantic settings. Never commit it to `.env`, `railway.json`, or any file.
+
+3. **Do NOT change the cron frequency below 2 minutes.** Running more frequently than every 2 minutes wastes Railway compute credits and provides negligible latency improvement. The 2-minute interval is already aggressive for a cron-based system.
+
+4. **Do NOT run `python -m notifications check-alerts` in production without understanding the cost.** Each run queries the database. At 2-minute intervals, that is 720 queries per day. This is fine for Neon PostgreSQL but should not be made more frequent.
+
+5. **Do NOT skip the MarkdownV2 fix.** Deploying with `parse_mode="Markdown"` (v1) while bot responses use MarkdownV2 escaping will produce garbled messages with visible backslashes in every bot response. Users will see `\-` and `\.` in messages, making the bot look broken.
+
+6. **Do NOT create a separate Telegram bot for testing and production.** Use one bot. Test with your own chat ID via `python3 -m notifications test-alert --chat-id YOUR_ID`. The subscriber system is multi-tenant -- each subscriber has independent preferences.
+
+7. **Do NOT manually insert subscriber rows in production to test.** Use the `/start` bot command instead. It creates the subscription with proper defaults and validates the chat ID is real.
+
+8. **Do NOT expose the health check endpoint with sensitive data.** The current implementation only returns aggregate stats (subscriber counts, last check time) and boolean flags. It does not expose individual subscriber data, chat IDs, or the bot token.
+
+9. **Do NOT attempt to send alerts to channels without first making the bot an admin** with "Post Messages" permission. Channel subscriptions must be created manually in the database since no user can send `/start` in a channel.
+
+10. **Do NOT remove the `# Always return 200 to Telegram so it doesn't retry` pattern** in the webhook endpoint. Returning non-200 causes Telegram to retry the same update repeatedly, potentially causing duplicate command processing and log spam.
+
+---
+
+### Critical Files for Implementation
+- `/Users/chris/Projects/shitpost-alpha/notifications/telegram_sender.py` - Fix parse_mode default to MarkdownV2 and escape special chars in format_telegram_alert
+- `/Users/chris/Projects/shitpost-alpha/railway.json` - Add notifications cron service entry
+- `/Users/chris/Projects/shitpost-alpha/shitty_ui/app.py` - Add /telegram/health monitoring endpoint
+- `/Users/chris/Projects/shitpost-alpha/shit/db/sync_session.py` - Add TelegramSubscription to create_tables imports
+- `/Users/chris/Projects/shitpost-alpha/documentation/TELEGRAM_SETUP_GUIDE.md` - Update deployment status note

--- a/documentation/planning/phases/system-evolution_2026-02-11/05_llm-provider-switch.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/05_llm-provider-switch.md
@@ -1,0 +1,1236 @@
+# Phase 05: LLM Provider Switch (Claude/Grok)
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: add Grok/xAI provider and provider comparison tooling for LLM analysis` |
+| **Risk Level** | Low |
+| **Estimated Effort** | Low (4-6 hours implementation, 2 hours testing) |
+| **Files Created** | `shit/llm/provider_config.py`, `shit/llm/compare_providers.py`, `shitpost_ai/compare_cli.py`, `shit_tests/shit/llm/test_provider_config.py`, `shit_tests/shit/llm/test_compare_providers.py`, `shit_tests/shit/llm/test_llm_client_grok.py` |
+| **Files Modified** | `shit/llm/llm_client.py`, `shit/config/shitpost_settings.py`, `shit/llm/__init__.py`, `requirements.txt`, `shit_tests/shit/llm/test_llm_client.py`, `CHANGELOG.md`, `CLAUDE.md` |
+| **Files Deleted** | None |
+
+---
+
+## Context: Why This Matters
+
+All changes are additive. The existing OpenAI and Anthropic code paths are only refactored minimally for normalization, and no database schema changes are required. The `llm_provider` and `llm_model` columns already exist on the `predictions` table.
+
+**Cost optimization**: OpenAI GPT-4 is the most expensive option at roughly $30-60/million input tokens. Claude Sonnet models and Grok models offer competitive quality at lower price points.
+
+**Quality improvement**: Different models have different strengths. Claude models tend to produce more structured JSON output with fewer parsing failures. Grok (built by xAI) has strong political/social media context which is directly relevant to analyzing Trump's Truth Social posts.
+
+**Vendor diversification**: Running production on a single LLM provider creates a single point of failure. If OpenAI has an outage or changes pricing, the system should be able to switch providers with a single environment variable change.
+
+**Evaluation capability**: The comparison tooling allows the team to run the same posts through multiple providers side-by-side, measuring confidence scores, asset extraction accuracy, and response latency -- enabling data-driven provider selection.
+
+---
+
+## Dependencies
+
+**None.** This phase has zero dependencies on any other phase. It can be implemented in parallel with all other system-evolution phases. The only external requirements are API keys for the providers you want to test (Anthropic API key for Claude, xAI API key for Grok).
+
+---
+
+## Audit of Current State
+
+### Anthropic Code Path (Already Functional)
+
+The current Anthropic code path at `/Users/chris/Projects/shitpost-alpha/shit/llm/llm_client.py` lines 44-45 and 156-169 is **already correct** for the current `anthropic` SDK (version `>=0.7.0` per `requirements.txt` line 16).
+
+**Key observations**:
+- Line 45: Uses `anthropic.AsyncAnthropic(api_key=self.api_key)` -- correct for SDK >=0.7.0
+- Line 159: Uses `self.client.messages.create(...)` -- correct Messages API
+- Line 162: Passes `system=system_message` as a top-level keyword argument -- correct (the Messages API takes `system` as a separate parameter, not as a message role)
+- Line 163-165: Uses `messages=[{"role": "user", "content": prompt}]` -- correct format
+- Line 169: Extracts response via `response.content[0].text` -- correct
+
+**One concern**: The `anthropic>=0.7.0` version pin is very old. The current Anthropic SDK is well past 0.40+. While backward-compatible, I recommend updating the pin to `anthropic>=0.40.0` to get the latest models (Claude 3.5 Sonnet, Claude 3.5 Haiku, Claude 4 Opus) and improved error handling.
+
+### OpenAI Code Path (Functional, Foundation for Grok)
+
+The OpenAI code path at lines 40-42 and 141-154 uses `AsyncOpenAI(api_key=self.api_key)`. This is correct for `openai>=1.0.0` (the new SDK).
+
+**Critical for Grok**: The `AsyncOpenAI` constructor accepts a `base_url` parameter. Grok's API is OpenAI-compatible, meaning we can reuse the exact same OpenAI code path by passing `base_url="https://api.x.ai/v1"`. This is the standard approach for OpenAI-compatible providers.
+
+### Settings (Needs Extension)
+
+`/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py`:
+- Line 38: `LLM_PROVIDER` defaults to `"openai"`, comment says `# openai, anthropic` -- needs to add `grok`
+- Line 36-37: Has `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` -- needs `XAI_API_KEY`
+- Lines 114-129: `get_llm_api_key()` only handles `openai` and `anthropic` -- needs `grok` branch
+
+### Response Format (Already Normalized)
+
+The `_parse_analysis_response()` method at line 175 works on raw text strings and is provider-agnostic. The `_call_llm()` method already normalizes each provider's response to a plain string (line 154 for OpenAI, line 169 for Anthropic). This pattern just needs extending for Grok.
+
+### Database (No Changes Needed)
+
+The `Prediction` model at `/Users/chris/Projects/shitpost-alpha/shitvault/shitpost_models.py` line 150-151 already has `llm_provider` (String(50)) and `llm_model` (String(100)) columns. The `store_analysis` method at `/Users/chris/Projects/shitpost-alpha/shitvault/prediction_operations.py` lines 82-83 already reads these from `analysis_data`. No schema changes are required.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Create Provider Configuration Module
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/llm/provider_config.py`
+
+This module provides a single source of truth for all provider metadata, including supported models, costs, rate limits, and base URLs.
+
+```python
+"""
+LLM Provider Configuration
+Centralized provider metadata for model selection and cost tracking.
+"""
+
+from typing import Dict, Optional, List
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a specific LLM model."""
+    model_id: str
+    display_name: str
+    input_cost_per_1m_tokens: float  # USD per 1M input tokens
+    output_cost_per_1m_tokens: float  # USD per 1M output tokens
+    max_output_tokens: int
+    context_window: int
+    recommended: bool = False
+    notes: str = ""
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for an LLM provider."""
+    provider_id: str  # 'openai', 'anthropic', 'grok'
+    display_name: str
+    base_url: Optional[str]  # None for providers with built-in SDK support
+    api_key_env_var: str  # Environment variable name for API key
+    sdk_type: str  # 'openai' or 'anthropic' -- which SDK to use
+    models: List[ModelConfig] = field(default_factory=list)
+    rate_limit_rpm: int = 60  # Requests per minute
+    notes: str = ""
+
+
+# --- Provider Definitions ---
+
+OPENAI_MODELS = [
+    ModelConfig(
+        model_id="gpt-4o",
+        display_name="GPT-4o",
+        input_cost_per_1m_tokens=2.50,
+        output_cost_per_1m_tokens=10.00,
+        max_output_tokens=16384,
+        context_window=128000,
+        recommended=True,
+        notes="Best balance of cost and quality for production use"
+    ),
+    ModelConfig(
+        model_id="gpt-4o-mini",
+        display_name="GPT-4o Mini",
+        input_cost_per_1m_tokens=0.15,
+        output_cost_per_1m_tokens=0.60,
+        max_output_tokens=16384,
+        context_window=128000,
+        notes="Cheapest OpenAI option, good for testing"
+    ),
+    ModelConfig(
+        model_id="gpt-4",
+        display_name="GPT-4",
+        input_cost_per_1m_tokens=30.00,
+        output_cost_per_1m_tokens=60.00,
+        max_output_tokens=8192,
+        context_window=8192,
+        notes="Legacy model, expensive. Consider migrating to gpt-4o"
+    ),
+]
+
+ANTHROPIC_MODELS = [
+    ModelConfig(
+        model_id="claude-sonnet-4-20250514",
+        display_name="Claude Sonnet 4",
+        input_cost_per_1m_tokens=3.00,
+        output_cost_per_1m_tokens=15.00,
+        max_output_tokens=8192,
+        context_window=200000,
+        recommended=True,
+        notes="Best quality/cost ratio for structured analysis"
+    ),
+    ModelConfig(
+        model_id="claude-haiku-3-5-20241022",
+        display_name="Claude 3.5 Haiku",
+        input_cost_per_1m_tokens=0.80,
+        output_cost_per_1m_tokens=4.00,
+        max_output_tokens=8192,
+        context_window=200000,
+        notes="Fast and cheap, good for high-volume analysis"
+    ),
+]
+
+GROK_MODELS = [
+    ModelConfig(
+        model_id="grok-2",
+        display_name="Grok 2",
+        input_cost_per_1m_tokens=2.00,
+        output_cost_per_1m_tokens=10.00,
+        max_output_tokens=8192,
+        context_window=131072,
+        recommended=True,
+        notes="Strong social media context, native X/Truth Social understanding"
+    ),
+    ModelConfig(
+        model_id="grok-2-mini",
+        display_name="Grok 2 Mini",
+        input_cost_per_1m_tokens=0.10,
+        output_cost_per_1m_tokens=0.40,
+        max_output_tokens=8192,
+        context_window=131072,
+        notes="Cheapest option, experimental quality"
+    ),
+]
+
+PROVIDERS: Dict[str, ProviderConfig] = {
+    "openai": ProviderConfig(
+        provider_id="openai",
+        display_name="OpenAI",
+        base_url=None,  # Uses default OpenAI API
+        api_key_env_var="OPENAI_API_KEY",
+        sdk_type="openai",
+        models=OPENAI_MODELS,
+        rate_limit_rpm=60,
+        notes="Current production provider"
+    ),
+    "anthropic": ProviderConfig(
+        provider_id="anthropic",
+        display_name="Anthropic",
+        base_url=None,  # Uses native Anthropic SDK
+        api_key_env_var="ANTHROPIC_API_KEY",
+        sdk_type="anthropic",
+        models=ANTHROPIC_MODELS,
+        rate_limit_rpm=60,
+        notes="Alternative provider with strong structured output"
+    ),
+    "grok": ProviderConfig(
+        provider_id="grok",
+        display_name="xAI (Grok)",
+        base_url="https://api.x.ai/v1",
+        api_key_env_var="XAI_API_KEY",
+        sdk_type="openai",  # Grok uses OpenAI-compatible API
+        models=GROK_MODELS,
+        rate_limit_rpm=60,
+        notes="xAI's model with strong social media/political context"
+    ),
+}
+
+
+def get_provider(provider_id: str) -> ProviderConfig:
+    """Get provider configuration by ID.
+
+    Args:
+        provider_id: Provider identifier ('openai', 'anthropic', 'grok')
+
+    Returns:
+        ProviderConfig for the specified provider
+
+    Raises:
+        ValueError: If provider_id is not supported
+    """
+    if provider_id not in PROVIDERS:
+        supported = ", ".join(PROVIDERS.keys())
+        raise ValueError(
+            f"Unsupported provider: '{provider_id}'. "
+            f"Supported providers: {supported}"
+        )
+    return PROVIDERS[provider_id]
+
+
+def get_recommended_model(provider_id: str) -> Optional[ModelConfig]:
+    """Get the recommended model for a provider.
+
+    Args:
+        provider_id: Provider identifier
+
+    Returns:
+        Recommended ModelConfig, or first model if none marked recommended
+    """
+    provider = get_provider(provider_id)
+    for model in provider.models:
+        if model.recommended:
+            return model
+    return provider.models[0] if provider.models else None
+
+
+def get_all_provider_ids() -> List[str]:
+    """Get list of all supported provider IDs."""
+    return list(PROVIDERS.keys())
+```
+
+### Step 2: Update Settings Configuration
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py`
+
+**Change 1**: Add `XAI_API_KEY` and `LLM_BASE_URL` settings (after line 37)
+
+Current (lines 36-39):
+```python
+    OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
+    ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
+    LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic
+    LLM_MODEL: str = Field(default="gpt-4", env="LLM_MODEL")
+```
+
+New (lines 36-42):
+```python
+    OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
+    ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
+    XAI_API_KEY: Optional[str] = Field(default=None, env="XAI_API_KEY")
+    LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic, grok
+    LLM_MODEL: str = Field(default="gpt-4", env="LLM_MODEL")
+    LLM_BASE_URL: Optional[str] = Field(default=None, env="LLM_BASE_URL")  # Custom base URL for OpenAI-compatible APIs
+```
+
+**Change 2**: Extend `get_llm_api_key()` method (lines 114-129)
+
+Current:
+```python
+    def get_llm_api_key(self) -> str:
+        """Get the appropriate LLM API key based on provider."""
+        if self.LLM_PROVIDER == "openai":
+            if not self.OPENAI_API_KEY:
+                raise ValueError(
+                    "OPENAI_API_KEY is required when LLM_PROVIDER is 'openai'"
+                )
+            return self.OPENAI_API_KEY
+        elif self.LLM_PROVIDER == "anthropic":
+            if not self.ANTHROPIC_API_KEY:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY is required when LLM_PROVIDER is 'anthropic'"
+                )
+            return self.ANTHROPIC_API_KEY
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.LLM_PROVIDER}")
+```
+
+New:
+```python
+    def get_llm_api_key(self) -> str:
+        """Get the appropriate LLM API key based on provider."""
+        if self.LLM_PROVIDER == "openai":
+            if not self.OPENAI_API_KEY:
+                raise ValueError(
+                    "OPENAI_API_KEY is required when LLM_PROVIDER is 'openai'"
+                )
+            return self.OPENAI_API_KEY
+        elif self.LLM_PROVIDER == "anthropic":
+            if not self.ANTHROPIC_API_KEY:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY is required when LLM_PROVIDER is 'anthropic'"
+                )
+            return self.ANTHROPIC_API_KEY
+        elif self.LLM_PROVIDER == "grok":
+            if not self.XAI_API_KEY:
+                raise ValueError(
+                    "XAI_API_KEY is required when LLM_PROVIDER is 'grok'"
+                )
+            return self.XAI_API_KEY
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.LLM_PROVIDER}")
+
+    def get_llm_base_url(self) -> Optional[str]:
+        """Get the base URL for the LLM provider, if applicable.
+
+        Returns:
+            Base URL string for OpenAI-compatible providers, or None for native SDKs.
+        """
+        if self.LLM_BASE_URL:
+            return self.LLM_BASE_URL
+        if self.LLM_PROVIDER == "grok":
+            return "https://api.x.ai/v1"
+        return None
+```
+
+### Step 3: Update LLMClient for Multi-Provider Support
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/llm/llm_client.py`
+
+**Change 1**: Update `__init__` to support Grok via `base_url` (lines 26-47)
+
+Current:
+```python
+    def __init__(self, provider: str = None, model: str = None, api_key: str = None):
+        """Initialize LLM client with optional overrides.
+
+        Args:
+            provider: LLM provider ('openai' or 'anthropic')
+            model: Model name (e.g., 'gpt-4', 'claude-3-sonnet')
+            api_key: API key (if not provided, uses settings)
+        """
+        self.provider = provider or settings.LLM_PROVIDER
+        self.model = model or settings.LLM_MODEL
+        self.api_key = api_key or settings.get_llm_api_key()
+        self.confidence_threshold = settings.CONFIDENCE_THRESHOLD
+
+        # Initialize client based on provider
+        if self.provider == "openai":
+            from openai import AsyncOpenAI
+            self.client = AsyncOpenAI(api_key=self.api_key)
+        elif self.provider == "anthropic":
+            import anthropic
+            self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.provider}")
+```
+
+New:
+```python
+    def __init__(self, provider: str = None, model: str = None, api_key: str = None, base_url: str = None):
+        """Initialize LLM client with optional overrides.
+
+        Args:
+            provider: LLM provider ('openai', 'anthropic', or 'grok')
+            model: Model name (e.g., 'gpt-4', 'claude-sonnet-4-20250514', 'grok-2')
+            api_key: API key (if not provided, uses settings)
+            base_url: Custom base URL for OpenAI-compatible APIs (if not provided, uses settings)
+        """
+        self.provider = provider or settings.LLM_PROVIDER
+        self.model = model or settings.LLM_MODEL
+        self.api_key = api_key or settings.get_llm_api_key()
+        self.base_url = base_url or settings.get_llm_base_url()
+        self.confidence_threshold = settings.CONFIDENCE_THRESHOLD
+
+        # Determine SDK type: grok uses OpenAI-compatible API
+        self._sdk_type = self._get_sdk_type()
+
+        # Initialize client based on SDK type
+        if self._sdk_type == "openai":
+            from openai import AsyncOpenAI
+            client_kwargs = {"api_key": self.api_key}
+            if self.base_url:
+                client_kwargs["base_url"] = self.base_url
+            self.client = AsyncOpenAI(**client_kwargs)
+        elif self._sdk_type == "anthropic":
+            import anthropic
+            self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.provider}")
+
+    def _get_sdk_type(self) -> str:
+        """Determine which SDK to use for this provider.
+
+        Returns:
+            'openai' or 'anthropic'
+
+        Raises:
+            ValueError: If provider is not supported
+        """
+        sdk_map = {
+            "openai": "openai",
+            "anthropic": "anthropic",
+            "grok": "openai",  # Grok uses OpenAI-compatible API
+        }
+        if self.provider not in sdk_map:
+            raise ValueError(f"Unsupported LLM provider: {self.provider}")
+        return sdk_map[self.provider]
+```
+
+**Change 2**: Update `_call_llm` to use `_sdk_type` instead of `self.provider` (lines 130-173)
+
+Current (lines 141 and 156):
+```python
+            if self.provider == "openai":
+                ...
+            elif self.provider == "anthropic":
+                ...
+```
+
+New:
+```python
+            if self._sdk_type == "openai":
+                response = await asyncio.wait_for(
+                    self.client.chat.completions.create(
+                        model=self.model,
+                        messages=[
+                            {"role": "system", "content": system_message or "You are a helpful AI assistant."},
+                            {"role": "user", "content": prompt}
+                        ],
+                        max_tokens=1000,
+                        temperature=0.3
+                    ),
+                    timeout=30.0  # 30 second timeout
+                )
+                return response.choices[0].message.content
+
+            elif self._sdk_type == "anthropic":
+                response = await asyncio.wait_for(
+                    self.client.messages.create(
+                        model=self.model,
+                        max_tokens=1000,
+                        temperature=0.3,
+                        system=system_message or "You are a helpful AI assistant.",
+                        messages=[
+                            {"role": "user", "content": prompt}
+                        ]
+                    ),
+                    timeout=30.0  # 30 second timeout
+                )
+                return response.content[0].text
+```
+
+This is the key insight: by switching from `self.provider` to `self._sdk_type`, the Grok provider automatically routes through the OpenAI SDK code path with the custom `base_url` already set in `__init__`.
+
+### Step 4: Create Provider Comparison Module
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/llm/compare_providers.py`
+
+```python
+"""
+LLM Provider Comparison
+Run the same content through multiple providers and compare results.
+"""
+
+import asyncio
+import json
+import time
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass, field
+
+from shit.llm.llm_client import LLMClient
+from shit.llm.provider_config import PROVIDERS, get_provider
+from shit.logging import get_service_logger
+
+logger = get_service_logger("llm_compare")
+
+
+@dataclass
+class ProviderResult:
+    """Result from a single provider analysis."""
+    provider: str
+    model: str
+    assets: List[str] = field(default_factory=list)
+    market_impact: Dict[str, str] = field(default_factory=dict)
+    confidence: float = 0.0
+    thesis: str = ""
+    latency_ms: float = 0.0
+    success: bool = True
+    error: Optional[str] = None
+    raw_response: Optional[Dict] = None
+
+
+@dataclass
+class ComparisonResult:
+    """Comparison result across multiple providers."""
+    content: str
+    results: List[ProviderResult] = field(default_factory=list)
+    asset_agreement: float = 0.0  # 0.0-1.0, how much providers agree on assets
+    sentiment_agreement: float = 0.0  # 0.0-1.0, how much providers agree on sentiment
+    confidence_spread: float = 0.0  # Difference between max and min confidence
+
+
+class ProviderComparator:
+    """Compare LLM provider analysis results."""
+
+    def __init__(self, providers: Optional[List[str]] = None):
+        """Initialize comparator with provider list.
+
+        Args:
+            providers: List of provider IDs to compare.
+                       Defaults to all providers with available API keys.
+        """
+        self.provider_ids = providers or list(PROVIDERS.keys())
+        self.clients: Dict[str, LLMClient] = {}
+
+    async def initialize(self) -> List[str]:
+        """Initialize LLM clients for all specified providers.
+
+        Returns:
+            List of provider IDs that were successfully initialized.
+        """
+        initialized = []
+
+        for provider_id in self.provider_ids:
+            try:
+                provider_config = get_provider(provider_id)
+                # Determine model and API key
+                from shit.config.shitpost_settings import Settings
+                settings = Settings()
+
+                api_key = getattr(settings, provider_config.api_key_env_var, None)
+                if not api_key:
+                    logger.warning(
+                        f"Skipping {provider_id}: no API key found "
+                        f"(set {provider_config.api_key_env_var})"
+                    )
+                    continue
+
+                # Get recommended model for this provider
+                from shit.llm.provider_config import get_recommended_model
+                model_config = get_recommended_model(provider_id)
+                model_id = model_config.model_id if model_config else None
+
+                base_url = provider_config.base_url
+
+                client = LLMClient(
+                    provider=provider_id,
+                    model=model_id,
+                    api_key=api_key,
+                    base_url=base_url
+                )
+                await client.initialize()
+                self.clients[provider_id] = client
+                initialized.append(provider_id)
+                logger.info(f"Initialized {provider_id} with model {model_id}")
+
+            except Exception as e:
+                logger.warning(f"Failed to initialize {provider_id}: {e}")
+
+        return initialized
+
+    async def compare(self, content: str) -> ComparisonResult:
+        """Run content through all initialized providers and compare results.
+
+        Args:
+            content: Content to analyze
+
+        Returns:
+            ComparisonResult with per-provider results and agreement metrics
+        """
+        comparison = ComparisonResult(content=content)
+
+        # Run all providers concurrently
+        tasks = []
+        for provider_id, client in self.clients.items():
+            tasks.append(self._analyze_with_provider(provider_id, client, content))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error(f"Provider comparison error: {result}")
+                continue
+            comparison.results.append(result)
+
+        # Calculate agreement metrics
+        self._calculate_agreement(comparison)
+
+        return comparison
+
+    async def _analyze_with_provider(
+        self, provider_id: str, client: LLMClient, content: str
+    ) -> ProviderResult:
+        """Analyze content with a single provider, capturing timing."""
+        result = ProviderResult(provider=provider_id, model=client.model)
+
+        start_time = time.monotonic()
+        try:
+            analysis = await client.analyze(content)
+            result.latency_ms = (time.monotonic() - start_time) * 1000
+
+            if analysis:
+                result.assets = analysis.get('assets', [])
+                result.market_impact = analysis.get('market_impact', {})
+                result.confidence = analysis.get('confidence', 0.0)
+                result.thesis = analysis.get('thesis', '')
+                result.raw_response = analysis
+                result.success = True
+            else:
+                result.success = False
+                result.error = "Analysis returned None"
+
+        except Exception as e:
+            result.latency_ms = (time.monotonic() - start_time) * 1000
+            result.success = False
+            result.error = str(e)
+
+        return result
+
+    def _calculate_agreement(self, comparison: ComparisonResult) -> None:
+        """Calculate agreement metrics across providers."""
+        successful = [r for r in comparison.results if r.success]
+
+        if len(successful) < 2:
+            return
+
+        # Asset agreement: Jaccard similarity of asset sets
+        all_asset_sets = [set(r.assets) for r in successful]
+        if any(s for s in all_asset_sets):  # At least one non-empty
+            union = set().union(*all_asset_sets)
+            intersection = set(all_asset_sets[0])
+            for s in all_asset_sets[1:]:
+                intersection = intersection.intersection(s)
+            comparison.asset_agreement = (
+                len(intersection) / len(union) if union else 1.0
+            )
+        else:
+            comparison.asset_agreement = 1.0  # All agree: no assets
+
+        # Sentiment agreement: compare market_impact values
+        # For each common asset, check if sentiment direction matches
+        common_assets = set()
+        for r in successful:
+            common_assets.update(r.market_impact.keys())
+
+        if common_assets:
+            agreements = 0
+            comparisons = 0
+            for asset in common_assets:
+                sentiments = [
+                    r.market_impact.get(asset)
+                    for r in successful
+                    if asset in r.market_impact
+                ]
+                if len(sentiments) >= 2:
+                    # Count pairwise agreements
+                    for i in range(len(sentiments)):
+                        for j in range(i + 1, len(sentiments)):
+                            comparisons += 1
+                            if sentiments[i] == sentiments[j]:
+                                agreements += 1
+            comparison.sentiment_agreement = (
+                agreements / comparisons if comparisons else 1.0
+            )
+
+        # Confidence spread
+        confidences = [r.confidence for r in successful]
+        comparison.confidence_spread = max(confidences) - min(confidences)
+
+
+def format_comparison_report(comparison: ComparisonResult) -> str:
+    """Format a comparison result as a human-readable report.
+
+    Args:
+        comparison: ComparisonResult to format
+
+    Returns:
+        Formatted string report
+    """
+    lines = []
+    lines.append("=" * 70)
+    lines.append("LLM PROVIDER COMPARISON REPORT")
+    lines.append("=" * 70)
+    lines.append("")
+
+    content_preview = comparison.content[:100] + "..." if len(comparison.content) > 100 else comparison.content
+    lines.append(f"Content: {content_preview}")
+    lines.append("")
+
+    for result in comparison.results:
+        lines.append(f"--- {result.provider.upper()} ({result.model}) ---")
+        if result.success:
+            lines.append(f"  Assets:     {', '.join(result.assets) if result.assets else 'None'}")
+            lines.append(f"  Impact:     {result.market_impact}")
+            lines.append(f"  Confidence: {result.confidence:.1%}")
+            lines.append(f"  Latency:    {result.latency_ms:.0f}ms")
+            thesis_preview = result.thesis[:120] + "..." if len(result.thesis) > 120 else result.thesis
+            lines.append(f"  Thesis:     {thesis_preview}")
+        else:
+            lines.append(f"  ERROR: {result.error}")
+        lines.append("")
+
+    lines.append("--- AGREEMENT METRICS ---")
+    lines.append(f"  Asset Agreement:     {comparison.asset_agreement:.1%}")
+    lines.append(f"  Sentiment Agreement: {comparison.sentiment_agreement:.1%}")
+    lines.append(f"  Confidence Spread:   {comparison.confidence_spread:.2f}")
+    lines.append("=" * 70)
+
+    return "\n".join(lines)
+```
+
+### Step 5: Create Comparison CLI
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shitpost_ai/compare_cli.py`
+
+```python
+"""
+Provider Comparison CLI
+Compare LLM providers for shitpost analysis quality.
+"""
+
+import argparse
+import asyncio
+import sys
+from typing import List, Optional
+
+from shit.llm.compare_providers import ProviderComparator, format_comparison_report
+from shit.llm.provider_config import PROVIDERS, get_all_provider_ids
+from shit.logging import setup_cli_logging
+
+
+COMPARE_EXAMPLES = """
+Examples:
+  # Compare all available providers on sample content
+  python -m shitpost_ai compare --content "Tesla is destroying American jobs!"
+
+  # Compare specific providers
+  python -m shitpost_ai compare --providers openai anthropic --content "Tariffs on China!"
+
+  # Compare using a post from the database (by shitpost_id)
+  python -m shitpost_ai compare --shitpost-id 123456789
+
+  # List available providers and models
+  python -m shitpost_ai compare --list-providers
+"""
+
+
+def create_compare_parser() -> argparse.ArgumentParser:
+    """Create argument parser for comparison CLI."""
+    parser = argparse.ArgumentParser(
+        description="Compare LLM provider analysis results",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=COMPARE_EXAMPLES
+    )
+
+    parser.add_argument(
+        "--content",
+        type=str,
+        help="Content text to analyze across providers"
+    )
+    parser.add_argument(
+        "--shitpost-id",
+        type=str,
+        help="Analyze a specific shitpost from the database by ID"
+    )
+    parser.add_argument(
+        "--providers",
+        nargs="+",
+        choices=get_all_provider_ids(),
+        help="Specific providers to compare (default: all available)"
+    )
+    parser.add_argument(
+        "--list-providers",
+        action="store_true",
+        help="List all available providers and their models"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose logging"
+    )
+
+    return parser
+
+
+def list_providers() -> None:
+    """Print all available providers and their models."""
+    print("\n=== Available LLM Providers ===\n")
+    for provider_id, config in PROVIDERS.items():
+        print(f"  {provider_id} ({config.display_name})")
+        print(f"    SDK: {config.sdk_type}")
+        print(f"    API Key Env: {config.api_key_env_var}")
+        if config.base_url:
+            print(f"    Base URL: {config.base_url}")
+        print(f"    Models:")
+        for model in config.models:
+            rec = " [RECOMMENDED]" if model.recommended else ""
+            print(f"      - {model.model_id}{rec}")
+            print(f"        Cost: ${model.input_cost_per_1m_tokens}/1M in, ${model.output_cost_per_1m_tokens}/1M out")
+            if model.notes:
+                print(f"        Note: {model.notes}")
+        print()
+
+
+async def run_comparison(content: str, providers: Optional[List[str]] = None) -> None:
+    """Run comparison and print report."""
+    comparator = ProviderComparator(providers=providers)
+
+    initialized = await comparator.initialize()
+    if len(initialized) < 2:
+        print(f"\nOnly {len(initialized)} provider(s) initialized. Need at least 2 for comparison.")
+        print("Check that API keys are set for the providers you want to compare.")
+        print("Run with --list-providers to see required environment variables.")
+        return
+
+    print(f"\nComparing {len(initialized)} providers: {', '.join(initialized)}")
+    print("Running analysis...\n")
+
+    result = await comparator.compare(content)
+    report = format_comparison_report(result)
+    print(report)
+
+
+async def compare_main() -> None:
+    """Main entry point for comparison CLI."""
+    parser = create_compare_parser()
+    args = parser.parse_args(sys.argv[2:])  # Skip 'compare' subcommand
+
+    setup_cli_logging(verbose=args.verbose)
+
+    if args.list_providers:
+        list_providers()
+        return
+
+    if args.shitpost_id:
+        # Fetch content from database
+        from shit.config.shitpost_settings import settings
+        from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
+        from shitvault.shitpost_operations import ShitpostOperations
+
+        db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
+        db_client = DatabaseClient(db_config)
+        await db_client.initialize()
+
+        async with db_client.get_session() as session:
+            db_ops = DatabaseOperations(session)
+            shitpost_ops = ShitpostOperations(db_ops)
+            shitpost = await shitpost_ops.get_shitpost_by_id(args.shitpost_id)
+
+            if not shitpost:
+                print(f"Shitpost {args.shitpost_id} not found in database")
+                return
+
+            content = shitpost.get('text', '')
+
+        await db_client.cleanup()
+
+    elif args.content:
+        content = args.content
+    else:
+        parser.error("Either --content or --shitpost-id is required")
+        return
+
+    await run_comparison(content, providers=args.providers)
+```
+
+### Step 6: Update shitpost_ai __main__.py for Compare Subcommand
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitpost_ai/__main__.py`
+
+Add support for the `compare` subcommand. The modification needs to detect if the first argument is `compare` and route to the comparison CLI, otherwise fall through to the existing analyzer logic.
+
+Add this after the existing imports (line 16) and before the existing `async def main()`:
+
+```python
+def _is_compare_command() -> bool:
+    """Check if the CLI was invoked with the 'compare' subcommand."""
+    return len(sys.argv) > 1 and sys.argv[1] == "compare"
+```
+
+Then at the bottom of the file, change lines 85-86:
+
+Current:
+```python
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+New:
+```python
+if __name__ == "__main__":
+    if _is_compare_command():
+        from shitpost_ai.compare_cli import compare_main
+        asyncio.run(compare_main())
+    else:
+        asyncio.run(main())
+```
+
+### Step 7: Update LLM Module __init__.py
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/llm/__init__.py`
+
+Add export of provider config:
+
+```python
+"""
+LLM Utilities
+Base LLM client and prompt utilities for the Shitpost-Alpha project.
+"""
+
+from .llm_client import LLMClient
+from .prompts import (
+    get_analysis_prompt,
+    get_detailed_analysis_prompt,
+    get_sector_analysis_prompt,
+    get_crypto_analysis_prompt,
+    get_alert_prompt
+)
+from .provider_config import PROVIDERS, get_provider, get_recommended_model
+
+__all__ = [
+    'LLMClient',
+    'get_analysis_prompt',
+    'get_detailed_analysis_prompt',
+    'get_sector_analysis_prompt',
+    'get_crypto_analysis_prompt',
+    'get_alert_prompt',
+    'PROVIDERS',
+    'get_provider',
+    'get_recommended_model',
+]
+```
+
+### Step 8: Update requirements.txt
+
+**File**: `/Users/chris/Projects/shitpost-alpha/requirements.txt`
+
+Change line 16 from:
+```
+anthropic>=0.7.0
+```
+to:
+```
+anthropic>=0.40.0
+```
+
+No new packages are needed. Grok uses the `openai` package (already installed) with a custom `base_url`. The `openai>=1.0.0` version already supports the `base_url` parameter.
+
+---
+
+## Test Plan
+
+### New Test File 1: Grok Provider Path
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/llm/test_llm_client_grok.py`
+
+Tests for Grok/xAI provider path in LLMClient. Grok uses the OpenAI-compatible API with a custom base_url.
+
+```
+class TestGrokProvider:
+    test_grok_initialization
+    test_grok_uses_openai_sdk
+    test_grok_call_llm
+    test_grok_analyze_produces_correct_metadata
+    test_grok_default_base_url_from_settings
+```
+
+**Approximate count: 5 tests**
+
+### New Test File 2: Provider Config
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/llm/test_provider_config.py`
+
+```
+class TestProviderConfig:
+    test_all_providers_defined
+    test_get_provider_valid
+    test_get_provider_invalid
+    test_grok_uses_openai_sdk
+    test_anthropic_uses_anthropic_sdk
+    test_each_provider_has_models
+    test_each_provider_has_recommended_model
+    test_get_all_provider_ids
+    test_model_costs_are_positive
+    test_provider_api_key_env_vars
+```
+
+**Approximate count: 10 tests**
+
+### New Test File 3: Provider Comparison
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/llm/test_compare_providers.py`
+
+```
+class TestProviderComparator:
+    test_calculate_agreement_identical_results
+    test_calculate_agreement_different_assets
+    test_format_comparison_report
+    test_format_report_with_error
+```
+
+**Approximate count: 4 tests**
+
+### Updates to Existing Test File
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/llm/test_llm_client.py`
+
+Add the following tests at the end of the `TestLLMClient` class:
+
+```
+    test_sdk_type_openai
+    test_sdk_type_anthropic
+    test_sdk_type_grok
+    test_base_url_not_passed_for_openai
+```
+
+**Approximate count: 4 tests**
+
+### Settings Tests
+
+Add to existing settings tests (or create new file if none exists):
+
+Test that `get_llm_api_key()` raises `ValueError` for grok when `XAI_API_KEY` is not set, and returns the key when it is. Test that `get_llm_base_url()` returns `"https://api.x.ai/v1"` for grok and `None` for openai/anthropic.
+
+**Total new tests: ~25**
+
+---
+
+## Documentation Updates
+
+### CLAUDE.md Updates
+
+In the `LLM Configuration` section of the Settings class comment (line 38), update the comment:
+
+```python
+LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic, grok
+```
+
+In the **Environment Variables** section, add:
+
+```
+# LLM Configuration
+XAI_API_KEY=xxx            # xAI/Grok API key (optional, for Grok provider)
+LLM_BASE_URL=              # Custom base URL for OpenAI-compatible APIs (optional)
+```
+
+Add a new section under **Common Development Tasks**:
+
+```
+# Compare LLM providers
+python -m shitpost_ai compare --content "Tesla is going bankrupt!"
+python -m shitpost_ai compare --list-providers
+python -m shitpost_ai compare --providers openai grok --shitpost-id 123456
+```
+
+### CHANGELOG.md
+
+Under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Grok/xAI LLM Provider** - Added xAI's Grok as a third LLM provider option
+  - Uses OpenAI-compatible API with custom base_url
+  - Supports grok-2 and grok-2-mini models
+  - Configure with `LLM_PROVIDER=grok` and `XAI_API_KEY`
+- **Provider Configuration Module** - Centralized provider metadata with model costs, rate limits, and recommendations
+- **Provider Comparison CLI** - Run `python -m shitpost_ai compare` to analyze content across multiple providers side-by-side
+  - Measures latency, asset extraction, sentiment agreement, and confidence spread
+  - Supports `--list-providers` to see all models and pricing
+
+### Changed
+- **LLMClient** - Refactored to use SDK-type routing instead of provider-name routing
+  - Grok routes through OpenAI SDK with custom base_url
+  - Added `base_url` parameter for OpenAI-compatible providers
+- **Anthropic SDK** - Updated minimum version from 0.7.0 to 0.40.0 for latest model support
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+### API Differences Across Providers
+
+**Temperature parameter**: All three providers support `temperature=0.3`. No changes needed.
+
+**Max tokens**: All three support `max_tokens=1000`. Grok's API accepts the same parameter name as OpenAI.
+
+**System message**: OpenAI and Grok use `{"role": "system", "content": ...}` in the messages array. Anthropic uses `system=` as a top-level parameter. The existing code already handles this correctly.
+
+**Response format**: OpenAI and Grok return `response.choices[0].message.content`. Anthropic returns `response.content[0].text`. The existing code already handles this.
+
+### Response Format Variations
+
+**JSON reliability**: Claude models tend to produce cleaner JSON with fewer markdown code fences. GPT-4 sometimes wraps JSON in triple backticks. Grok behavior is similar to GPT-4.
+
+The existing `_extract_json()` method (lines 196-210) uses `text.find('{')` and `text.rfind('}')` which handles all these cases correctly -- it strips any surrounding text/markdown and extracts the JSON object.
+
+**Edge case**: If a model returns the JSON inside a markdown code block, the `_extract_json` method still works because `find('{')` will find the opening brace inside the code block.
+
+### Rate Limits
+
+| Provider | Rate Limit | Notes |
+|----------|-----------|-------|
+| OpenAI GPT-4o | ~500 RPM (Tier 1) | Higher tiers available |
+| Anthropic Claude | ~60 RPM (default) | Varies by model |
+| xAI Grok | ~60 RPM (default) | Beta, limits may change |
+
+The existing `llm_rate_limiter` in `/Users/chris/Projects/shitpost-alpha/shit/utils/error_handling.py` (line 200) is set to 50 RPM, which is conservative enough for all providers. No changes needed.
+
+### Error Handling
+
+**Grok-specific errors**: Grok may return different error codes than OpenAI despite using the same SDK. The existing catch-all `except Exception` in `_call_llm()` (line 171) handles this.
+
+**Authentication failures**: If an incorrect `XAI_API_KEY` is provided, the OpenAI SDK will raise an `AuthenticationError`. This is caught by the existing exception handler.
+
+**Model not found**: If `grok-2` is specified but the API doesn't recognize it (e.g., the model name changed), the SDK raises an error that is caught by existing handlers.
+
+### Connection Test
+
+The `_test_connection()` method (lines 61-73) sends a simple "Respond with 'OK'" prompt. This works identically across all three providers since it's just a basic chat completion.
+
+---
+
+## Verification Checklist
+
+After implementation, verify each item:
+
+```bash
+# 1. Activate virtual environment
+source venv/bin/activate
+
+# 2. Run existing LLM tests to ensure no regressions
+pytest -v shit_tests/shit/llm/
+
+# 3. Run only the new tests
+pytest -v shit_tests/shit/llm/test_llm_client_grok.py
+pytest -v shit_tests/shit/llm/test_provider_config.py
+pytest -v shit_tests/shit/llm/test_compare_providers.py
+
+# 4. Verify Grok initialization creates AsyncOpenAI with base_url
+python3 -c "from shit.llm.provider_config import get_provider; p = get_provider('grok'); print(f'SDK: {p.sdk_type}, URL: {p.base_url}')"
+
+# 5. Verify provider config is importable
+python3 -c "from shit.llm import PROVIDERS, get_provider, get_recommended_model; print(f'Providers: {list(PROVIDERS.keys())}')"
+
+# 6. Verify comparison CLI help
+python3 -m shitpost_ai compare --list-providers
+
+# 7. Check code style
+python3 -m ruff check shit/llm/provider_config.py
+python3 -m ruff check shit/llm/compare_providers.py
+python3 -m ruff check shit/llm/llm_client.py
+python3 -m ruff check shit/config/shitpost_settings.py
+
+# 8. Format code
+python3 -m ruff format .
+
+# 9. Run full test suite
+pytest -v
+```
+
+**Additional verification items**:
+- [ ] **Grok initialization**: `LLMClient(provider="grok", model="grok-2", api_key="...", base_url="https://api.x.ai/v1")` creates an `AsyncOpenAI` instance with `base_url`
+- [ ] **Grok analysis**: Running `.analyze()` on a Grok client produces output with `llm_provider="grok"` and `llm_model="grok-2"` in the result dict
+- [ ] **Anthropic still works**: `LLMClient(provider="anthropic", ...)` still initializes and calls correctly
+- [ ] **OpenAI unchanged**: `LLMClient(provider="openai", ...)` still works identically (no `base_url` passed when not needed)
+- [ ] **Settings validation**: `get_llm_api_key()` raises `ValueError` for `grok` when `XAI_API_KEY` is missing
+- [ ] **Settings base URL**: `get_llm_base_url()` returns `"https://api.x.ai/v1"` for grok, `None` for openai/anthropic
+- [ ] **Provider config**: `get_provider("grok")` returns correct config, `get_provider("invalid")` raises `ValueError`
+- [ ] **Response parsing**: JSON parsing works identically for all providers (test with same sample JSON)
+- [ ] **Database storage**: Predictions stored via Grok analysis have `llm_provider='grok'` and `llm_model='grok-2'`
+- [ ] **Lint clean**: `ruff check .` passes
+- [ ] **Format clean**: `ruff format .` passes
+- [ ] **CHANGELOG updated**: Entry added under `[Unreleased]`
+
+---
+
+## What NOT To Do
+
+1. **Do NOT install a separate `grok` or `xai` Python package.** Grok uses the standard `openai` SDK with a custom `base_url`. Adding a separate package creates an unnecessary dependency.
+
+2. **Do NOT change the database schema.** The `predictions` table already has `llm_provider` and `llm_model` columns (see `/Users/chris/Projects/shitpost-alpha/shitvault/shitpost_models.py` lines 150-152). No migration is needed.
+
+3. **Do NOT modify the prompts.** The prompts in `/Users/chris/Projects/shitpost-alpha/shit/llm/prompts.py` are provider-agnostic. They instruct the LLM to return JSON with a specific structure. All three providers understand these instructions. Do not add provider-specific prompt variations.
+
+4. **Do NOT remove the Anthropic-specific code path.** Anthropic has a fundamentally different API (Messages API vs. Chat Completions), so it cannot be unified with the OpenAI SDK path. Keep the `if _sdk_type == "anthropic"` branch.
+
+5. **Do NOT run the comparison script against production without explicit user approval.** Each comparison call sends content to multiple LLM APIs, costing real money. The comparison CLI is for development/evaluation use.
+
+6. **Do NOT hardcode API keys.** All keys must come from environment variables via the settings singleton. The comparison CLI must also read keys from settings, not accept them as CLI arguments.
+
+7. **Do NOT change the default provider.** Production is running `LLM_PROVIDER=openai` and `LLM_MODEL=gpt-4`. The defaults in settings must remain unchanged. Provider switching should only happen by changing environment variables.
+
+8. **Do NOT make the comparison script a required dependency of the main pipeline.** The comparison module (`compare_providers.py`) must be importable independently. The main `ShitpostAnalyzer` should not import from it.
+
+9. **Do NOT update model pricing without verifying current prices.** The costs listed in `provider_config.py` are approximate. They should include a comment noting they are approximate and may change. Do not use them for billing calculations.
+
+10. **Do NOT break the existing test fixtures.** The `conftest.py` at `/Users/chris/Projects/shitpost-alpha/shit_tests/conftest.py` sets `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `setup_test_environment()` (lines 551-554). Add `XAI_API_KEY` to this fixture as well, but do not remove or change existing entries.
+
+---
+
+### Critical Files for Implementation
+- `/Users/chris/Projects/shitpost-alpha/shit/llm/llm_client.py` - Core file to modify: add `base_url` parameter, `_sdk_type` routing, and Grok support
+- `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py` - Add `XAI_API_KEY`, `LLM_BASE_URL`, extend `get_llm_api_key()` and add `get_llm_base_url()`
+- `/Users/chris/Projects/shitpost-alpha/shit/llm/provider_config.py` - New file: centralized provider metadata (models, costs, base URLs)
+- `/Users/chris/Projects/shitpost-alpha/shit/llm/compare_providers.py` - New file: comparison engine for running content through multiple providers
+- `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/llm/test_llm_client.py` - Existing test file: add `_sdk_type` and `base_url` tests to maintain coverage

--- a/documentation/planning/phases/system-evolution_2026-02-11/06_harvester-abstraction-layer.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/06_harvester-abstraction-layer.md
@@ -1,0 +1,1769 @@
+# Phase 06: Harvester Abstraction Layer (Multi-Source Interface)
+
+**PR Title:** `feat: harvester abstraction layer with multi-source interface`
+**Risk Level:** Medium
+**Estimated Effort:** High (3-5 days)
+**Branch Name:** `feature/harvester-abstraction-layer`
+
+---
+
+## Files Summary
+
+### Files Created (7)
+- `shitposts/base_harvester.py` -- Abstract base class `SignalHarvester`
+- `shitposts/harvester_registry.py` -- Registry pattern for dynamic source management
+- `shitposts/harvester_models.py` -- Shared data models for harvester results
+- `shitposts/twitter_harvester.py` -- Skeleton `TwitterHarvester` template
+- `shit_tests/shitposts/test_base_harvester.py` -- Tests for abstract base class
+- `shit_tests/shitposts/test_harvester_registry.py` -- Tests for registry
+- `shit_tests/shitposts/test_twitter_harvester.py` -- Tests for skeleton harvester
+
+### Files Modified (7)
+- `shitposts/truth_social_s3_harvester.py` -- Refactor to implement `SignalHarvester` interface
+- `shitposts/cli.py` -- Generalize CLI helpers (remove "Truth Social" hardcoding)
+- `shitposts/__main__.py` -- Update to support `--source` flag
+- `shitpost_alpha.py` -- Update orchestrator to iterate over registered harvesters
+- `shit/s3/s3_config.py` -- Support per-source prefix configuration
+- `shit/config/shitpost_settings.py` -- Add multi-source settings
+- `shit_tests/shitposts/test_truth_social_s3_harvester.py` -- Update tests for refactored class
+
+### Files Deleted (0)
+None. This is a pure additive refactor.
+
+---
+
+## 1. Context
+
+### Why This Matters
+
+The current system is hardwired to a single data source: Trump's Truth Social posts via the ScrapeCreators API. This creates three serious risks:
+
+1. **Single Vendor Lock-in**: If ScrapeCreators raises prices, changes their API, or goes offline, the entire pipeline breaks with zero alternatives.
+2. **Limited Signal Coverage**: Financial markets react to signals from many sources (X/Twitter, news feeds, SEC filings, press conferences). A single-source system misses most of the signal landscape.
+3. **Coupling Everywhere**: The `TruthSocialS3Harvester` class hardcodes ScrapeCreators endpoints (`https://api.scrapecreators.com/v1`), Trump's user ID (`107780257626128497`), Truth Social API field names (`posts`, `created_at`), and the S3 path prefix (`truth-social/`). Adding any new source would require duplicating this entire class with no shared structure.
+
+The abstraction layer introduces a `SignalHarvester` interface that any source can implement. The existing Truth Social harvester becomes one implementation among potentially many. A registry allows the orchestrator to discover and run all configured harvesters without knowing their internals.
+
+### Relationship to Phase 02 (Source-Agnostic Data Model)
+
+Phase 02 focuses on making the _database schema_ source-agnostic (renaming `truth_social_shitposts` to a generic table, adding a `source` column, etc.). Phase 06 focuses on making the _harvesting layer_ source-agnostic.
+
+**Dependency**: Phase 02 should ideally complete first so that downstream processing (S3 processor, database storage, analysis) can handle multi-source data. However, Phase 06 can proceed independently because:
+- The harvester already writes raw data to S3 (not directly to the database).
+- The S3 storage format already includes a `metadata.source` field (`truth_social_api`).
+- The `platform` column on `TruthSocialShitpost` already exists with value `truth_social`.
+
+If Phase 02 is not done yet, Phase 06 works perfectly for S3 storage -- the downstream S3-to-database processing will simply continue handling only `truth_social` source data until Phase 02 makes the DB layer multi-source.
+
+---
+
+## 2. Dependencies
+
+| Dependency | Status | Impact if Missing |
+|---|---|---|
+| Phase 02 (Source-Agnostic Data Model) | Should complete first | Phase 06 works for S3 storage; DB loading of non-TS sources blocked until Phase 02 |
+| `shitposts/truth_social_s3_harvester.py` | Exists | Will be refactored |
+| `shit/s3/s3_data_lake.py` | Exists | Used by all harvesters (shared) |
+| `shit/s3/s3_config.py` | Exists | Will be enhanced for per-source prefixes |
+| `shitpost_alpha.py` | Exists | Will be updated |
+
+---
+
+## 3. Detailed Implementation Plan
+
+### Step 1: Create Harvester Data Models (`shitposts/harvester_models.py`)
+
+**Purpose**: Define shared data structures that all harvesters produce, decoupling the rest of the system from source-specific field names.
+
+**Create file** at `/Users/chris/Projects/shitpost-alpha/shitposts/harvester_models.py`:
+
+```python
+"""
+Harvester Data Models
+Shared data structures for all signal harvesters.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional, Any
+
+
+class HarvesterMode(str, Enum):
+    """Supported harvesting modes."""
+    INCREMENTAL = "incremental"
+    BACKFILL = "backfill"
+    RANGE = "range"
+    FROM_DATE = "from_date"
+
+
+class HarvesterStatus(str, Enum):
+    """Harvester execution status."""
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class HarvestResult:
+    """Standardized result from any harvester.
+    
+    Every harvester yields these through harvest(), regardless of source.
+    """
+    source_name: str          # e.g., "truth_social", "twitter", "sec_filings"
+    source_post_id: str       # Original ID from the source platform
+    s3_key: str               # Where the raw data was stored in S3
+    timestamp: str            # ISO format timestamp of the original post
+    content_preview: str      # First ~100 chars for logging
+    stored_at: str            # ISO format timestamp of when we stored it
+    metadata: Dict[str, Any] = field(default_factory=dict)  # Source-specific extras
+
+
+@dataclass
+class HarvestSummary:
+    """Summary of a single harvester execution run."""
+    source_name: str
+    mode: str
+    status: HarvesterStatus
+    total_harvested: int
+    total_api_calls: int
+    started_at: str           # ISO format
+    completed_at: str         # ISO format
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HarvesterConfig:
+    """Configuration for a harvester instance.
+    
+    Each harvester reads its own source-specific settings but reports
+    them through this common structure for the registry.
+    """
+    source_name: str
+    enabled: bool = True
+    mode: HarvesterMode = HarvesterMode.INCREMENTAL
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    limit: Optional[int] = None
+    s3_prefix: Optional[str] = None  # Override for S3 path prefix
+    extra: Dict[str, Any] = field(default_factory=dict)  # Source-specific config
+```
+
+**Rationale**: Currently, the Truth Social harvester yields raw dicts with keys like `shitpost_id`, `s3_key`, `timestamp`, `content_preview`, `stored_at`. By creating a `HarvestResult` dataclass, we formalize this contract. Every harvester must produce the same shape of output.
+
+---
+
+### Step 2: Create Abstract Base Class (`shitposts/base_harvester.py`)
+
+**Purpose**: Define the interface that every harvester must implement.
+
+**Create file** at `/Users/chris/Projects/shitpost-alpha/shitposts/base_harvester.py`:
+
+```python
+"""
+Signal Harvester Base Class
+Abstract interface for all data source harvesters.
+"""
+
+import abc
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator, Dict, Optional, List
+
+from shit.s3 import S3DataLake, S3Config
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+from shitposts.harvester_models import (
+    HarvestResult,
+    HarvestSummary,
+    HarvesterConfig,
+    HarvesterMode,
+    HarvesterStatus,
+)
+
+logger = get_service_logger("harvester")
+
+
+class SignalHarvester(abc.ABC):
+    """Abstract base class for all signal harvesters.
+    
+    Every data source (Truth Social, Twitter, SEC filings, news feeds, etc.)
+    implements this interface. The orchestrator and registry interact only
+    through these methods.
+    
+    Lifecycle:
+        1. __init__(config) -- configure mode, dates, limits
+        2. initialize(dry_run) -- establish connections, verify API access
+        3. harvest(dry_run) -- yield HarvestResult items
+        4. cleanup() -- release resources
+    """
+    
+    def __init__(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+    ):
+        """Initialize the harvester with common parameters.
+        
+        Args:
+            mode: Harvesting mode - "incremental", "backfill", "range", "from_date"
+            start_date: Start date for range/from_date modes (YYYY-MM-DD)
+            end_date: End date for range mode (YYYY-MM-DD)
+            limit: Maximum number of posts to harvest (optional)
+        """
+        self.mode = mode
+        self.start_date = start_date
+        self.end_date = end_date
+        self.limit = limit
+        
+        # Parse dates if provided
+        self.start_datetime: Optional[datetime] = None
+        self.end_datetime: Optional[datetime] = None
+        
+        if start_date:
+            self.start_datetime = datetime.fromisoformat(start_date).replace(tzinfo=None)
+        if end_date:
+            self.end_datetime = datetime.fromisoformat(end_date).replace(tzinfo=None)
+        else:
+            self.end_datetime = datetime.now().replace(
+                hour=23, minute=59, second=59, microsecond=999999
+            )
+        
+        # S3 Data Lake (initialized in initialize())
+        self.s3_data_lake: Optional[S3DataLake] = None
+        
+        # Tracking
+        self.api_call_count = 0
+        self._start_time: Optional[str] = None
+    
+    # ── Abstract methods (must be implemented by each source) ──────────
+    
+    @abc.abstractmethod
+    def get_source_name(self) -> str:
+        """Return the unique source identifier.
+        
+        This is used for S3 path prefixes, logging, and registry keys.
+        
+        Returns:
+            Source name string, e.g. "truth_social", "twitter", "sec_filings"
+        """
+        ...
+    
+    @abc.abstractmethod
+    async def _test_connection(self) -> None:
+        """Test connectivity to the source API.
+        
+        Raises:
+            Exception: If connection test fails.
+        """
+        ...
+    
+    @abc.abstractmethod
+    async def _fetch_batch(self, cursor: Optional[str] = None) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of items from the source API.
+        
+        Args:
+            cursor: Pagination cursor (source-specific). None for first page.
+            
+        Returns:
+            Tuple of (list of raw items, next cursor or None if done).
+        """
+        ...
+    
+    @abc.abstractmethod
+    def _extract_item_id(self, item: Dict) -> str:
+        """Extract the unique item ID from a raw API response item.
+        
+        Args:
+            item: Single raw item from the source API.
+            
+        Returns:
+            The source-specific unique identifier string.
+        """
+        ...
+    
+    @abc.abstractmethod
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        """Extract the creation timestamp from a raw API response item.
+        
+        Args:
+            item: Single raw item from the source API.
+            
+        Returns:
+            Datetime of when the item was originally created.
+        """
+        ...
+    
+    @abc.abstractmethod
+    def _extract_content_preview(self, item: Dict) -> str:
+        """Extract a short text preview for logging purposes.
+        
+        Args:
+            item: Single raw item from the source API.
+            
+        Returns:
+            First ~100 characters of content for display.
+        """
+        ...
+    
+    # ── Concrete methods (shared by all harvesters) ────────────────────
+    
+    def _get_s3_prefix(self) -> str:
+        """Get the S3 prefix for this harvester's data.
+        
+        Default pattern: {source_name}
+        Combined with S3Config.raw_data_prefix to produce:
+            {source_name}/raw/YYYY/MM/DD/{id}.json
+            
+        Returns:
+            S3 prefix string for this source.
+        """
+        return self.get_source_name()
+    
+    async def initialize(self, dry_run: bool = False) -> None:
+        """Initialize the harvester: verify API access and prepare S3.
+        
+        Args:
+            dry_run: If True, skip S3 initialization.
+        """
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"INITIALIZING HARVESTER: {self.get_source_name()}")
+        logger.info("=" * 59)
+        
+        self._start_time = datetime.now().isoformat()
+        
+        # Source-specific connection test
+        await self._test_connection()
+        logger.info(f"API connection successful for {self.get_source_name()}")
+        
+        # Initialize S3 Data Lake
+        if not dry_run:
+            logger.info("Initializing S3 Data Lake...")
+            s3_config = S3Config(
+                bucket_name=settings.S3_BUCKET_NAME,
+                prefix=self._get_s3_prefix(),
+                region=settings.AWS_REGION,
+                access_key_id=settings.AWS_ACCESS_KEY_ID,
+                secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            )
+            self.s3_data_lake = S3DataLake(s3_config)
+            await self.s3_data_lake.initialize()
+            logger.info("S3 Data Lake initialized successfully")
+        else:
+            logger.info("Dry run mode - skipping S3 initialization")
+        
+        logger.info(f"Harvester {self.get_source_name()} initialized successfully")
+    
+    async def harvest(self, dry_run: bool = False) -> AsyncGenerator[HarvestResult, None]:
+        """Harvest items from the source. Main entry point.
+        
+        This is the universal harvest loop. It delegates to _fetch_batch()
+        and handles mode logic (incremental, backfill, range), date filtering,
+        limit enforcement, and S3 storage.
+        
+        Args:
+            dry_run: If True, do not store to S3.
+            
+        Yields:
+            HarvestResult for each successfully processed item.
+        """
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"HARVESTING FROM {self.get_source_name().upper()}")
+        logger.info("=" * 59)
+        
+        incremental_mode = (self.mode == "incremental")
+        start_date = self.start_datetime if self.mode in ("range", "from_date") else None
+        end_date = self.end_datetime if self.mode in ("range", "from_date") else None
+        
+        if incremental_mode:
+            logger.info("Mode: Incremental (will stop when encountering existing items in S3)")
+        elif start_date and end_date:
+            logger.info(f"Mode: Date Range ({start_date.date()} to {end_date.date()})")
+        else:
+            logger.info("Mode: Full Backfill")
+        
+        cursor: Optional[str] = None
+        total_harvested = 0
+        
+        while True:
+            try:
+                items, next_cursor = await self._fetch_batch(cursor)
+                
+                if not items:
+                    logger.debug("No more items to harvest")
+                    break
+                
+                if self.limit and total_harvested >= self.limit:
+                    break
+                
+                for item in items:
+                    try:
+                        item_id = self._extract_item_id(item)
+                        item_timestamp = self._extract_timestamp(item)
+                        
+                        # Date filtering
+                        if start_date and item_timestamp < start_date:
+                            logger.debug(f"Reached items before start date, stopping")
+                            return
+                        if end_date and item_timestamp > end_date:
+                            cursor = next_cursor
+                            continue
+                        
+                        # Incremental check: stop if item already in S3
+                        if incremental_mode and not dry_run and self.s3_data_lake:
+                            expected_key = self.s3_data_lake._generate_s3_key(
+                                item_id, item_timestamp
+                            )
+                            try:
+                                exists = await asyncio.wait_for(
+                                    self.s3_data_lake.check_object_exists(expected_key),
+                                    timeout=15,
+                                )
+                                if exists:
+                                    logger.info(
+                                        f"Incremental: found existing item {item_id}, "
+                                        f"stopping. Harvested {total_harvested} new items."
+                                    )
+                                    return
+                            except asyncio.TimeoutError:
+                                logger.warning(f"S3 check timed out for {item_id}, assuming new")
+                            except Exception as e:
+                                logger.warning(f"S3 check failed for {item_id}: {e}, assuming new")
+                        
+                        # Store to S3
+                        if dry_run:
+                            s3_key = f"{self._get_s3_prefix()}/raw/{item_timestamp.strftime('%Y/%m/%d')}/{item_id}.json"
+                        else:
+                            s3_key = await self.s3_data_lake.store_raw_data(item)
+                            logger.info(f"Stored {item_id} to S3: {s3_key}")
+                        
+                        result = HarvestResult(
+                            source_name=self.get_source_name(),
+                            source_post_id=item_id,
+                            s3_key=s3_key,
+                            timestamp=item_timestamp.isoformat() if isinstance(item_timestamp, datetime) else str(item_timestamp),
+                            content_preview=self._extract_content_preview(item),
+                            stored_at=datetime.now().isoformat(),
+                        )
+                        
+                        yield result
+                        total_harvested += 1
+                        
+                        if self.limit and total_harvested >= self.limit:
+                            logger.debug(f"Reached limit of {self.limit}")
+                            return
+                        
+                    except Exception as e:
+                        logger.error(f"Error processing item {self._extract_item_id(item)}: {e}")
+                        continue
+                
+                cursor = next_cursor
+                if cursor is None:
+                    break
+                
+                logger.info(f"Progress: {total_harvested} items harvested from {self.get_source_name()}")
+                await asyncio.sleep(1)  # Rate limiting
+                
+            except Exception as e:
+                logger.error(f"Error in harvest loop: {e}")
+                import traceback
+                logger.error(f"Full traceback: {traceback.format_exc()}")
+                break
+        
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"HARVEST SUMMARY ({self.get_source_name()})")
+        logger.info("=" * 59)
+        logger.info(f"Total items harvested: {total_harvested}")
+        logger.info(f"Total API calls made: {self.api_call_count}")
+    
+    async def get_s3_stats(self) -> Dict:
+        """Get S3 storage statistics for this source."""
+        if not self.s3_data_lake:
+            return {"error": "S3 Data Lake not initialized"}
+        return await self.s3_data_lake.get_data_stats()
+    
+    async def cleanup(self) -> None:
+        """Release all resources held by this harvester.
+        
+        Subclasses should override to close API sessions, then call super().
+        """
+        if self.s3_data_lake:
+            await self.s3_data_lake.cleanup()
+        logger.debug(f"{self.get_source_name()} harvester cleaned up")
+    
+    def get_summary(self, total_harvested: int, status: HarvesterStatus, error: Optional[str] = None) -> HarvestSummary:
+        """Build a HarvestSummary for this run."""
+        return HarvestSummary(
+            source_name=self.get_source_name(),
+            mode=self.mode,
+            status=status,
+            total_harvested=total_harvested,
+            total_api_calls=self.api_call_count,
+            started_at=self._start_time or datetime.now().isoformat(),
+            completed_at=datetime.now().isoformat(),
+            error_message=error,
+        )
+```
+
+**Key design decisions**:
+
+1. **`_fetch_batch()` returns `(items, next_cursor)`**: This decouples pagination from the harvest loop. ScrapeCreators uses `next_max_id`. Twitter uses cursor tokens. SEC filings might use page numbers. The base class does not care.
+
+2. **The harvest loop lives in the base class**: Date filtering, incremental S3 checking, limit enforcement, and error handling are universal. Subclasses only implement "fetch a batch" and "extract fields."
+
+3. **Six abstract methods**: `get_source_name()`, `_test_connection()`, `_fetch_batch()`, `_extract_item_id()`, `_extract_timestamp()`, `_extract_content_preview()`. These are the minimum a source needs to provide.
+
+4. **S3 prefix is `{source_name}`**: Instead of hardcoding `truth-social`, each harvester uses its source name. The `S3Config.prefix` is set per harvester instance.
+
+---
+
+### Step 3: Refactor `TruthSocialS3Harvester` to Implement Interface
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shitposts/truth_social_s3_harvester.py`.
+
+The key changes:
+- Inherit from `SignalHarvester` instead of being a standalone class
+- Move ScrapeCreators-specific logic into the abstract method implementations
+- Remove the duplicated harvest loop (use the base class `harvest()` instead)
+- Keep the `main()` function working unchanged for CLI
+
+**Before** (current lines 27-68 of `truth_social_s3_harvester.py`):
+
+```python
+class TruthSocialS3Harvester:
+    """Harvester for Truth Social posts that stores raw data in S3."""
+    
+    def __init__(self, mode="incremental", start_date=None, end_date=None, limit=None, max_id=None):
+        self.username = settings.TRUTH_SOCIAL_USERNAME
+        self.mode = mode
+        self.start_date = start_date
+        self.end_date = end_date
+        self.limit = limit
+        self.max_id = max_id
+        # ... date parsing ...
+        self.api_key = settings.SCRAPECREATORS_API_KEY
+        self.base_url = "https://api.scrapecreators.com/v1"
+        self.user_id = "107780257626128497"
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.s3_data_lake: Optional[S3DataLake] = None
+        self.api_call_count = 0
+```
+
+**After** (refactored):
+
+```python
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvestResult
+
+class TruthSocialS3Harvester(SignalHarvester):
+    """Harvester for Truth Social posts via ScrapeCreators API."""
+    
+    def __init__(self, mode="incremental", start_date=None, end_date=None, limit=None, max_id=None):
+        super().__init__(mode=mode, start_date=start_date, end_date=end_date, limit=limit)
+        
+        # Truth Social-specific config
+        self.username = settings.TRUTH_SOCIAL_USERNAME
+        self.max_id = max_id  # ScrapeCreators-specific pagination
+        self.api_key = settings.SCRAPECREATORS_API_KEY
+        self.base_url = "https://api.scrapecreators.com/v1"
+        self.user_id = "107780257626128497"  # Trump's Truth Social user ID
+        
+        # HTTP session (created in initialize)
+        self.session: Optional[aiohttp.ClientSession] = None
+        
+        # Track current pagination cursor for _fetch_batch
+        self._current_cursor: Optional[str] = max_id
+    
+    # ── Interface implementation ───────────────────────────────────────
+    
+    def get_source_name(self) -> str:
+        return "truth_social"
+    
+    async def _test_connection(self) -> None:
+        """Test the ScrapeCreators API connection."""
+        if not self.api_key:
+            raise ValueError("SCRAPECREATORS_API_KEY not configured. Please add it to your .env file.")
+        
+        # Create aiohttp session
+        self.session = aiohttp.ClientSession(
+            headers={
+                'x-api-key': self.api_key,
+                'Content-Type': 'application/json',
+                'User-Agent': 'Shitpost-Alpha-S3-Harvester/1.0'
+            }
+        )
+        
+        url = f"{self.base_url}/truthsocial/user/posts?user_id={self.user_id}&limit=1"
+        logger.debug(f"Testing API connection to: {url}")
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with self.session.get(url, timeout=timeout) as response:
+            if response.status != 200:
+                raise Exception(f"API connection test failed: {response.status}")
+            data = await response.json()
+            if not data.get('success'):
+                raise Exception(f"API returned error: {data}")
+        logger.debug("ScrapeCreators API connection test successful")
+    
+    async def _fetch_batch(self, cursor: Optional[str] = None) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of posts from ScrapeCreators API.
+        
+        Args:
+            cursor: The next_max_id for ScrapeCreators pagination.
+            
+        Returns:
+            (list of raw post dicts, next cursor string or None)
+        """
+        try:
+            url = f"{self.base_url}/truthsocial/user/posts"
+            params = {'user_id': self.user_id, 'limit': 20}
+            
+            if cursor:
+                params['next_max_id'] = cursor
+            
+            self.api_call_count += 1
+            logger.info(f"Making API call #{self.api_call_count} to Truth Social API")
+            
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with self.session.get(url, params=params, timeout=timeout) as response:
+                if response.status != 200:
+                    logger.error(f"API request failed: {response.status}")
+                    return [], None
+                
+                data = await response.json()
+                if not data.get('success'):
+                    logger.error(f"API returned error: {data}")
+                    return [], None
+                
+                posts = data.get('posts', [])
+                logger.info(f"Fetched {len(posts)} posts from Truth Social API")
+                
+                # Determine next cursor: use the last post's ID
+                next_cursor = posts[-1].get('id') if posts else None
+                
+                return posts, next_cursor
+                
+        except Exception as e:
+            logger.error(f"Error fetching posts: {e}")
+            return [], None
+    
+    def _extract_item_id(self, item: Dict) -> str:
+        return item.get('id', '')
+    
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        created_at = item.get('created_at', '')
+        if created_at.endswith('Z'):
+            created_at = created_at.replace('Z', '+00:00')
+        return datetime.fromisoformat(created_at).replace(tzinfo=None)
+    
+    def _extract_content_preview(self, item: Dict) -> str:
+        content = item.get('content', '')
+        if content and len(content) > 100:
+            return content[:100] + '...'
+        return content or 'No content'
+    
+    # ── Lifecycle overrides ────────────────────────────────────────────
+    
+    async def initialize(self, dry_run: bool = False) -> None:
+        """Initialize with Truth Social-specific connection setup."""
+        # The base class calls _test_connection() which creates the session
+        await super().initialize(dry_run=dry_run)
+    
+    async def cleanup(self) -> None:
+        """Cleanup aiohttp session and S3 resources."""
+        if self.session:
+            await self.session.close()
+        await super().cleanup()
+    
+    # ── Backward-compatible methods ────────────────────────────────────
+    
+    async def harvest_shitposts(self, dry_run: bool = False) -> AsyncGenerator[Dict, None]:
+        """Backward-compatible wrapper that delegates to harvest().
+        
+        Existing callers expect Dict yields with 'shitpost_id' key.
+        This adapter translates HarvestResult to the legacy format.
+        """
+        async for result in self.harvest(dry_run=dry_run):
+            yield {
+                'shitpost_id': result.source_post_id,
+                's3_key': result.s3_key,
+                'timestamp': result.timestamp,
+                'content_preview': result.content_preview,
+                'stored_at': result.stored_at,
+            }
+```
+
+**What changed**:
+
+| Aspect | Before | After |
+|---|---|---|
+| Inheritance | `class TruthSocialS3Harvester:` | `class TruthSocialS3Harvester(SignalHarvester):` |
+| Harvest loop | 150-line `_harvest_backfill()` method | Inherited from `SignalHarvester.harvest()` |
+| Pagination | Manual `max_id` tracking inside loop | `_fetch_batch()` returns `(items, next_cursor)` |
+| S3 init | Done inside `initialize()` | Delegated to `super().initialize()` |
+| Date parsing | Manual in `__init__` | Handled by `super().__init__()` |
+| Source identity | Implicit (hardcoded strings) | Explicit via `get_source_name()` return |
+| API calls | `_fetch_recent_shitposts()` | `_fetch_batch()` (same logic, new name) |
+| Backward compat | N/A | `harvest_shitposts()` wraps `harvest()` |
+
+**Critical**: The `harvest_shitposts()` method is kept as a backward-compatible wrapper so the existing `main()` function at line 393 and the existing tests continue to work without changes. The `main()` function calls `harvester.harvest_shitposts()` at line 434, so this adapter is essential.
+
+---
+
+### Step 4: Create Harvester Registry (`shitposts/harvester_registry.py`)
+
+**Purpose**: Config-driven discovery and management of available harvesters. The orchestrator asks "give me all enabled harvesters" rather than hardcoding `TruthSocialS3Harvester`.
+
+**Create file** at `/Users/chris/Projects/shitpost-alpha/shitposts/harvester_registry.py`:
+
+```python
+"""
+Harvester Registry
+Config-driven discovery and management of signal harvesters.
+"""
+
+from typing import Dict, List, Optional, Type
+
+from shit.logging import get_service_logger
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvesterConfig
+
+logger = get_service_logger("harvester_registry")
+
+
+class HarvesterRegistry:
+    """Registry for signal harvesters.
+    
+    Usage:
+        registry = HarvesterRegistry()
+        registry.register("truth_social", TruthSocialS3Harvester)
+        registry.register("twitter", TwitterHarvester)
+        
+        harvesters = registry.create_all(mode="incremental")
+        for harvester in harvesters:
+            await harvester.initialize()
+            async for result in harvester.harvest():
+                process(result)
+    """
+    
+    def __init__(self):
+        self._registry: Dict[str, Type[SignalHarvester]] = {}
+        self._configs: Dict[str, HarvesterConfig] = {}
+    
+    def register(
+        self,
+        source_name: str,
+        harvester_class: Type[SignalHarvester],
+        config: Optional[HarvesterConfig] = None,
+    ) -> None:
+        """Register a harvester class for a source.
+        
+        Args:
+            source_name: Unique source identifier (e.g., "truth_social")
+            harvester_class: The harvester class (not an instance)
+            config: Optional configuration override
+        """
+        if not issubclass(harvester_class, SignalHarvester):
+            raise TypeError(
+                f"{harvester_class.__name__} must be a subclass of SignalHarvester"
+            )
+        
+        self._registry[source_name] = harvester_class
+        if config:
+            self._configs[source_name] = config
+        else:
+            self._configs[source_name] = HarvesterConfig(source_name=source_name)
+        
+        logger.info(f"Registered harvester: {source_name} -> {harvester_class.__name__}")
+    
+    def unregister(self, source_name: str) -> None:
+        """Remove a harvester from the registry."""
+        self._registry.pop(source_name, None)
+        self._configs.pop(source_name, None)
+        logger.info(f"Unregistered harvester: {source_name}")
+    
+    def get_class(self, source_name: str) -> Optional[Type[SignalHarvester]]:
+        """Get the harvester class for a source."""
+        return self._registry.get(source_name)
+    
+    def get_config(self, source_name: str) -> Optional[HarvesterConfig]:
+        """Get the configuration for a source."""
+        return self._configs.get(source_name)
+    
+    def list_sources(self) -> List[str]:
+        """List all registered source names."""
+        return list(self._registry.keys())
+    
+    def list_enabled_sources(self) -> List[str]:
+        """List source names where the harvester is enabled."""
+        return [
+            name for name, config in self._configs.items()
+            if config.enabled
+        ]
+    
+    def create_harvester(
+        self,
+        source_name: str,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> SignalHarvester:
+        """Create a harvester instance for a specific source.
+        
+        Args:
+            source_name: Which source to create
+            mode: Harvesting mode
+            start_date: Start date (YYYY-MM-DD)
+            end_date: End date (YYYY-MM-DD)
+            limit: Maximum items to harvest
+            **kwargs: Source-specific arguments
+            
+        Returns:
+            Configured harvester instance
+            
+        Raises:
+            KeyError: If source_name is not registered
+        """
+        if source_name not in self._registry:
+            raise KeyError(
+                f"Unknown source: '{source_name}'. "
+                f"Registered sources: {self.list_sources()}"
+            )
+        
+        cls = self._registry[source_name]
+        return cls(
+            mode=mode,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+            **kwargs,
+        )
+    
+    def create_all_enabled(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[SignalHarvester]:
+        """Create harvester instances for all enabled sources.
+        
+        Args:
+            mode: Harvesting mode (applied to all)
+            start_date: Start date (applied to all)
+            end_date: End date (applied to all)
+            limit: Limit (applied to all)
+            
+        Returns:
+            List of configured harvester instances
+        """
+        harvesters = []
+        for source_name in self.list_enabled_sources():
+            config = self._configs[source_name]
+            extra_kwargs = config.extra if config.extra else {}
+            
+            harvester = self.create_harvester(
+                source_name=source_name,
+                mode=mode,
+                start_date=start_date,
+                end_date=end_date,
+                limit=limit,
+                **extra_kwargs,
+            )
+            harvesters.append(harvester)
+        
+        return harvesters
+
+
+def create_default_registry() -> HarvesterRegistry:
+    """Create the default registry with all known harvesters.
+    
+    This is the single place that wires up which sources are available.
+    """
+    from shitposts.truth_social_s3_harvester import TruthSocialS3Harvester
+    
+    registry = HarvesterRegistry()
+    
+    # Register Truth Social (always enabled - it's the primary source)
+    registry.register(
+        "truth_social",
+        TruthSocialS3Harvester,
+        HarvesterConfig(source_name="truth_social", enabled=True),
+    )
+    
+    # Future sources will be registered here:
+    # registry.register("twitter", TwitterHarvester, HarvesterConfig(..., enabled=False))
+    # registry.register("sec_filings", SECHarvester, HarvesterConfig(..., enabled=False))
+    
+    return registry
+```
+
+**Design notes**:
+
+- **Lazy imports** in `create_default_registry()` avoid circular imports (the registry module imports harvester classes only when called).
+- **`create_all_enabled()`** is what the orchestrator will call -- it returns a list of instantiated harvesters for all sources marked `enabled=True`.
+- **`HarvesterConfig.extra`** allows source-specific kwargs (e.g., `max_id` for Truth Social) to be passed through.
+
+---
+
+### Step 5: Update S3 Config for Per-Source Prefixes
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shit/s3/s3_config.py`.
+
+The current `S3Config.prefix` defaults to `"truth-social"`. After refactoring, each harvester passes its own prefix based on `get_source_name()`.
+
+**Lines 11-15, before**:
+
+```python
+@dataclass
+class S3Config:
+    """S3 configuration settings."""
+    
+    # S3 Connection
+    bucket_name: str
+    prefix: str = "truth-social"
+```
+
+**After**:
+
+```python
+@dataclass
+class S3Config:
+    """S3 configuration settings."""
+    
+    # S3 Connection
+    bucket_name: str
+    prefix: str = "truth-social"  # Default for backward compat; harvesters override this
+```
+
+No actual code change needed here -- the default remains `truth-social` for backward compatibility. The `TruthSocialS3Harvester.get_source_name()` returns `"truth_social"`, which the base class passes as `S3Config(prefix=...)`. But we must note this means the S3 prefix changes from `truth-social` (hyphen) to `truth_social` (underscore).
+
+**IMPORTANT DECISION**: To avoid breaking existing S3 data, override `_get_s3_prefix()` in the Truth Social harvester:
+
+```python
+# In TruthSocialS3Harvester
+def _get_s3_prefix(self) -> str:
+    """Use hyphenated form for backward compatibility with existing S3 data."""
+    return "truth-social"
+```
+
+This ensures existing S3 keys like `truth-social/raw/2025/01/15/12345.json` continue to be found. New sources will use underscored names (e.g., `twitter/raw/...`).
+
+---
+
+### Step 6: Update Settings for Multi-Source Configuration
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py`.
+
+Add settings for future sources. These are optional and will be `None` by default.
+
+**After line 103** (after `AWS_REGION`), add:
+
+```python
+    # Multi-Source Harvester Configuration
+    ENABLED_HARVESTERS: str = Field(
+        default="truth_social",
+        env="ENABLED_HARVESTERS",
+    )  # Comma-separated list of enabled harvester source names
+    
+    # Twitter/X Configuration (Future)
+    TWITTER_API_KEY: Optional[str] = Field(default=None, env="TWITTER_API_KEY")
+    TWITTER_API_SECRET: Optional[str] = Field(default=None, env="TWITTER_API_SECRET")
+    TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None, env="TWITTER_BEARER_TOKEN")
+    TWITTER_TARGET_USERS: str = Field(
+        default="", env="TWITTER_TARGET_USERS"
+    )  # Comma-separated Twitter usernames to monitor
+    
+    def get_enabled_harvester_names(self) -> list[str]:
+        """Parse ENABLED_HARVESTERS into a list of source names."""
+        return [h.strip() for h in self.ENABLED_HARVESTERS.split(",") if h.strip()]
+```
+
+---
+
+### Step 7: Update CLI Module for Multi-Source Support
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shitposts/cli.py`.
+
+The current CLI helpers hardcode "Truth Social" strings. Generalize them while keeping backward compatibility.
+
+**Lines 104-112, before**:
+
+```python
+def print_harvest_start(mode: str, limit: Optional[int] = None) -> None:
+    limit_text = f" (limit: {limit})" if limit else ""
+    print_info(f"Starting Truth Social S3 harvesting in {mode} mode{limit_text}...")
+```
+
+**After**:
+
+```python
+def print_harvest_start(mode: str, limit: Optional[int] = None, source: str = "Truth Social") -> None:
+    """Print harvester start message.
+    
+    Args:
+        mode: Harvesting mode
+        limit: Harvest limit (optional)
+        source: Source name for display (default: Truth Social for backward compat)
+    """
+    limit_text = f" (limit: {limit})" if limit else ""
+    print_info(f"Starting {source} S3 harvesting in {mode} mode{limit_text}...")
+```
+
+Apply the same pattern to `print_harvest_complete`:
+
+**Lines 128-140, before**:
+
+```python
+def print_harvest_complete(harvested_count: int, dry_run: bool = False) -> None:
+    print_success(f"S3 harvesting completed! Total posts: {harvested_count}")
+    ...
+```
+
+**After** -- add optional `source` parameter:
+
+```python
+def print_harvest_complete(harvested_count: int, dry_run: bool = False, source: str = "S3") -> None:
+    """Print harvester completion message."""
+    print_success(f"{source} harvesting completed! Total posts: {harvested_count}")
+    ...
+```
+
+Add a `--source` argument to `create_harvester_parser`:
+
+```python
+# After the --max-id argument (line 74), add:
+parser.add_argument(
+    "--source",
+    type=str,
+    default=None,
+    help="Harvester source name (e.g., truth_social, twitter). Default: all enabled."
+)
+```
+
+---
+
+### Step 8: Update `__main__.py` for Source Selection
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shitposts/__main__.py`.
+
+**Before** (current, lines 1-8):
+
+```python
+"""
+CLI entry point for shitposts package.
+"""
+import asyncio
+from shitposts.truth_social_s3_harvester import main
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+**After**:
+
+```python
+"""
+CLI entry point for shitposts package.
+
+Supports:
+    python -m shitposts                          # Truth Social (default)
+    python -m shitposts --source truth_social    # Explicit source
+    python -m shitposts --source twitter         # Future: Twitter source
+"""
+import asyncio
+from shitposts.truth_social_s3_harvester import main
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The `main()` function in `truth_social_s3_harvester.py` already handles the `--source` flag via the parser. For now, `main()` continues to create `TruthSocialS3Harvester` directly. A future enhancement can route to the registry based on `--source`. This is intentionally minimal for Phase 06 -- the main entry point for multi-source harvesting is the orchestrator, not the CLI.
+
+---
+
+### Step 9: Update Orchestrator for Multi-Source Harvesting
+
+**Modify file** at `/Users/chris/Projects/shitpost-alpha/shitpost_alpha.py`.
+
+The orchestrator currently calls `python -m shitposts` as a subprocess (line 60). For multi-source support, we need it to iterate over enabled harvesters.
+
+**Add a new function** after `_build_harvesting_cmd` (after line 71):
+
+```python
+def _build_harvesting_cmd_for_source(args, source_name: str) -> list[str]:
+    """Build command for a specific source's harvesting CLI."""
+    cmd = [sys.executable, "-m", "shitposts", "--mode", args.mode, "--source", source_name]
+    if args.from_date:
+        cmd.extend(["--from", args.from_date])
+    if args.to_date:
+        cmd.extend(["--to", args.to_date])
+    if args.limit:
+        cmd.extend(["--limit", str(args.limit)])
+    if hasattr(args, "max_id") and args.max_id:
+        cmd.extend(["--max-id", args.max_id])
+    if args.verbose:
+        cmd.append("--verbose")
+    return cmd
+```
+
+**Modify `execute_harvesting_cli`** (lines 102-104) to support multiple sources:
+
+**Before**:
+
+```python
+async def execute_harvesting_cli(args) -> bool:
+    """Execute the harvesting CLI with appropriate parameters."""
+    return await _execute_subprocess(_build_harvesting_cmd(args), "Harvesting", "🚀")
+```
+
+**After**:
+
+```python
+async def execute_harvesting_cli(args) -> bool:
+    """Execute harvesting CLI for all enabled sources.
+    
+    If args has a 'sources' attribute, iterate over each source.
+    Otherwise, fall back to the default single-source behavior.
+    """
+    sources = getattr(args, 'sources', None)
+    
+    if not sources:
+        # Legacy single-source mode
+        return await _execute_subprocess(_build_harvesting_cmd(args), "Harvesting", "🚀")
+    
+    # Multi-source mode
+    all_success = True
+    for source_name in sources:
+        cmd = _build_harvesting_cmd_for_source(args, source_name)
+        success = await _execute_subprocess(
+            cmd, f"Harvesting ({source_name})", "🚀"
+        )
+        if not success:
+            logger.warning(f"Harvesting failed for source: {source_name}")
+            all_success = False
+            # Continue with other sources even if one fails
+    
+    return all_success
+```
+
+**Add `--sources` argument** to the orchestrator's argument parser (after line 166):
+
+```python
+parser.add_argument(
+    "--sources",
+    type=str,
+    default=None,
+    help="Comma-separated list of harvester sources to run (e.g., truth_social,twitter). Default: all enabled."
+)
+```
+
+**In `main()`**, parse the sources argument (after line 189):
+
+```python
+    # Parse sources list
+    if args.sources:
+        args.sources = [s.strip() for s in args.sources.split(",")]
+    else:
+        # Use settings to determine enabled sources
+        from shit.config.shitpost_settings import settings as app_settings
+        args.sources = app_settings.get_enabled_harvester_names()
+```
+
+**Update the dry run output** (around line 207) to show per-source commands:
+
+```python
+    if args.dry_run:
+        print_info("DRY RUN MODE - No commands will be executed")
+        print_info(f"Processing Mode: {args.mode}")
+        print_info(f"Sources: {', '.join(args.sources)}")
+        print_info(f"Shared Settings: from={args.from_date}, to={args.to_date}, limit={args.limit}")
+        print_info(f"\nCommands that would be executed:")
+        for i, source in enumerate(args.sources, 1):
+            cmd = _build_harvesting_cmd_for_source(args, source)
+            print_info(f"  {i}a. Harvesting ({source}): {' '.join(cmd)}")
+        print_info(f"  2. S3 to Database: {' '.join(_build_s3_to_db_cmd(args))}")
+        print_info(f"  3. LLM Analysis: {' '.join(_build_analysis_cmd(args))}")
+        return
+```
+
+---
+
+### Step 10: Create Skeleton Twitter Harvester
+
+**Purpose**: Demonstrate the pattern for adding a new source. This is NOT a working implementation -- it is a template with clear `TODO` markers.
+
+**Create file** at `/Users/chris/Projects/shitpost-alpha/shitposts/twitter_harvester.py`:
+
+```python
+"""
+Twitter/X Signal Harvester (Skeleton)
+
+This is a TEMPLATE for implementing a new signal source.
+It demonstrates the SignalHarvester interface pattern.
+
+To make this functional:
+    1. Set TWITTER_BEARER_TOKEN in .env
+    2. Implement _test_connection() with real Twitter API v2 calls
+    3. Implement _fetch_batch() with Twitter search/timeline endpoints
+    4. Register in harvester_registry.py with enabled=True
+    5. Add "twitter" to ENABLED_HARVESTERS in .env
+
+See TruthSocialS3Harvester for a complete working example.
+"""
+
+import aiohttp
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+from shitposts.base_harvester import SignalHarvester
+
+logger = get_service_logger("twitter_harvester")
+
+
+class TwitterHarvester(SignalHarvester):
+    """Skeleton harvester for Twitter/X posts.
+    
+    NOT YET FUNCTIONAL. This class demonstrates the SignalHarvester
+    interface for future implementation.
+    """
+    
+    def __init__(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+        target_users: Optional[List[str]] = None,
+    ):
+        super().__init__(mode=mode, start_date=start_date, end_date=end_date, limit=limit)
+        
+        # Twitter-specific config
+        self.bearer_token = settings.TWITTER_BEARER_TOKEN
+        self.base_url = "https://api.twitter.com/2"
+        self.target_users = target_users or self._parse_target_users()
+        
+        # HTTP session
+        self.session: Optional[aiohttp.ClientSession] = None
+    
+    def _parse_target_users(self) -> List[str]:
+        """Parse target users from settings."""
+        raw = getattr(settings, 'TWITTER_TARGET_USERS', '')
+        return [u.strip() for u in raw.split(",") if u.strip()]
+    
+    # ── Interface implementation ───────────────────────────────────────
+    
+    def get_source_name(self) -> str:
+        return "twitter"
+    
+    async def _test_connection(self) -> None:
+        """Test Twitter API v2 connection.
+        
+        TODO: Implement with real Twitter API call.
+        """
+        if not self.bearer_token:
+            raise ValueError(
+                "TWITTER_BEARER_TOKEN not configured. "
+                "Please add it to your .env file."
+            )
+        
+        self.session = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bearer {self.bearer_token}",
+                "Content-Type": "application/json",
+                "User-Agent": "Shitpost-Alpha-Twitter-Harvester/1.0",
+            }
+        )
+        
+        # TODO: Make a real test call to Twitter API v2
+        # url = f"{self.base_url}/users/me"
+        # async with self.session.get(url) as response:
+        #     if response.status != 200:
+        #         raise Exception(f"Twitter API test failed: {response.status}")
+        
+        raise NotImplementedError(
+            "TwitterHarvester is a skeleton. "
+            "Implement _test_connection() with real API calls."
+        )
+    
+    async def _fetch_batch(
+        self, cursor: Optional[str] = None
+    ) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of tweets.
+        
+        TODO: Implement with Twitter API v2 search or user timeline.
+        
+        Twitter API v2 uses pagination_token for cursor-based pagination.
+        """
+        # TODO: Implement real Twitter API call
+        # url = f"{self.base_url}/users/{user_id}/tweets"
+        # params = {"max_results": 100, "tweet.fields": "created_at,text,public_metrics"}
+        # if cursor:
+        #     params["pagination_token"] = cursor
+        # async with self.session.get(url, params=params) as response:
+        #     data = await response.json()
+        #     tweets = data.get("data", [])
+        #     next_token = data.get("meta", {}).get("next_token")
+        #     return tweets, next_token
+        
+        raise NotImplementedError(
+            "TwitterHarvester is a skeleton. "
+            "Implement _fetch_batch() with real API calls."
+        )
+    
+    def _extract_item_id(self, item: Dict) -> str:
+        """Extract tweet ID."""
+        return item.get("id", "")
+    
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        """Extract tweet creation timestamp.
+        
+        Twitter API v2 uses ISO 8601 format: 2024-01-15T10:30:00.000Z
+        """
+        created_at = item.get("created_at", "")
+        if created_at.endswith("Z"):
+            created_at = created_at.replace("Z", "+00:00")
+        return datetime.fromisoformat(created_at).replace(tzinfo=None)
+    
+    def _extract_content_preview(self, item: Dict) -> str:
+        """Extract tweet text preview."""
+        text = item.get("text", "")
+        if len(text) > 100:
+            return text[:100] + "..."
+        return text or "No content"
+    
+    async def cleanup(self) -> None:
+        """Cleanup aiohttp session."""
+        if self.session:
+            await self.session.close()
+        await super().cleanup()
+```
+
+---
+
+### Step 11: Create `shitposts/__init__.py`
+
+This file does not currently exist (confirmed by glob search). Create it to make the package properly importable.
+
+**Create file** at `/Users/chris/Projects/shitpost-alpha/shitposts/__init__.py`:
+
+```python
+"""
+Shitposts Package
+Signal harvesting from multiple data sources.
+"""
+
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_registry import HarvesterRegistry, create_default_registry
+from shitposts.harvester_models import HarvestResult, HarvestSummary, HarvesterConfig
+
+__all__ = [
+    "SignalHarvester",
+    "HarvesterRegistry",
+    "create_default_registry",
+    "HarvestResult",
+    "HarvestSummary",
+    "HarvesterConfig",
+]
+```
+
+---
+
+## 4. Test Plan
+
+### New Test Files
+
+#### `shit_tests/shitposts/test_base_harvester.py` (approx. 25-30 tests)
+
+```python
+"""
+Tests for SignalHarvester abstract base class.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvestResult
+
+
+# Concrete test implementation
+class MockHarvester(SignalHarvester):
+    """Minimal concrete implementation for testing the base class."""
+    
+    def __init__(self, items=None, **kwargs):
+        super().__init__(**kwargs)
+        self._items = items or []
+        self._batch_index = 0
+        self._connection_tested = False
+    
+    def get_source_name(self) -> str:
+        return "mock_source"
+    
+    async def _test_connection(self) -> None:
+        self._connection_tested = True
+    
+    async def _fetch_batch(self, cursor=None):
+        if self._batch_index >= len(self._items):
+            return [], None
+        batch = self._items[self._batch_index]
+        self._batch_index += 1
+        next_cursor = str(self._batch_index) if self._batch_index < len(self._items) else None
+        return batch, next_cursor
+    
+    def _extract_item_id(self, item):
+        return item.get("id", "")
+    
+    def _extract_timestamp(self, item):
+        return datetime.fromisoformat(item.get("created_at", "2024-01-01T00:00:00"))
+    
+    def _extract_content_preview(self, item):
+        return item.get("text", "")[:100]
+
+
+class TestSignalHarvesterInterface:
+    """Test that abstract interface is enforced."""
+
+    def test_cannot_instantiate_abstract_class(self):
+        with pytest.raises(TypeError):
+            SignalHarvester()  # Missing abstract methods
+
+    def test_concrete_implementation_instantiates(self):
+        harvester = MockHarvester()
+        assert harvester.get_source_name() == "mock_source"
+
+    def test_default_parameters(self):
+        harvester = MockHarvester()
+        assert harvester.mode == "incremental"
+        assert harvester.start_date is None
+        assert harvester.end_date is None
+        assert harvester.limit is None
+
+    def test_custom_parameters(self):
+        harvester = MockHarvester(
+            mode="range",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            limit=100
+        )
+        assert harvester.mode == "range"
+        assert harvester.start_datetime == datetime(2024, 1, 1)
+        assert harvester.limit == 100
+
+    def test_s3_prefix_default(self):
+        harvester = MockHarvester()
+        assert harvester._get_s3_prefix() == "mock_source"
+
+
+class TestSignalHarvesterInitialize:
+    """Test the initialize() method."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_dry_run(self):
+        harvester = MockHarvester()
+        await harvester.initialize(dry_run=True)
+        assert harvester._connection_tested is True
+        assert harvester.s3_data_lake is None
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_s3(self):
+        harvester = MockHarvester()
+        with patch('shitposts.base_harvester.S3DataLake') as mock_s3_class, \
+             patch('shitposts.base_harvester.settings') as mock_settings:
+            mock_settings.S3_BUCKET_NAME = "test-bucket"
+            mock_settings.AWS_REGION = "us-east-1"
+            mock_settings.AWS_ACCESS_KEY_ID = "key"
+            mock_settings.AWS_SECRET_ACCESS_KEY = "secret"
+            mock_s3 = AsyncMock()
+            mock_s3_class.return_value = mock_s3
+            
+            await harvester.initialize(dry_run=False)
+            
+            assert harvester.s3_data_lake is not None
+            mock_s3.initialize.assert_called_once()
+
+
+class TestSignalHarvesterHarvest:
+    """Test the harvest() generator."""
+
+    @pytest.mark.asyncio
+    async def test_harvest_yields_results(self):
+        items = [[
+            {"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Hello"},
+            {"id": "002", "created_at": "2024-01-15T11:00:00", "text": "World"},
+        ]]
+        harvester = MockHarvester(items=items)
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="mock/raw/2024/01/15/001.json")
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="mock/raw/2024/01/15/001.json")
+        
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+        
+        assert len(results) == 2
+        assert isinstance(results[0], HarvestResult)
+        assert results[0].source_name == "mock_source"
+        assert results[0].source_post_id == "001"
+
+    @pytest.mark.asyncio
+    async def test_harvest_respects_limit(self):
+        items = [[
+            {"id": "001", "created_at": "2024-01-15T10:00:00", "text": "A"},
+            {"id": "002", "created_at": "2024-01-15T11:00:00", "text": "B"},
+            {"id": "003", "created_at": "2024-01-15T12:00:00", "text": "C"},
+        ]]
+        harvester = MockHarvester(items=items, limit=2)
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+        
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+        
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_harvest_dry_run_skips_s3(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Test"}]]
+        harvester = MockHarvester(items=items)
+        
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+        
+        assert len(results) == 1
+        assert harvester.s3_data_lake is None
+
+    @pytest.mark.asyncio
+    async def test_harvest_incremental_stops_on_existing(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Exists"}]]
+        harvester = MockHarvester(items=items, mode="incremental")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.check_object_exists = AsyncMock(return_value=True)
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+        
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+        
+        assert len(results) == 0  # Should stop, not yield
+```
+
+#### `shit_tests/shitposts/test_harvester_registry.py` (approx. 15-20 tests)
+
+Test cases should cover:
+- `register()` with valid and invalid classes
+- `unregister()` removes entries
+- `list_sources()` and `list_enabled_sources()` correctness
+- `create_harvester()` with known and unknown source names
+- `create_all_enabled()` returns only enabled harvesters
+- `create_default_registry()` includes Truth Social
+- `TypeError` when registering a non-`SignalHarvester` class
+
+#### `shit_tests/shitposts/test_twitter_harvester.py` (approx. 5-8 tests)
+
+Test cases for the skeleton:
+- Instantiation succeeds with mock settings
+- `get_source_name()` returns `"twitter"`
+- `_test_connection()` raises `NotImplementedError`
+- `_fetch_batch()` raises `NotImplementedError`
+- `_extract_item_id()`, `_extract_timestamp()`, `_extract_content_preview()` work with sample tweet dicts
+- `cleanup()` closes session
+
+### Updated Test File
+
+#### `shit_tests/shitposts/test_truth_social_s3_harvester.py`
+
+Most existing tests should continue working because `harvest_shitposts()` is kept as a backward-compatible wrapper. The specific changes needed:
+
+1. **`test_initialization_defaults`** (line 64): Must still pass. The `__init__` signature is unchanged.
+
+2. **`test_initialize`** (line 134): The patching changes slightly because `initialize()` now calls `super().initialize()`. The mock path for `S3DataLake` changes from `shitposts.truth_social_s3_harvester.S3DataLake` to `shitposts.base_harvester.S3DataLake`. Update the `patch` target:
+
+   **Before** (line 156):
+   ```python
+   with patch('aiohttp.ClientSession', ...), \
+        patch('shitposts.truth_social_s3_harvester.S3DataLake') as mock_s3_class:
+   ```
+   
+   **After**:
+   ```python
+   with patch('aiohttp.ClientSession', ...), \
+        patch('shitposts.base_harvester.S3DataLake') as mock_s3_class:
+   ```
+
+3. **Tests that directly test `_harvest_backfill`**: These methods are removed from `TruthSocialS3Harvester`. Tests like `test_harvest_backfill_success` (line 413), `test_harvest_backfill_with_limit` (line 460), etc. need to be updated to either:
+   - Test through `harvest_shitposts()` (which calls `harvest()` from base)
+   - Or test `_fetch_batch()` directly for the Truth Social-specific API logic
+
+4. **`test_harvest_shitposts_incremental_mode`** (line 332): Should work as-is since `harvest_shitposts()` still exists.
+
+**Estimated test impact**: ~8-10 tests need patch path updates, ~5 tests that directly tested `_harvest_backfill` need rewriting to test `_fetch_batch` or `harvest()` instead.
+
+---
+
+## 5. Documentation Updates
+
+### `shitposts/README.md`
+
+Create or update this file to document:
+- The `SignalHarvester` interface and its abstract methods
+- How to add a new source (step-by-step using Twitter skeleton as example)
+- The registry pattern and `create_default_registry()`
+- S3 path conventions: `{source}/raw/YYYY/MM/DD/{id}.json`
+- CLI usage with `--source` flag
+
+### `CHANGELOG.md`
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Harvester Abstraction Layer** - Multi-source harvesting interface
+  - `SignalHarvester` abstract base class with standardized lifecycle
+  - `HarvesterRegistry` for config-driven source management
+  - Shared data models (`HarvestResult`, `HarvestSummary`, `HarvesterConfig`)
+  - Skeleton `TwitterHarvester` as template for future sources
+  - `--source` CLI flag and `--sources` orchestrator flag
+  - `ENABLED_HARVESTERS` environment variable for source selection
+
+### Changed
+- **TruthSocialS3Harvester** now implements `SignalHarvester` interface
+  - Backward-compatible: `harvest_shitposts()` still works for existing callers
+  - Harvest loop logic moved to shared base class
+  - ScrapeCreators-specific code isolated in abstract method implementations
+- **Orchestrator** updated to support running multiple harvesters sequentially
+```
+
+### `CLAUDE.md`
+
+Add to the "Core Services Reference" section:
+
+```markdown
+### Signal Harvesting Architecture (`shitposts/`)
+
+**Base Class**: `SignalHarvester` (abstract)
+- `get_source_name()` -> str
+- `initialize(dry_run)` -> verify API, init S3
+- `harvest(dry_run)` -> yields `HarvestResult`
+- `cleanup()` -> release resources
+
+**Implementations**:
+- `TruthSocialS3Harvester` - Truth Social via ScrapeCreators API
+- `TwitterHarvester` - Twitter/X (skeleton, not yet functional)
+
+**Registry**: `create_default_registry()` returns configured registry.
+```
+
+---
+
+## 6. Stress Testing and Edge Cases
+
+### Source-Specific Failure Isolation
+
+**Scenario**: Truth Social API goes down but Twitter API works.
+**Expected behavior**: The orchestrator logs the Truth Social failure, continues to harvest from Twitter, and reports partial success.
+**Where to test**: `shitpost_alpha.py` `execute_harvesting_cli()` -- the multi-source loop uses `all_success` tracking and continues on failure.
+
+### Mixed S3 Prefix Handling
+
+**Scenario**: Existing S3 data uses `truth-social/raw/...` (hyphenated). New Truth Social data must use the same prefix.
+**Solution**: `TruthSocialS3Harvester._get_s3_prefix()` returns `"truth-social"` (not `"truth_social"`). New sources use their own prefix (e.g., `twitter/raw/...`).
+**Risk**: If someone changes `get_source_name()` to return `"truth-social"` and removes the `_get_s3_prefix()` override, the S3 keys change and incremental mode breaks (it can't find existing objects).
+
+### Backward Compatibility
+
+**Scenario**: The `main()` function in `truth_social_s3_harvester.py` calls `harvester.harvest_shitposts()`.
+**Solution**: `harvest_shitposts()` is a wrapper that delegates to `harvest()` and converts `HarvestResult` back to the legacy dict format.
+**Test**: All existing tests that call `harvest_shitposts()` must pass without modification.
+
+### Registry Duplicate Registration
+
+**Scenario**: Someone registers the same source name twice.
+**Expected behavior**: The second registration overwrites the first (last-write-wins). This is logged via `logger.info()`.
+**Test**: Register "foo" twice with different classes, verify the second class is returned by `get_class("foo")`.
+
+### Empty Batch from API
+
+**Scenario**: `_fetch_batch()` returns `([], None)` on the first call.
+**Expected behavior**: `harvest()` exits the while loop immediately, yields zero results.
+**Test**: Create `MockHarvester(items=[])` and verify zero yields.
+
+### Concurrent Harvester Initialization Failures
+
+**Scenario**: `_test_connection()` raises for one source during `initialize()`.
+**Expected behavior**: The exception propagates to the caller. The orchestrator catches it and skips that source.
+**Where it matters**: The orchestrator runs sources sequentially (not concurrently), so one failure does not affect others.
+
+---
+
+## 7. Verification Checklist
+
+Before merging this PR, verify all of the following:
+
+- [ ] `SignalHarvester` cannot be instantiated directly (abstract class enforcement)
+- [ ] `TruthSocialS3Harvester` passes all existing tests without functional changes
+- [ ] `harvest_shitposts()` backward-compatible method yields the same dict structure as before
+- [ ] S3 keys for Truth Social data remain `truth-social/raw/YYYY/MM/DD/{id}.json` (no path change)
+- [ ] `create_default_registry()` includes Truth Social and returns it from `list_enabled_sources()`
+- [ ] The orchestrator `--dry-run` shows per-source commands
+- [ ] `TwitterHarvester._test_connection()` raises `NotImplementedError`
+- [ ] `TwitterHarvester._fetch_batch()` raises `NotImplementedError`
+- [ ] No new settings are required to run the system (all new settings have defaults)
+- [ ] `python -m shitposts --mode incremental --dry-run` still works
+- [ ] `python shitpost_alpha.py --dry-run` shows the correct commands
+- [ ] All new code has type hints on function signatures
+- [ ] All new public functions have Google-style docstrings
+- [ ] `ruff check .` passes with no new errors
+- [ ] `ruff format .` produces no changes
+- [ ] Test count increases by at least 45 new tests
+- [ ] CHANGELOG.md is updated
+- [ ] No imports of `truth_social_s3_harvester` from the base class (would cause circular imports)
+
+---
+
+## 8. What NOT To Do
+
+1. **Do NOT change the S3 path for existing Truth Social data.** The current path is `truth-social/raw/YYYY/MM/DD/{id}.json`. The `_get_s3_prefix()` override in `TruthSocialS3Harvester` MUST return `"truth-social"` (hyphenated), not `"truth_social"` (underscored). Changing this breaks incremental mode because it cannot find existing S3 objects.
+
+2. **Do NOT remove `harvest_shitposts()` from `TruthSocialS3Harvester`.** The `main()` function at line 434 calls it. The existing CLI and tests depend on it. Keep it as a backward-compatible wrapper.
+
+3. **Do NOT make the Twitter harvester functional.** It is a skeleton only. It must raise `NotImplementedError` in `_test_connection()` and `_fetch_batch()`. A working Twitter integration is a separate future PR.
+
+4. **Do NOT run harvesters in parallel (concurrently).** The orchestrator runs them sequentially. Parallel execution introduces race conditions in S3 writes, rate limit contention, and makes error reporting confusing. Keep it sequential.
+
+5. **Do NOT change the database schema.** Phase 06 is about the harvester layer only. The `TruthSocialShitpost` model, `platform` column, and all database tables remain unchanged. Database schema changes belong in Phase 02.
+
+6. **Do NOT add the `--source` flag to the `main()` function yet.** The `main()` in `truth_social_s3_harvester.py` is the Truth Social-specific CLI. Multi-source routing belongs in the orchestrator. The CLI flag is added to the parser for forward compatibility but does not change behavior yet.
+
+7. **Do NOT register disabled harvesters in `create_default_registry()` with `enabled=True`.** Only Truth Social should be enabled by default. Future sources should be registered with `enabled=False` until they are implemented.
+
+8. **Do NOT import `TruthSocialS3Harvester` at the top of `harvester_registry.py`.** Use lazy imports inside `create_default_registry()` to avoid circular import chains (`registry -> harvester -> base -> registry`).
+
+9. **Do NOT modify `shit/s3/s3_data_lake.py`.** The `S3DataLake` class is shared infrastructure. It works with whatever `S3Config.prefix` is passed to it. No changes needed.
+
+10. **Do NOT modify `shitvault/s3_processor.py`.** The S3-to-database processor reads from S3 using the data lake. It does not need to know about multiple sources yet. That is Phase 02's concern (making the DB schema source-agnostic).
+
+---
+
+### Critical Files for Implementation
+- `/Users/chris/Projects/shitpost-alpha/shitposts/base_harvester.py` - Core abstract base class to create (the heart of this phase)
+- `/Users/chris/Projects/shitpost-alpha/shitposts/truth_social_s3_harvester.py` - Must refactor to implement SignalHarvester interface while keeping backward compatibility
+- `/Users/chris/Projects/shitpost-alpha/shitposts/harvester_registry.py` - Registry pattern to create for dynamic source management
+- `/Users/chris/Projects/shitpost-alpha/shitpost_alpha.py` - Orchestrator to update for multi-source harvesting loop
+- `/Users/chris/Projects/shitpost-alpha/shit_tests/shitposts/test_truth_social_s3_harvester.py` - Existing tests to update (patch paths change from direct to base class)

--- a/documentation/planning/phases/system-evolution_2026-02-11/07_market-data-resilience.md
+++ b/documentation/planning/phases/system-evolution_2026-02-11/07_market-data-resilience.md
@@ -1,0 +1,1982 @@
+# Phase 07: Market Data Resilience (Fallback Sources, Health Checks, Failure Alerting)
+
+## PR Title
+`feat: add market data resilience with fallback provider, retry logic, health checks, and failure alerting`
+
+## Risk Level
+**Low** -- All changes are additive. The existing yfinance path remains the primary source; fallback, retry, health check, and alerting are layered on top. No database schema changes. No breaking API changes.
+
+## Estimated Effort
+**Medium** -- Approximately 8-12 hours of implementation, 4-6 hours of testing.
+
+## Files Summary
+
+### Files Created (7)
+| File | Purpose |
+|------|---------|
+| `shit/market_data/price_provider.py` | Abstract base class and provider interface |
+| `shit/market_data/yfinance_provider.py` | yfinance implementation of provider interface |
+| `shit/market_data/alphavantage_provider.py` | Alpha Vantage fallback implementation |
+| `shit/market_data/health.py` | Health check logic and data freshness monitoring |
+| `shit_tests/shit/market_data/test_price_provider.py` | Tests for abstract provider and provider selection |
+| `shit_tests/shit/market_data/test_alphavantage_provider.py` | Tests for Alpha Vantage provider |
+| `shit_tests/shit/market_data/test_health.py` | Tests for health checks and freshness monitoring |
+
+### Files Modified (5)
+| File | Purpose |
+|------|---------|
+| `shit/market_data/client.py` | Integrate provider abstraction, retry logic, fallback chain |
+| `shit/market_data/cli.py` | Add `health-check` CLI command |
+| `shit/market_data/__init__.py` | Export new classes |
+| `shit/config/shitpost_settings.py` | Add Alpha Vantage and health check settings |
+| `requirements.txt` | Add `alpha-vantage` or `requests` usage note (already present) |
+
+### Files Deleted
+None.
+
+---
+
+## 1. Context: Why This Matters
+
+The entire prediction measurement system depends on accurate, timely price data. Today:
+
+- **Single point of failure**: `shit/market_data/client.py` lines 79-88 call `yf.Ticker(symbol).history(...)` directly. If yfinance is down, rate-limited, or its scraping breaks (which happens regularly since it is an unofficial API), the pipeline silently produces zero prices and returns empty lists.
+- **No retry logic**: A single transient network error on line 139 causes the entire fetch to fail and re-raise the exception. The `update_prices_for_symbols` method on line 246-254 catches per-symbol errors but records `results[symbol] = 0` with no retry.
+- **No staleness detection**: There is no mechanism to detect that price data has not been updated for days. The `auto_backfill_service.py` checks `needs_price_update()` (lines 72-93) but only answers "are there any prices in the last N days?" -- it does not alert anyone when the answer is "no."
+- **No failure notification**: When market data fetching fails, it logs an error (line 140-146) but nobody gets notified. The Telegram notification system exists (`notifications/telegram_sender.py`) but is only wired to prediction alerts, not infrastructure failures.
+
+If price data silently stops flowing, prediction outcomes cannot be measured, the accuracy report becomes stale, and the dashboard shows misleading data. This phase makes the market data pipeline self-healing and observable.
+
+---
+
+## 2. Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| Phase 01 (Market Data Pipeline) | **Required** -- must be complete | The market data pipeline (`client.py`, `outcome_calculator.py`, `auto_backfill_service.py`) must be deployed and working |
+| Phase 04 (Telegram Alerting) | **Nice-to-have** | If Telegram is configured, failure alerts go to Telegram. If not, they only go to logs. The code gracefully degrades. |
+| Alpha Vantage API key | **Required for fallback** | Free tier provides 25 requests/day. Sufficient for fallback-only usage. |
+
+---
+
+## 3. Detailed Implementation Plan
+
+### Step 3.1: Add Configuration Settings
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py`
+
+Add new settings to the `Settings` class for the Alpha Vantage fallback provider, retry behavior, and health check thresholds.
+
+**Current code (lines 23-108)** -- Add the following new fields after the existing `TELEGRAM_WEBHOOK_URL` field (line 89) and before the ScrapeCreators section (line 92):
+
+```python
+# Market Data Resilience Configuration
+ALPHA_VANTAGE_API_KEY: Optional[str] = Field(default=None, env="ALPHA_VANTAGE_API_KEY")
+MARKET_DATA_PRIMARY_PROVIDER: str = Field(default="yfinance", env="MARKET_DATA_PRIMARY_PROVIDER")
+MARKET_DATA_FALLBACK_PROVIDER: str = Field(default="alphavantage", env="MARKET_DATA_FALLBACK_PROVIDER")
+MARKET_DATA_MAX_RETRIES: int = Field(default=3, env="MARKET_DATA_MAX_RETRIES")
+MARKET_DATA_RETRY_DELAY: float = Field(default=1.0, env="MARKET_DATA_RETRY_DELAY")  # seconds
+MARKET_DATA_RETRY_BACKOFF: float = Field(default=2.0, env="MARKET_DATA_RETRY_BACKOFF")  # multiplier
+MARKET_DATA_STALENESS_THRESHOLD_HOURS: int = Field(default=48, env="MARKET_DATA_STALENESS_THRESHOLD_HOURS")
+MARKET_DATA_HEALTH_CHECK_SYMBOLS: str = Field(default="SPY,AAPL", env="MARKET_DATA_HEALTH_CHECK_SYMBOLS")  # comma-separated
+MARKET_DATA_FAILURE_ALERT_CHAT_ID: Optional[str] = Field(default=None, env="MARKET_DATA_FAILURE_ALERT_CHAT_ID")  # Telegram chat ID for infra alerts
+```
+
+**Location**: Insert these after line 89 (`TELEGRAM_WEBHOOK_URL`) and before line 92 (`SCRAPECREATORS_API_KEY`).
+
+---
+
+### Step 3.2: Create the Price Provider Abstraction
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/price_provider.py`
+
+This file defines the abstract interface that all price data sources must implement. The key insight is that `MarketDataClient` currently interleaves fetching logic (yfinance calls) with storage logic (SQLAlchemy session operations). We separate the "fetch raw OHLCV data" responsibility into providers, while `MarketDataClient` retains the "store to database" responsibility.
+
+```python
+"""
+Price Provider Abstraction
+Defines the interface for market data sources (yfinance, Alpha Vantage, etc.).
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Optional
+import logging
+
+from shit.logging import get_service_logger
+
+logger = get_service_logger("price_provider")
+
+
+@dataclass
+class RawPriceRecord:
+    """Raw price data from a provider, not yet stored in the database.
+
+    This is a plain data transfer object -- no SQLAlchemy dependency.
+    """
+    symbol: str
+    date: date
+    open: Optional[float]
+    high: Optional[float]
+    low: Optional[float]
+    close: float
+    volume: Optional[int]
+    adjusted_close: Optional[float]
+    source: str  # e.g. "yfinance", "alphavantage"
+
+
+class PriceProvider(ABC):
+    """Abstract base class for price data providers."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name of the provider (e.g. 'yfinance', 'alphavantage')."""
+        ...
+
+    @abstractmethod
+    def fetch_prices(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[RawPriceRecord]:
+        """
+        Fetch historical price data from this provider.
+
+        Args:
+            symbol: Ticker symbol (e.g., 'AAPL', 'BTC-USD')
+            start_date: Start of date range (inclusive)
+            end_date: End of date range (inclusive)
+
+        Returns:
+            List of RawPriceRecord objects. Empty list if no data found.
+
+        Raises:
+            ProviderError: If the provider is unavailable or returns an error.
+        """
+        ...
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Quick check: is this provider configured and likely to work?
+
+        Returns:
+            True if the provider has credentials/configuration and is ready.
+        """
+        ...
+
+
+class ProviderError(Exception):
+    """Raised when a price provider fails to fetch data."""
+
+    def __init__(self, provider_name: str, message: str, original_error: Optional[Exception] = None):
+        self.provider_name = provider_name
+        self.original_error = original_error
+        super().__init__(f"[{provider_name}] {message}")
+
+
+class ProviderChain:
+    """
+    Tries multiple providers in order until one succeeds.
+
+    Usage:
+        chain = ProviderChain([yfinance_provider, alphavantage_provider])
+        prices = chain.fetch_with_fallback("AAPL", start, end)
+    """
+
+    def __init__(self, providers: List[PriceProvider]):
+        self.providers = [p for p in providers if p.is_available()]
+        if not self.providers:
+            logger.warning("No price providers are available/configured")
+
+    def fetch_with_fallback(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[RawPriceRecord]:
+        """
+        Try each provider in order. Return results from the first that succeeds.
+
+        Args:
+            symbol: Ticker symbol
+            start_date: Start of date range
+            end_date: End of date range
+
+        Returns:
+            List of RawPriceRecord from the first successful provider.
+
+        Raises:
+            ProviderError: If ALL providers fail.
+        """
+        errors = []
+
+        for provider in self.providers:
+            try:
+                logger.info(
+                    f"Attempting {provider.name} for {symbol}",
+                    extra={"provider": provider.name, "symbol": symbol}
+                )
+                records = provider.fetch_prices(symbol, start_date, end_date)
+                if records:
+                    logger.info(
+                        f"{provider.name} returned {len(records)} records for {symbol}",
+                        extra={"provider": provider.name, "symbol": symbol, "count": len(records)}
+                    )
+                    return records
+                else:
+                    logger.warning(
+                        f"{provider.name} returned empty results for {symbol}",
+                        extra={"provider": provider.name, "symbol": symbol}
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"{provider.name} failed for {symbol}: {e}",
+                    extra={"provider": provider.name, "symbol": symbol, "error": str(e)}
+                )
+                errors.append(ProviderError(provider.name, str(e), original_error=e))
+
+        # All providers failed
+        error_summary = "; ".join(str(e) for e in errors)
+        raise ProviderError(
+            "all_providers",
+            f"All providers failed for {symbol}: {error_summary}"
+        )
+```
+
+---
+
+### Step 3.3: Create the yfinance Provider
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/yfinance_provider.py`
+
+Extract the yfinance-specific fetching logic from `client.py` lines 79-136 into a provider class.
+
+```python
+"""
+yfinance Price Provider
+Wraps the yfinance library behind the PriceProvider interface.
+"""
+
+from datetime import date, timedelta
+from typing import List
+
+import yfinance as yf
+
+from shit.market_data.price_provider import PriceProvider, RawPriceRecord, ProviderError
+from shit.logging import get_service_logger
+
+logger = get_service_logger("yfinance_provider")
+
+
+class YFinanceProvider(PriceProvider):
+    """Price provider backed by the yfinance library."""
+
+    @property
+    def name(self) -> str:
+        return "yfinance"
+
+    def is_available(self) -> bool:
+        """yfinance is always available (no API key needed)."""
+        return True
+
+    def fetch_prices(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[RawPriceRecord]:
+        """
+        Fetch prices from yfinance.
+
+        Note: yfinance end_date is exclusive, so we add 1 day.
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            hist = ticker.history(start=start_date, end=end_date + timedelta(days=1))
+
+            if hist.empty:
+                logger.warning(
+                    f"yfinance returned empty data for {symbol}",
+                    extra={"symbol": symbol}
+                )
+                return []
+
+            records = []
+            for idx, row in hist.iterrows():
+                price_date = idx.date() if hasattr(idx, 'date') else idx
+
+                record = RawPriceRecord(
+                    symbol=symbol,
+                    date=price_date,
+                    open=float(row['Open']) if 'Open' in row and row['Open'] is not None else None,
+                    high=float(row['High']) if 'High' in row and row['High'] is not None else None,
+                    low=float(row['Low']) if 'Low' in row and row['Low'] is not None else None,
+                    close=float(row['Close']) if 'Close' in row else 0.0,
+                    volume=int(row['Volume']) if 'Volume' in row and row['Volume'] is not None else None,
+                    adjusted_close=float(row['Close']) if 'Close' in row else None,
+                    source="yfinance",
+                )
+                records.append(record)
+
+            return records
+
+        except Exception as e:
+            raise ProviderError("yfinance", f"Failed to fetch {symbol}: {e}", original_error=e)
+```
+
+---
+
+### Step 3.4: Create the Alpha Vantage Provider
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/alphavantage_provider.py`
+
+Alpha Vantage free tier: 25 requests/day, 5 requests/minute. We use the `TIME_SERIES_DAILY` endpoint via simple `requests` calls (no new dependency needed -- `requests` is already in `requirements.txt` at line 9).
+
+```python
+"""
+Alpha Vantage Price Provider
+Fallback price source using the Alpha Vantage free API.
+"""
+
+from datetime import date, datetime
+from typing import List, Optional
+
+import requests
+
+from shit.market_data.price_provider import PriceProvider, RawPriceRecord, ProviderError
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+
+logger = get_service_logger("alphavantage_provider")
+
+ALPHA_VANTAGE_BASE_URL = "https://www.alphavantage.co/query"
+
+
+class AlphaVantageProvider(PriceProvider):
+    """Price provider backed by the Alpha Vantage REST API."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialize Alpha Vantage provider.
+
+        Args:
+            api_key: Alpha Vantage API key. Falls back to settings if not provided.
+        """
+        self._api_key = api_key or settings.ALPHA_VANTAGE_API_KEY
+
+    @property
+    def name(self) -> str:
+        return "alphavantage"
+
+    def is_available(self) -> bool:
+        """Available only if an API key is configured."""
+        return self._api_key is not None and len(self._api_key) > 0
+
+    def fetch_prices(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[RawPriceRecord]:
+        """
+        Fetch daily prices from Alpha Vantage TIME_SERIES_DAILY endpoint.
+
+        Note: Alpha Vantage returns up to 100 days of data by default
+        (full output with outputsize=full returns 20+ years but counts as 1 call).
+        """
+        if not self.is_available():
+            raise ProviderError("alphavantage", "API key not configured")
+
+        # Determine output size: compact (last 100 days) vs full (20 years)
+        days_requested = (end_date - start_date).days
+        output_size = "full" if days_requested > 100 else "compact"
+
+        params = {
+            "function": "TIME_SERIES_DAILY",
+            "symbol": symbol,
+            "outputsize": output_size,
+            "apikey": self._api_key,
+        }
+
+        try:
+            response = requests.get(
+                ALPHA_VANTAGE_BASE_URL,
+                params=params,
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        except requests.exceptions.Timeout:
+            raise ProviderError("alphavantage", f"Request timed out for {symbol}")
+        except requests.exceptions.RequestException as e:
+            raise ProviderError("alphavantage", f"HTTP error for {symbol}: {e}", original_error=e)
+
+        # Check for API error responses
+        if "Error Message" in data:
+            raise ProviderError("alphavantage", f"API error for {symbol}: {data['Error Message']}")
+
+        if "Note" in data:
+            # Rate limit message
+            raise ProviderError("alphavantage", f"Rate limited: {data['Note']}")
+
+        if "Information" in data:
+            raise ProviderError("alphavantage", f"API info: {data['Information']}")
+
+        time_series = data.get("Time Series (Daily)", {})
+
+        if not time_series:
+            logger.warning(
+                f"Alpha Vantage returned no time series data for {symbol}",
+                extra={"symbol": symbol}
+            )
+            return []
+
+        records = []
+        for date_str, daily_data in time_series.items():
+            try:
+                price_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+            except ValueError:
+                continue
+
+            # Filter to requested date range
+            if price_date < start_date or price_date > end_date:
+                continue
+
+            try:
+                record = RawPriceRecord(
+                    symbol=symbol,
+                    date=price_date,
+                    open=float(daily_data.get("1. open", 0)),
+                    high=float(daily_data.get("2. high", 0)),
+                    low=float(daily_data.get("3. low", 0)),
+                    close=float(daily_data.get("4. close", 0)),
+                    volume=int(daily_data.get("5. volume", 0)),
+                    adjusted_close=float(daily_data.get("4. close", 0)),
+                    source="alphavantage",
+                )
+                records.append(record)
+            except (ValueError, TypeError) as e:
+                logger.warning(
+                    f"Skipping malformed price record for {symbol} on {date_str}: {e}",
+                    extra={"symbol": symbol, "date": date_str}
+                )
+
+        # Sort by date ascending (Alpha Vantage returns newest first)
+        records.sort(key=lambda r: r.date)
+
+        logger.info(
+            f"Alpha Vantage returned {len(records)} records for {symbol}",
+            extra={"symbol": symbol, "count": len(records)}
+        )
+
+        return records
+```
+
+**Rationale for Alpha Vantage over other alternatives**:
+- Free tier available (25 calls/day) -- sufficient for fallback-only usage
+- Simple REST API, no special SDK needed (uses `requests` already in requirements)
+- Covers US equities, which is the primary use case for this project
+- Well-documented, stable API that has been operational for years
+- Crypto support via separate endpoints (can be added later if needed)
+
+**Limitation**: Alpha Vantage free tier does not support crypto tickers like `BTC-USD`. For the first iteration, crypto fallback will log a warning and return empty. This can be enhanced later.
+
+---
+
+### Step 3.5: Refactor MarketDataClient to Use Provider Chain + Retry Logic
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/client.py`
+
+This is the most significant change. We refactor `fetch_price_history` to:
+1. Build a `ProviderChain` from configured providers
+2. Use `sync_retry` decorator from existing `error_handling.py` for retry with exponential backoff
+3. Convert `RawPriceRecord` objects to `MarketPrice` database objects
+4. Send failure alerts when all providers fail
+
+**Replace the entire file**. Here is the new version with changes annotated:
+
+```python
+"""
+Market Data Client
+Fetches stock/asset prices using pluggable providers and stores in database.
+"""
+
+import time
+from datetime import datetime, date, timedelta
+from typing import List, Optional, Dict, Any
+
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from shit.market_data.models import MarketPrice
+from shit.market_data.price_provider import (
+    PriceProvider, ProviderChain, RawPriceRecord, ProviderError,
+)
+from shit.market_data.yfinance_provider import YFinanceProvider
+from shit.market_data.alphavantage_provider import AlphaVantageProvider
+from shit.db.sync_session import get_session
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+
+logger = get_service_logger("market_data")
+
+
+def _build_default_provider_chain() -> ProviderChain:
+    """Build the default provider chain from settings."""
+    providers: List[PriceProvider] = []
+
+    # Primary provider
+    primary = settings.MARKET_DATA_PRIMARY_PROVIDER
+    if primary == "yfinance":
+        providers.append(YFinanceProvider())
+    elif primary == "alphavantage":
+        providers.append(AlphaVantageProvider())
+
+    # Fallback provider
+    fallback = settings.MARKET_DATA_FALLBACK_PROVIDER
+    if fallback == "yfinance" and primary != "yfinance":
+        providers.append(YFinanceProvider())
+    elif fallback == "alphavantage" and primary != "alphavantage":
+        providers.append(AlphaVantageProvider())
+
+    # If neither resolved, always include yfinance as baseline
+    if not providers:
+        providers.append(YFinanceProvider())
+
+    return ProviderChain(providers)
+
+
+def _send_failure_alert(symbol: str, error: str) -> None:
+    """Send a Telegram alert when market data fetching fails completely."""
+    chat_id = settings.MARKET_DATA_FAILURE_ALERT_CHAT_ID
+    if not chat_id:
+        return  # No alert chat configured, just log
+
+    try:
+        from notifications.telegram_sender import send_telegram_message
+
+        message = (
+            "\u26a0\ufe0f *MARKET DATA FAILURE*\n\n"
+            f"*Symbol:* `{symbol}`\n"
+            f"*Error:* {error}\n"
+            f"*Time:* {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}\n\n"
+            "All price providers failed. Prediction outcomes may be affected."
+        )
+        success, err = send_telegram_message(chat_id, message)
+        if not success:
+            logger.warning(f"Failed to send failure alert via Telegram: {err}")
+    except Exception as e:
+        logger.warning(f"Could not send failure alert: {e}")
+
+
+class MarketDataClient:
+    """Client for fetching and storing market data with fallback providers."""
+
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+        provider_chain: Optional[ProviderChain] = None,
+    ):
+        """
+        Initialize market data client.
+
+        Args:
+            session: Optional SQLAlchemy session (creates new one if not provided)
+            provider_chain: Optional custom provider chain (uses default if not provided)
+        """
+        self.session = session
+        self._own_session = session is None
+        self._provider_chain = provider_chain or _build_default_provider_chain()
+
+    def __enter__(self):
+        if self._own_session:
+            self.session = get_session().__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._own_session and self.session:
+            self.session.__exit__(exc_type, exc_val, exc_tb)
+
+    def fetch_price_history(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: Optional[date] = None,
+        force_refresh: bool = False,
+    ) -> List[MarketPrice]:
+        """
+        Fetch historical price data for a symbol with retry and fallback.
+
+        Args:
+            symbol: Ticker symbol (e.g., 'AAPL', 'TSLA', 'BTC-USD')
+            start_date: Start date for historical data
+            end_date: End date (defaults to today)
+            force_refresh: If True, refetch even if data exists
+
+        Returns:
+            List of MarketPrice objects
+        """
+        if end_date is None:
+            end_date = date.today()
+
+        logger.info(
+            f"Fetching price history for {symbol}",
+            extra={"symbol": symbol, "start_date": str(start_date), "end_date": str(end_date)}
+        )
+
+        # Check if we already have this data (unless force refresh)
+        if not force_refresh:
+            existing = self._get_existing_prices(symbol, start_date, end_date)
+            if len(existing) > 0:
+                logger.info(
+                    f"Found {len(existing)} existing prices for {symbol}, skipping fetch",
+                    extra={"symbol": symbol, "count": len(existing)}
+                )
+                return existing
+
+        # Fetch from providers with retry logic
+        raw_records = self._fetch_with_retry(symbol, start_date, end_date)
+
+        if not raw_records:
+            logger.warning(
+                f"No price data found for {symbol} from any provider",
+                extra={"symbol": symbol}
+            )
+            return []
+
+        # Store raw records in database
+        try:
+            prices = self._store_raw_records(raw_records, force_refresh)
+            self.session.commit()
+
+            logger.info(
+                f"Successfully stored {len(prices)} prices for {symbol}",
+                extra={"symbol": symbol, "count": len(prices)}
+            )
+            return prices
+
+        except Exception as e:
+            logger.error(
+                f"Error storing prices for {symbol}: {e}",
+                extra={"symbol": symbol, "error": str(e)},
+                exc_info=True,
+            )
+            self.session.rollback()
+            raise
+
+    def _fetch_with_retry(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[RawPriceRecord]:
+        """
+        Fetch prices with exponential backoff retry across providers.
+
+        Retries the entire provider chain on each attempt.
+
+        Returns:
+            List of RawPriceRecord on success, empty list if all fail after retries.
+        """
+        max_retries = settings.MARKET_DATA_MAX_RETRIES
+        delay = settings.MARKET_DATA_RETRY_DELAY
+        backoff = settings.MARKET_DATA_RETRY_BACKOFF
+
+        last_error = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                return self._provider_chain.fetch_with_fallback(symbol, start_date, end_date)
+            except ProviderError as e:
+                last_error = e
+
+                if attempt == max_retries:
+                    logger.error(
+                        f"All providers failed for {symbol} after {max_retries + 1} attempts: {e}",
+                        extra={"symbol": symbol, "attempts": max_retries + 1, "error": str(e)}
+                    )
+                    _send_failure_alert(symbol, str(e))
+                    return []
+
+                wait_time = delay * (backoff ** attempt)
+                logger.warning(
+                    f"Provider chain failed for {symbol} (attempt {attempt + 1}/{max_retries + 1}), "
+                    f"retrying in {wait_time:.1f}s: {e}",
+                    extra={"symbol": symbol, "attempt": attempt + 1, "wait_time": wait_time}
+                )
+                time.sleep(wait_time)
+
+        return []
+
+    def _store_raw_records(
+        self,
+        records: List[RawPriceRecord],
+        force_refresh: bool = False,
+    ) -> List[MarketPrice]:
+        """Convert RawPriceRecord objects to MarketPrice ORM objects and store."""
+        prices = []
+
+        for record in records:
+            # Check if price already exists
+            existing_price = self.session.query(MarketPrice).filter(
+                and_(
+                    MarketPrice.symbol == record.symbol,
+                    MarketPrice.date == record.date,
+                )
+            ).first()
+
+            if existing_price and not force_refresh:
+                prices.append(existing_price)
+                continue
+
+            # Create or update price record
+            if existing_price:
+                price_obj = existing_price
+            else:
+                price_obj = MarketPrice(symbol=record.symbol, date=record.date)
+
+            price_obj.open = record.open
+            price_obj.high = record.high
+            price_obj.low = record.low
+            price_obj.close = record.close
+            price_obj.volume = record.volume
+            price_obj.adjusted_close = record.adjusted_close
+            price_obj.source = record.source
+            price_obj.last_updated = datetime.utcnow()
+            price_obj.is_market_open = True
+
+            if not existing_price:
+                self.session.add(price_obj)
+
+            prices.append(price_obj)
+
+        return prices
+
+    # --- All methods below remain UNCHANGED from current implementation ---
+
+    def get_price_on_date(
+        self,
+        symbol: str,
+        target_date: date,
+        lookback_days: int = 7,
+    ) -> Optional[MarketPrice]:
+        """Get price for a specific date, with fallback for market closed days."""
+        # (Identical to current lines 148-202 -- no changes)
+        price = self.session.query(MarketPrice).filter(
+            and_(
+                MarketPrice.symbol == symbol,
+                MarketPrice.date == target_date,
+            )
+        ).first()
+
+        if price:
+            return price
+
+        logger.debug(
+            f"No price found for {symbol} on {target_date}, checking previous days",
+            extra={"symbol": symbol, "target_date": str(target_date)}
+        )
+
+        for days_back in range(1, lookback_days + 1):
+            check_date = target_date - timedelta(days=days_back)
+            price = self.session.query(MarketPrice).filter(
+                and_(
+                    MarketPrice.symbol == symbol,
+                    MarketPrice.date == check_date,
+                )
+            ).first()
+
+            if price:
+                logger.debug(
+                    f"Found price for {symbol} on {check_date} ({days_back} days before {target_date})",
+                    extra={"symbol": symbol, "price_date": str(check_date)}
+                )
+                return price
+
+        logger.warning(
+            f"No price found for {symbol} within {lookback_days} days of {target_date}",
+            extra={"symbol": symbol, "target_date": str(target_date), "lookback_days": lookback_days}
+        )
+        return None
+
+    def get_latest_price(self, symbol: str) -> Optional[MarketPrice]:
+        """Get the most recent price for a symbol."""
+        # (Identical to current lines 204-218)
+        return self.session.query(MarketPrice).filter(
+            MarketPrice.symbol == symbol
+        ).order_by(MarketPrice.date.desc()).first()
+
+    def update_prices_for_symbols(
+        self,
+        symbols: List[str],
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> Dict[str, int]:
+        """Update prices for multiple symbols."""
+        # (Identical to current lines 220-256)
+        if start_date is None:
+            start_date = date.today() - timedelta(days=30)
+        if end_date is None:
+            end_date = date.today()
+
+        results = {}
+        for symbol in symbols:
+            try:
+                prices = self.fetch_price_history(symbol, start_date, end_date)
+                results[symbol] = len(prices)
+            except Exception as e:
+                logger.error(
+                    f"Failed to update prices for {symbol}: {e}",
+                    extra={"symbol": symbol, "error": str(e)}
+                )
+                results[symbol] = 0
+
+        return results
+
+    def _get_existing_prices(
+        self,
+        symbol: str,
+        start_date: date,
+        end_date: date,
+    ) -> List[MarketPrice]:
+        """Get existing prices in database for date range."""
+        # (Identical to current lines 258-271)
+        return self.session.query(MarketPrice).filter(
+            and_(
+                MarketPrice.symbol == symbol,
+                MarketPrice.date >= start_date,
+                MarketPrice.date <= end_date,
+            )
+        ).order_by(MarketPrice.date).all()
+
+    def get_price_stats(self, symbol: str) -> Dict[str, Any]:
+        """Get statistics about stored prices for a symbol."""
+        # (Identical to current lines 273-310)
+        from sqlalchemy import func
+
+        stats = self.session.query(
+            func.count(MarketPrice.id).label('count'),
+            func.min(MarketPrice.date).label('earliest_date'),
+            func.max(MarketPrice.date).label('latest_date'),
+        ).filter(
+            MarketPrice.symbol == symbol
+        ).first()
+
+        if not stats or stats.count == 0:
+            return {
+                "symbol": symbol,
+                "count": 0,
+                "earliest_date": None,
+                "latest_date": None,
+                "latest_price": None,
+            }
+
+        latest = self.get_latest_price(symbol)
+
+        return {
+            "symbol": symbol,
+            "count": stats.count,
+            "earliest_date": stats.earliest_date,
+            "latest_date": stats.latest_date,
+            "latest_price": latest.close if latest else None,
+        }
+```
+
+**Key changes in `client.py`**:
+- `__init__` gains optional `provider_chain` parameter (backwards-compatible -- default is `None` which builds from settings)
+- Removed `import yfinance as yf` (now in `yfinance_provider.py`)
+- Added `_fetch_with_retry` method implementing exponential backoff
+- Added `_store_raw_records` method to convert `RawPriceRecord` to `MarketPrice`
+- Added `_send_failure_alert` module-level function for Telegram alerts
+- All existing public methods (`get_price_on_date`, `get_latest_price`, `update_prices_for_symbols`, `_get_existing_prices`, `get_price_stats`) are **unchanged**
+
+---
+
+### Step 3.6: Create Health Check Module
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/health.py`
+
+This module provides both programmatic and CLI-accessible health checks.
+
+```python
+"""
+Market Data Health Checks
+Monitors data freshness, provider availability, and overall pipeline health.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Dict, List, Optional, Any
+
+from sqlalchemy import func, and_
+
+from shit.market_data.models import MarketPrice
+from shit.market_data.price_provider import ProviderChain
+from shit.market_data.yfinance_provider import YFinanceProvider
+from shit.market_data.alphavantage_provider import AlphaVantageProvider
+from shit.db.sync_session import get_session
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+
+logger = get_service_logger("market_data_health")
+
+
+@dataclass
+class ProviderHealthStatus:
+    """Health status for a single provider."""
+    name: str
+    available: bool
+    can_fetch: bool = False
+    error: Optional[str] = None
+    response_time_ms: Optional[float] = None
+
+
+@dataclass
+class FreshnessStatus:
+    """Data freshness status for a symbol."""
+    symbol: str
+    latest_date: Optional[date]
+    days_stale: int
+    is_stale: bool
+    threshold_hours: int
+
+
+@dataclass
+class HealthReport:
+    """Complete health report for the market data pipeline."""
+    timestamp: datetime
+    overall_healthy: bool
+    providers: List[ProviderHealthStatus]
+    freshness: List[FreshnessStatus]
+    total_symbols: int
+    stale_symbols: int
+    summary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dict for JSON serialization / CLI display."""
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "overall_healthy": self.overall_healthy,
+            "providers": [
+                {
+                    "name": p.name,
+                    "available": p.available,
+                    "can_fetch": p.can_fetch,
+                    "error": p.error,
+                    "response_time_ms": p.response_time_ms,
+                }
+                for p in self.providers
+            ],
+            "freshness": [
+                {
+                    "symbol": f.symbol,
+                    "latest_date": str(f.latest_date) if f.latest_date else None,
+                    "days_stale": f.days_stale,
+                    "is_stale": f.is_stale,
+                }
+                for f in self.freshness
+            ],
+            "total_symbols": self.total_symbols,
+            "stale_symbols": self.stale_symbols,
+            "summary": self.summary,
+        }
+
+
+def check_provider_health(provider_name: str) -> ProviderHealthStatus:
+    """
+    Check if a specific provider is available and can fetch data.
+
+    Uses SPY as a canary symbol for a quick connectivity check.
+    """
+    import time
+
+    if provider_name == "yfinance":
+        provider = YFinanceProvider()
+    elif provider_name == "alphavantage":
+        provider = AlphaVantageProvider()
+    else:
+        return ProviderHealthStatus(name=provider_name, available=False, error="Unknown provider")
+
+    status = ProviderHealthStatus(name=provider_name, available=provider.is_available())
+
+    if not status.available:
+        status.error = "Not configured (missing API key or disabled)"
+        return status
+
+    # Try a quick fetch of SPY (most liquid US ETF) for yesterday
+    try:
+        test_date = date.today() - timedelta(days=3)  # 3 days back to handle weekends
+        end_date = date.today()
+
+        start_time = time.time()
+        records = provider.fetch_prices("SPY", test_date, end_date)
+        elapsed_ms = (time.time() - start_time) * 1000
+
+        status.response_time_ms = round(elapsed_ms, 1)
+        status.can_fetch = len(records) > 0
+
+        if not status.can_fetch:
+            status.error = "Returned empty results for SPY"
+
+    except Exception as e:
+        status.can_fetch = False
+        status.error = str(e)
+
+    return status
+
+
+def check_data_freshness(
+    symbols: Optional[List[str]] = None,
+    threshold_hours: Optional[int] = None,
+) -> List[FreshnessStatus]:
+    """
+    Check how fresh the price data is for each tracked symbol.
+
+    Args:
+        symbols: Specific symbols to check. If None, checks all symbols in DB.
+        threshold_hours: Hours after which data is considered stale. Defaults to settings.
+
+    Returns:
+        List of FreshnessStatus for each symbol.
+    """
+    if threshold_hours is None:
+        threshold_hours = settings.MARKET_DATA_STALENESS_THRESHOLD_HOURS
+
+    results = []
+
+    with get_session() as session:
+        if symbols:
+            # Check specific symbols
+            for symbol in symbols:
+                latest = session.query(func.max(MarketPrice.date)).filter(
+                    MarketPrice.symbol == symbol
+                ).scalar()
+
+                days_stale = (date.today() - latest).days if latest else 999
+                # Account for weekends: 2 days of staleness is normal on Monday
+                # Use threshold_hours converted to days (e.g., 48h = 2 days)
+                threshold_days = max(threshold_hours // 24, 1)
+                is_stale = days_stale > threshold_days
+
+                results.append(FreshnessStatus(
+                    symbol=symbol,
+                    latest_date=latest,
+                    days_stale=days_stale,
+                    is_stale=is_stale,
+                    threshold_hours=threshold_hours,
+                ))
+        else:
+            # Check all symbols in DB
+            symbol_dates = session.query(
+                MarketPrice.symbol,
+                func.max(MarketPrice.date).label("latest_date"),
+            ).group_by(MarketPrice.symbol).all()
+
+            threshold_days = max(threshold_hours // 24, 1)
+
+            for symbol, latest_date in symbol_dates:
+                days_stale = (date.today() - latest_date).days if latest_date else 999
+                is_stale = days_stale > threshold_days
+
+                results.append(FreshnessStatus(
+                    symbol=symbol,
+                    latest_date=latest_date,
+                    days_stale=days_stale,
+                    is_stale=is_stale,
+                    threshold_hours=threshold_hours,
+                ))
+
+    return results
+
+
+def run_health_check(
+    check_providers: bool = True,
+    check_freshness: bool = True,
+    send_alert_on_failure: bool = True,
+) -> HealthReport:
+    """
+    Run a comprehensive health check on the market data pipeline.
+
+    Args:
+        check_providers: Whether to ping providers with a test fetch.
+        check_freshness: Whether to check data staleness.
+        send_alert_on_failure: Whether to send Telegram alert if unhealthy.
+
+    Returns:
+        HealthReport with full status.
+    """
+    providers_status: List[ProviderHealthStatus] = []
+    freshness_status: List[FreshnessStatus] = []
+    issues: List[str] = []
+
+    # Check providers
+    if check_providers:
+        for name in ["yfinance", "alphavantage"]:
+            status = check_provider_health(name)
+            providers_status.append(status)
+
+            if status.available and not status.can_fetch:
+                issues.append(f"Provider {name} is configured but cannot fetch data: {status.error}")
+            elif not status.available and name == "yfinance":
+                issues.append(f"Primary provider {name} is unavailable")
+
+    # Check freshness
+    stale_count = 0
+    total_symbols = 0
+    if check_freshness:
+        # Use health check symbols from settings
+        health_symbols_str = settings.MARKET_DATA_HEALTH_CHECK_SYMBOLS
+        health_symbols = [s.strip() for s in health_symbols_str.split(",") if s.strip()]
+
+        freshness_status = check_data_freshness(symbols=health_symbols if health_symbols else None)
+        total_symbols = len(freshness_status)
+        stale_count = sum(1 for f in freshness_status if f.is_stale)
+
+        if stale_count > 0:
+            stale_names = [f.symbol for f in freshness_status if f.is_stale]
+            issues.append(f"{stale_count} symbol(s) have stale data: {', '.join(stale_names)}")
+
+    # Determine overall health
+    overall_healthy = len(issues) == 0
+
+    # Build summary
+    if overall_healthy:
+        summary = "All market data systems healthy"
+    else:
+        summary = f"{len(issues)} issue(s) detected: " + "; ".join(issues)
+
+    report = HealthReport(
+        timestamp=datetime.utcnow(),
+        overall_healthy=overall_healthy,
+        providers=providers_status,
+        freshness=freshness_status,
+        total_symbols=total_symbols,
+        stale_symbols=stale_count,
+        summary=summary,
+    )
+
+    # Log the result
+    if overall_healthy:
+        logger.info("Health check passed", extra=report.to_dict())
+    else:
+        logger.warning("Health check failed", extra=report.to_dict())
+
+        # Send alert if configured
+        if send_alert_on_failure:
+            _send_health_alert(report)
+
+    return report
+
+
+def _send_health_alert(report: HealthReport) -> None:
+    """Send a Telegram alert for unhealthy status."""
+    chat_id = settings.MARKET_DATA_FAILURE_ALERT_CHAT_ID
+    if not chat_id:
+        return
+
+    try:
+        from notifications.telegram_sender import send_telegram_message
+
+        provider_lines = []
+        for p in report.providers:
+            status_emoji = "\u2705" if p.can_fetch else ("\u26a0\ufe0f" if p.available else "\u274c")
+            latency = f" ({p.response_time_ms}ms)" if p.response_time_ms else ""
+            provider_lines.append(f"  {status_emoji} {p.name}{latency}")
+
+        stale_lines = []
+        for f in report.freshness:
+            if f.is_stale:
+                stale_lines.append(f"  \u26a0\ufe0f {f.symbol}: {f.days_stale} days stale")
+
+        message = (
+            "\U0001f6a8 *MARKET DATA HEALTH CHECK FAILED*\n\n"
+            f"*Summary:* {report.summary}\n\n"
+            "*Providers:*\n" + "\n".join(provider_lines) + "\n"
+        )
+
+        if stale_lines:
+            message += "\n*Stale Data:*\n" + "\n".join(stale_lines) + "\n"
+
+        message += f"\n_Checked at {report.timestamp.strftime('%Y-%m-%d %H:%M UTC')}_"
+
+        success, err = send_telegram_message(chat_id, message)
+        if not success:
+            logger.warning(f"Failed to send health alert: {err}")
+
+    except Exception as e:
+        logger.warning(f"Could not send health alert: {e}")
+```
+
+---
+
+### Step 3.7: Add Health Check CLI Command
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/cli.py`
+
+Add a new `health-check` command. Insert this after the existing `price_stats` command (after line 356) and before the `auto_pipeline` command (line 359).
+
+**Insert after line 356** (after the `price_stats` command closing):
+
+```python
+@cli.command(name="health-check")
+@click.option("--providers/--no-providers", default=True, help="Check provider connectivity")
+@click.option("--freshness/--no-freshness", default=True, help="Check data freshness")
+@click.option("--alert/--no-alert", default=False, help="Send Telegram alert if unhealthy")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def health_check(providers: bool, freshness: bool, alert: bool, as_json: bool):
+    """Run health check on market data pipeline."""
+    from shit.market_data.health import run_health_check
+
+    print_info("Running market data health check...")
+
+    try:
+        report = run_health_check(
+            check_providers=providers,
+            check_freshness=freshness,
+            send_alert_on_failure=alert,
+        )
+
+        if as_json:
+            import json
+            rprint(json.dumps(report.to_dict(), indent=2, default=str))
+            return
+
+        # Pretty print the report
+        status_icon = "\u2705" if report.overall_healthy else "\u274c"
+        rprint(f"\n{status_icon} [bold]Market Data Health: {'HEALTHY' if report.overall_healthy else 'UNHEALTHY'}[/bold]")
+
+        if report.providers:
+            rprint("\n[bold]Provider Status:[/bold]")
+            provider_table = Table()
+            provider_table.add_column("Provider", style="cyan")
+            provider_table.add_column("Available", justify="center")
+            provider_table.add_column("Can Fetch", justify="center")
+            provider_table.add_column("Latency", justify="right")
+            provider_table.add_column("Error", style="red")
+
+            for p in report.providers:
+                provider_table.add_row(
+                    p.name,
+                    "\u2705" if p.available else "\u274c",
+                    "\u2705" if p.can_fetch else "\u274c",
+                    f"{p.response_time_ms:.0f}ms" if p.response_time_ms else "N/A",
+                    p.error or "",
+                )
+            console.print(provider_table)
+
+        if report.freshness:
+            rprint("\n[bold]Data Freshness:[/bold]")
+            fresh_table = Table()
+            fresh_table.add_column("Symbol", style="cyan")
+            fresh_table.add_column("Latest Date", style="yellow")
+            fresh_table.add_column("Days Stale", justify="right")
+            fresh_table.add_column("Status", justify="center")
+
+            for f in report.freshness:
+                status = "\u2705 Fresh" if not f.is_stale else "\u26a0\ufe0f Stale"
+                fresh_table.add_row(
+                    f.symbol,
+                    str(f.latest_date) if f.latest_date else "No data",
+                    str(f.days_stale),
+                    status,
+                )
+            console.print(fresh_table)
+
+        rprint(f"\n[bold]Summary:[/bold] {report.summary}")
+
+        if not report.overall_healthy:
+            raise SystemExit(1)
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        print_error(f"\u274c Error running health check: {e}")
+        raise click.Abort()
+```
+
+---
+
+### Step 3.8: Update Module `__init__.py` Exports
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/market_data/__init__.py`
+
+Replace current content with:
+
+```python
+"""
+Market Data Module
+Fetches stock prices and calculates prediction outcomes.
+"""
+
+from shit.market_data.models import MarketPrice, PredictionOutcome
+from shit.market_data.client import MarketDataClient
+from shit.market_data.outcome_calculator import OutcomeCalculator
+from shit.market_data.price_provider import PriceProvider, ProviderChain, RawPriceRecord, ProviderError
+from shit.market_data.yfinance_provider import YFinanceProvider
+from shit.market_data.alphavantage_provider import AlphaVantageProvider
+from shit.market_data.health import run_health_check, HealthReport
+
+__all__ = [
+    "MarketPrice",
+    "PredictionOutcome",
+    "MarketDataClient",
+    "OutcomeCalculator",
+    "PriceProvider",
+    "ProviderChain",
+    "RawPriceRecord",
+    "ProviderError",
+    "YFinanceProvider",
+    "AlphaVantageProvider",
+    "run_health_check",
+    "HealthReport",
+]
+```
+
+---
+
+### Step 3.9: Update `requirements.txt`
+
+**File**: `/Users/chris/Projects/shitpost-alpha/requirements.txt`
+
+No new pip packages are needed. Alpha Vantage is accessed via plain `requests` (already at line 9). However, add a comment for clarity. After line 49 (`yfinance>=0.2.48`), add:
+
+```
+# Alpha Vantage accessed via requests (no separate package needed)
+# API key required in .env as ALPHA_VANTAGE_API_KEY (free tier: alphavantage.co)
+```
+
+---
+
+## 4. Test Plan
+
+### 4.1: Tests for Price Provider Abstraction
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/market_data/test_price_provider.py`
+
+```python
+"""Tests for price_provider.py -- abstract interface, ProviderChain, RawPriceRecord."""
+
+import pytest
+from datetime import date
+from unittest.mock import MagicMock
+
+from shit.market_data.price_provider import (
+    PriceProvider, ProviderChain, ProviderError, RawPriceRecord,
+)
+
+
+class TestRawPriceRecord:
+    def test_creation(self):
+        r = RawPriceRecord(
+            symbol="AAPL", date=date(2026, 1, 15),
+            open=150.0, high=155.0, low=149.0, close=153.0,
+            volume=1000000, adjusted_close=153.0, source="test",
+        )
+        assert r.symbol == "AAPL"
+        assert r.close == 153.0
+        assert r.source == "test"
+
+    def test_optional_fields_can_be_none(self):
+        r = RawPriceRecord(
+            symbol="X", date=date(2026, 1, 1),
+            open=None, high=None, low=None, close=10.0,
+            volume=None, adjusted_close=None, source="test",
+        )
+        assert r.open is None
+
+
+class TestProviderError:
+    def test_stores_provider_name(self):
+        e = ProviderError("yfinance", "API down")
+        assert e.provider_name == "yfinance"
+        assert "yfinance" in str(e)
+
+    def test_stores_original_error(self):
+        original = ValueError("bad")
+        e = ProviderError("test", "wrapper", original_error=original)
+        assert e.original_error is original
+
+
+class TestProviderChain:
+    def _make_provider(self, name, available=True, records=None, error=None):
+        p = MagicMock(spec=PriceProvider)
+        p.name = name
+        p.is_available.return_value = available
+        if error:
+            p.fetch_prices.side_effect = error
+        else:
+            p.fetch_prices.return_value = records or []
+        return p
+
+    def test_returns_first_successful_result(self):
+        p1 = self._make_provider("p1", records=[MagicMock()])
+        p2 = self._make_provider("p2", records=[MagicMock(), MagicMock()])
+        chain = ProviderChain([p1, p2])
+
+        result = chain.fetch_with_fallback("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert len(result) == 1  # From p1
+        p2.fetch_prices.assert_not_called()
+
+    def test_falls_back_on_error(self):
+        p1 = self._make_provider("p1", error=ProviderError("p1", "down"))
+        p2 = self._make_provider("p2", records=[MagicMock()])
+        chain = ProviderChain([p1, p2])
+
+        result = chain.fetch_with_fallback("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert len(result) == 1
+
+    def test_falls_back_on_empty_result(self):
+        p1 = self._make_provider("p1", records=[])
+        p2 = self._make_provider("p2", records=[MagicMock()])
+        chain = ProviderChain([p1, p2])
+
+        result = chain.fetch_with_fallback("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert len(result) == 1
+
+    def test_raises_when_all_fail(self):
+        p1 = self._make_provider("p1", error=ProviderError("p1", "down"))
+        p2 = self._make_provider("p2", error=ProviderError("p2", "also down"))
+        chain = ProviderChain([p1, p2])
+
+        with pytest.raises(ProviderError, match="all_providers"):
+            chain.fetch_with_fallback("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+    def test_excludes_unavailable_providers(self):
+        p1 = self._make_provider("p1", available=False)
+        p2 = self._make_provider("p2", records=[MagicMock()])
+        chain = ProviderChain([p1, p2])
+
+        assert len(chain.providers) == 1
+        assert chain.providers[0].name == "p2"
+
+    def test_empty_chain_logs_warning(self):
+        chain = ProviderChain([])
+        assert len(chain.providers) == 0
+```
+
+### 4.2: Tests for Alpha Vantage Provider
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/market_data/test_alphavantage_provider.py`
+
+```python
+"""Tests for alphavantage_provider.py."""
+
+import pytest
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+from shit.market_data.alphavantage_provider import AlphaVantageProvider
+from shit.market_data.price_provider import ProviderError
+
+
+class TestAlphaVantageProviderInit:
+    def test_name(self):
+        p = AlphaVantageProvider(api_key="test_key")
+        assert p.name == "alphavantage"
+
+    def test_available_with_key(self):
+        p = AlphaVantageProvider(api_key="test_key")
+        assert p.is_available() is True
+
+    def test_unavailable_without_key(self):
+        p = AlphaVantageProvider(api_key=None)
+        assert p.is_available() is False
+
+    def test_unavailable_with_empty_key(self):
+        p = AlphaVantageProvider(api_key="")
+        assert p.is_available() is False
+
+
+class TestAlphaVantageProviderFetch:
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_successful_fetch(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "Time Series (Daily)": {
+                "2026-01-15": {
+                    "1. open": "150.00",
+                    "2. high": "155.00",
+                    "3. low": "149.00",
+                    "4. close": "153.00",
+                    "5. volume": "1000000",
+                },
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        records = provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+        assert len(records) == 1
+        assert records[0].symbol == "AAPL"
+        assert records[0].close == 153.0
+        assert records[0].source == "alphavantage"
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_filters_by_date_range(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "Time Series (Daily)": {
+                "2026-01-15": {"1. open": "150", "2. high": "155", "3. low": "149", "4. close": "153", "5. volume": "1000000"},
+                "2025-12-01": {"1. open": "140", "2. high": "145", "3. low": "139", "4. close": "143", "5. volume": "900000"},
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        records = provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+        assert len(records) == 1
+        assert records[0].date == date(2026, 1, 15)
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_handles_api_error_message(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"Error Message": "Invalid symbol"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        with pytest.raises(ProviderError, match="Invalid symbol"):
+            provider.fetch_prices("BADTICKER", date(2026, 1, 1), date(2026, 1, 31))
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_handles_rate_limit(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"Note": "Thank you for using...5 calls per minute"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        with pytest.raises(ProviderError, match="Rate limited"):
+            provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_handles_timeout(self, mock_get):
+        import requests
+        mock_get.side_effect = requests.exceptions.Timeout("timed out")
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        with pytest.raises(ProviderError, match="timed out"):
+            provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+    def test_raises_when_no_api_key(self):
+        provider = AlphaVantageProvider(api_key=None)
+        with pytest.raises(ProviderError, match="not configured"):
+            provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_empty_time_series(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"Time Series (Daily)": {}}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        result = provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert result == []
+
+    @patch("shit.market_data.alphavantage_provider.requests.get")
+    def test_records_sorted_by_date(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "Time Series (Daily)": {
+                "2026-01-20": {"1. open": "160", "2. high": "165", "3. low": "159", "4. close": "163", "5. volume": "1100000"},
+                "2026-01-15": {"1. open": "150", "2. high": "155", "3. low": "149", "4. close": "153", "5. volume": "1000000"},
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        provider = AlphaVantageProvider(api_key="test_key")
+        records = provider.fetch_prices("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert records[0].date < records[1].date
+```
+
+### 4.3: Tests for Health Checks
+
+**New file**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/market_data/test_health.py`
+
+```python
+"""Tests for health.py -- provider health checks and data freshness."""
+
+import pytest
+from datetime import date, datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+from shit.market_data.health import (
+    check_provider_health,
+    check_data_freshness,
+    run_health_check,
+    HealthReport,
+    ProviderHealthStatus,
+    FreshnessStatus,
+)
+
+
+class TestCheckProviderHealth:
+    @patch("shit.market_data.health.YFinanceProvider")
+    def test_yfinance_healthy(self, mock_yf_cls):
+        mock_provider = MagicMock()
+        mock_provider.is_available.return_value = True
+        mock_provider.fetch_prices.return_value = [MagicMock()]
+        mock_yf_cls.return_value = mock_provider
+
+        status = check_provider_health("yfinance")
+        assert status.available is True
+        assert status.can_fetch is True
+        assert status.response_time_ms is not None
+
+    @patch("shit.market_data.health.AlphaVantageProvider")
+    def test_alphavantage_unavailable(self, mock_av_cls):
+        mock_provider = MagicMock()
+        mock_provider.is_available.return_value = False
+        mock_av_cls.return_value = mock_provider
+
+        status = check_provider_health("alphavantage")
+        assert status.available is False
+        assert status.can_fetch is False
+
+    def test_unknown_provider(self):
+        status = check_provider_health("unknown_provider")
+        assert status.available is False
+        assert "Unknown" in status.error
+
+    @patch("shit.market_data.health.YFinanceProvider")
+    def test_provider_fetch_fails(self, mock_yf_cls):
+        mock_provider = MagicMock()
+        mock_provider.is_available.return_value = True
+        mock_provider.fetch_prices.side_effect = Exception("Connection refused")
+        mock_yf_cls.return_value = mock_provider
+
+        status = check_provider_health("yfinance")
+        assert status.available is True
+        assert status.can_fetch is False
+        assert "Connection refused" in status.error
+
+
+class TestCheckDataFreshness:
+    @patch("shit.market_data.health.get_session")
+    def test_fresh_data(self, mock_get_session):
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.scalar.return_value = date.today() - timedelta(days=1)
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        results = check_data_freshness(symbols=["SPY"], threshold_hours=48)
+        assert len(results) == 1
+        assert results[0].is_stale is False
+
+    @patch("shit.market_data.health.get_session")
+    def test_stale_data(self, mock_get_session):
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.scalar.return_value = date.today() - timedelta(days=10)
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        results = check_data_freshness(symbols=["OLD_STOCK"], threshold_hours=48)
+        assert len(results) == 1
+        assert results[0].is_stale is True
+        assert results[0].days_stale == 10
+
+    @patch("shit.market_data.health.get_session")
+    def test_no_data_is_stale(self, mock_get_session):
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.scalar.return_value = None
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        results = check_data_freshness(symbols=["MISSING"], threshold_hours=48)
+        assert results[0].is_stale is True
+        assert results[0].days_stale == 999
+
+
+class TestRunHealthCheck:
+    @patch("shit.market_data.health.check_data_freshness")
+    @patch("shit.market_data.health.check_provider_health")
+    def test_healthy_report(self, mock_provider_check, mock_freshness):
+        mock_provider_check.return_value = ProviderHealthStatus(
+            name="yfinance", available=True, can_fetch=True, response_time_ms=150.0,
+        )
+        mock_freshness.return_value = [
+            FreshnessStatus(symbol="SPY", latest_date=date.today(), days_stale=0, is_stale=False, threshold_hours=48),
+        ]
+
+        report = run_health_check(send_alert_on_failure=False)
+        assert report.overall_healthy is True
+
+    @patch("shit.market_data.health.check_data_freshness")
+    @patch("shit.market_data.health.check_provider_health")
+    def test_unhealthy_when_provider_down(self, mock_provider_check, mock_freshness):
+        mock_provider_check.return_value = ProviderHealthStatus(
+            name="yfinance", available=True, can_fetch=False, error="API down",
+        )
+        mock_freshness.return_value = []
+
+        report = run_health_check(send_alert_on_failure=False)
+        assert report.overall_healthy is False
+        assert "cannot fetch" in report.summary.lower()
+
+    def test_report_to_dict(self):
+        report = HealthReport(
+            timestamp=datetime(2026, 1, 15, 10, 0, 0),
+            overall_healthy=True,
+            providers=[],
+            freshness=[],
+            total_symbols=0,
+            stale_symbols=0,
+            summary="OK",
+        )
+        d = report.to_dict()
+        assert d["overall_healthy"] is True
+        assert "2026" in d["timestamp"]
+```
+
+### 4.4: Update Existing `test_client.py`
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/market_data/test_client.py`
+
+The existing tests mock `yf.Ticker` directly. After refactoring, the client uses `ProviderChain` instead. We need to update mocking targets. Key changes:
+
+1. Replace `@patch("shit.market_data.client.yf")` with `@patch("shit.market_data.client._build_default_provider_chain")`
+2. Mock the provider chain's `fetch_with_fallback` method to return `RawPriceRecord` objects
+3. Add new tests for retry logic and failure alerting
+
+Add these new test classes to the existing file:
+
+```python
+class TestFetchWithRetry:
+    """Test the retry logic in MarketDataClient."""
+
+    @patch("shit.market_data.client.settings")
+    def test_retries_on_provider_error(self, mock_settings, client, mock_session):
+        from shit.market_data.price_provider import ProviderError, RawPriceRecord
+
+        mock_settings.MARKET_DATA_MAX_RETRIES = 2
+        mock_settings.MARKET_DATA_RETRY_DELAY = 0.01  # fast for tests
+        mock_settings.MARKET_DATA_RETRY_BACKOFF = 1.0
+
+        mock_chain = MagicMock()
+        mock_chain.fetch_with_fallback.side_effect = [
+            ProviderError("all", "down"),
+            ProviderError("all", "still down"),
+            [RawPriceRecord(symbol="AAPL", date=date(2026, 1, 15),
+                            open=150.0, high=155.0, low=149.0, close=153.0,
+                            volume=1000000, adjusted_close=153.0, source="test")],
+        ]
+        client._provider_chain = mock_chain
+
+        result = client._fetch_with_retry("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert len(result) == 1
+        assert mock_chain.fetch_with_fallback.call_count == 3
+
+    @patch("shit.market_data.client._send_failure_alert")
+    @patch("shit.market_data.client.settings")
+    def test_sends_alert_after_all_retries_exhausted(self, mock_settings, mock_alert, client):
+        from shit.market_data.price_provider import ProviderError
+
+        mock_settings.MARKET_DATA_MAX_RETRIES = 1
+        mock_settings.MARKET_DATA_RETRY_DELAY = 0.01
+        mock_settings.MARKET_DATA_RETRY_BACKOFF = 1.0
+
+        mock_chain = MagicMock()
+        mock_chain.fetch_with_fallback.side_effect = ProviderError("all", "permanently down")
+        client._provider_chain = mock_chain
+
+        result = client._fetch_with_retry("AAPL", date(2026, 1, 1), date(2026, 1, 31))
+        assert result == []
+        mock_alert.assert_called_once()
+
+
+class TestStoreRawRecords:
+    """Test conversion from RawPriceRecord to MarketPrice."""
+
+    def test_creates_new_price_records(self, client, mock_session):
+        from shit.market_data.price_provider import RawPriceRecord
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        records = [
+            RawPriceRecord(symbol="AAPL", date=date(2026, 1, 15),
+                           open=150.0, high=155.0, low=149.0, close=153.0,
+                           volume=1000000, adjusted_close=153.0, source="yfinance"),
+        ]
+
+        result = client._store_raw_records(records)
+        assert len(result) == 1
+        mock_session.add.assert_called_once()
+
+    def test_skips_existing_unless_force(self, client, mock_session):
+        from shit.market_data.price_provider import RawPriceRecord
+
+        existing = MagicMock(spec=MarketPrice)
+        mock_session.query.return_value.filter.return_value.first.return_value = existing
+
+        records = [
+            RawPriceRecord(symbol="AAPL", date=date(2026, 1, 15),
+                           open=150.0, high=155.0, low=149.0, close=153.0,
+                           volume=1000000, adjusted_close=153.0, source="yfinance"),
+        ]
+
+        result = client._store_raw_records(records, force_refresh=False)
+        assert result[0] is existing
+        mock_session.add.assert_not_called()
+```
+
+**Estimated test count**: ~50 new tests across the 3 new test files, plus ~5 updated/new tests in existing `test_client.py`.
+
+---
+
+## 5. Documentation Updates
+
+### 5.1: CHANGELOG.md
+
+Add under `## [Unreleased]` / `### Added`:
+
+```markdown
+- **Market Data Resilience** - Multi-provider price fetching with fallback and monitoring
+  - Added price provider abstraction (`PriceProvider` interface) for pluggable data sources
+  - Added Alpha Vantage as fallback provider (free tier: 25 requests/day)
+  - Added retry logic with exponential backoff (configurable: 3 retries, 1s base delay, 2x backoff)
+  - Added data freshness monitoring with configurable staleness threshold (default: 48 hours)
+  - Added `health-check` CLI command (`python -m shit.market_data health-check`)
+  - Added Telegram failure alerting when all price providers fail
+  - ~50 new tests covering providers, fallback chain, retry logic, health checks
+```
+
+### 5.2: CLAUDE.md
+
+Add to the `## Core Services Reference` section under market data:
+
+```markdown
+**Fallback Providers**: If yfinance fails, Alpha Vantage is tried automatically.
+Configure `ALPHA_VANTAGE_API_KEY` in `.env` to enable the fallback.
+
+**Health Checks**: Run `python -m shit.market_data health-check` to verify provider
+connectivity and data freshness. Use `--alert` flag to send Telegram notification on failure.
+```
+
+### 5.3: Environment Variables
+
+Document in the `.env` file (or wherever environment documentation lives):
+
+```
+# Market Data Resilience
+ALPHA_VANTAGE_API_KEY=           # Free API key from alphavantage.co
+MARKET_DATA_STALENESS_THRESHOLD_HOURS=48  # Alert if data older than this
+MARKET_DATA_FAILURE_ALERT_CHAT_ID=        # Telegram chat ID for infra alerts
+MARKET_DATA_MAX_RETRIES=3
+MARKET_DATA_RETRY_DELAY=1.0
+MARKET_DATA_RETRY_BACKOFF=2.0
+MARKET_DATA_HEALTH_CHECK_SYMBOLS=SPY,AAPL
+```
+
+---
+
+## 6. Stress Testing and Edge Cases
+
+### Scenario: Both Providers Down
+
+- `ProviderChain.fetch_with_fallback` raises `ProviderError("all_providers", ...)`
+- `_fetch_with_retry` catches it, retries `MARKET_DATA_MAX_RETRIES` times
+- After exhausting retries, returns empty list and calls `_send_failure_alert`
+- `fetch_price_history` logs warning and returns `[]`
+- Downstream callers (`auto_backfill_service.py`, `outcome_calculator.py`) handle empty results gracefully (already tested -- see `test_outcome_calculator.py` line 167-178)
+
+### Scenario: Partial Data from Fallback
+
+- yfinance fails with `ProviderError`
+- Alpha Vantage returns data but for fewer dates than requested (e.g., only last 100 trading days)
+- `_store_raw_records` stores whatever was returned
+- Missing dates remain unfilled -- this is correct behavior (market was either closed or data is truly missing)
+
+### Scenario: Stale Data Accumulates
+
+- Health check detects symbols where `max(date)` is more than 2 days ago
+- Reports them as stale in the `FreshnessStatus`
+- If `--alert` flag is used (or called from a cron job), sends Telegram notification
+- Does NOT auto-fix -- staleness is an alert, not an auto-action
+
+### Scenario: Alpha Vantage Rate Limit
+
+- Free tier: 5 requests/minute, 25 requests/day
+- If rate limited, Alpha Vantage returns `{"Note": "..."}` instead of data
+- `AlphaVantageProvider.fetch_prices` detects this and raises `ProviderError`
+- Chain moves on (if there were another fallback) or fails gracefully
+- Retry logic waits with exponential backoff, which may allow the rate limit to clear
+
+### Scenario: Invalid/Unsupported Symbol
+
+- Provider returns empty results (not an error)
+- `ProviderChain` tries next provider which also returns empty
+- Returns empty list (no `ProviderError` raised for empty results from all providers -- only for actual errors)
+- This matches current behavior where yfinance returns empty DataFrame for unknown symbols
+
+### Scenario: Network Timeout
+
+- `requests.get` times out (30s timeout configured in Alpha Vantage)
+- `AlphaVantageProvider` catches `requests.exceptions.Timeout` and raises `ProviderError`
+- `yfinance` has its own internal timeout handling
+- Retry logic with exponential backoff handles transient network issues
+
+---
+
+## 7. Verification Checklist
+
+After implementation, verify each item:
+
+- [ ] `python -m shit.market_data health-check` runs and shows provider status
+- [ ] `python -m shit.market_data health-check --json` outputs valid JSON
+- [ ] With `ALPHA_VANTAGE_API_KEY` set, health check shows Alpha Vantage as available
+- [ ] Without `ALPHA_VANTAGE_API_KEY`, Alpha Vantage shows "Not configured" but system is still healthy
+- [ ] `python -m shit.market_data fetch-prices -s AAPL -d 7` still works (backwards compatibility)
+- [ ] `python -m shit.market_data auto-pipeline` still works (backwards compatibility)
+- [ ] All existing tests pass: `source venv/bin/activate && pytest shit_tests/shit/market_data/ -v`
+- [ ] New tests pass: `source venv/bin/activate && pytest shit_tests/shit/market_data/test_price_provider.py shit_tests/shit/market_data/test_alphavantage_provider.py shit_tests/shit/market_data/test_health.py -v`
+- [ ] Full test suite passes: `source venv/bin/activate && pytest -v`
+- [ ] Linting passes: `python3 -m ruff check shit/market_data/`
+- [ ] Formatting passes: `python3 -m ruff format shit/market_data/`
+- [ ] Health check CLI exits with code 1 when unhealthy (testable by setting `MARKET_DATA_HEALTH_CHECK_SYMBOLS=DEFINITELY_NOT_A_REAL_TICKER`)
+- [ ] When both providers fail, a Telegram alert is sent (if `MARKET_DATA_FAILURE_ALERT_CHAT_ID` is configured)
+- [ ] `MarketPrice.source` column shows "yfinance" or "alphavantage" depending on which provider served the data
+- [ ] Existing `auto_backfill_service.py` and `outcome_calculator.py` work unchanged (they construct `MarketDataClient()` which now builds a provider chain internally)
+
+---
+
+## 8. What NOT To Do
+
+1. **Do NOT replace yfinance as the primary provider.** yfinance is free, unlimited, and works well for most equities. Alpha Vantage is a fallback only, with rate limits.
+
+2. **Do NOT add Alpha Vantage as a pip dependency.** We use plain `requests` (already in requirements) to call the REST API. Adding the `alpha_vantage` Python package would add unnecessary dependency weight for a simple API call.
+
+3. **Do NOT change the `MarketPrice` database model or schema.** The `source` column already exists (line 35 of `models.py`). No migration is needed.
+
+4. **Do NOT make the health check run automatically in the main pipeline (`shitpost_alpha.py`).** Health checks should be opt-in via CLI or a separate cron job. Adding it to the main pipeline would slow it down with test-fetch calls on every run.
+
+5. **Do NOT catch and swallow `ProviderError` in `fetch_price_history`.** The method should still raise exceptions for database errors (line 139-146 in current code). Only provider-level errors are retried; database errors propagate immediately.
+
+6. **Do NOT make retry delays longer than necessary in tests.** All test retry delays should use `0.01` seconds (not the production default of `1.0s`) to keep tests fast.
+
+7. **Do NOT send Telegram alerts on every individual provider failure.** Only send alerts when ALL providers fail after ALL retries are exhausted. A single yfinance failure that Alpha Vantage handles is expected behavior, not an alert.
+
+8. **Do NOT add async versions of the providers.** The market data pipeline uses synchronous SQLAlchemy sessions (`sync_session.py`). Keep providers synchronous for consistency. The existing `error_handling.py` has both `sync_retry` and `async_retry` -- use the sync patterns only.
+
+9. **Do NOT hardcode the Alpha Vantage API key anywhere.** It must come from `settings.ALPHA_VANTAGE_API_KEY` which reads from the `.env` file. Never commit API keys.
+
+10. **Do NOT add crypto support to Alpha Vantage in this phase.** Alpha Vantage's crypto endpoint uses different parameters (`DIGITAL_CURRENCY_DAILY` with `market=USD`). That can be a follow-up enhancement.
+
+---
+
+### Critical Files for Implementation
+- `/Users/chris/Projects/shitpost-alpha/shit/market_data/client.py` - Core file to refactor: extract yfinance calls into provider, add retry logic, wire up fallback chain
+- `/Users/chris/Projects/shitpost-alpha/shit/market_data/price_provider.py` - New file: abstract interface, RawPriceRecord, ProviderChain -- the architectural backbone of this phase
+- `/Users/chris/Projects/shitpost-alpha/shit/market_data/health.py` - New file: health check logic, freshness monitoring, alert integration
+- `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py` - Add all new configuration fields (API key, retry params, staleness threshold, alert chat ID)
+- `/Users/chris/Projects/shitpost-alpha/shit_tests/shit/market_data/test_client.py` - Existing tests that need mock updates plus new retry/fallback tests

--- a/railway.json
+++ b/railway.json
@@ -27,7 +27,7 @@
     },
     "market-data": {
       "source": ".",
-      "startCommand": "python -m shit.market_data auto-pipeline --days-back 30",
+      "startCommand": "python -m shit.market_data auto-pipeline --days-back 7",
       "cronSchedule": "*/15 * * * *"
     }
   }

--- a/shit/db/sync_session.py
+++ b/shit/db/sync_session.py
@@ -76,6 +76,6 @@ def create_tables():
         Subscriber,
         LLMFeedback
     )
-    from shit.market_data.models import MarketPrice, PredictionOutcome
+    from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
 
     Base.metadata.create_all(engine)

--- a/shit/market_data/__init__.py
+++ b/shit/market_data/__init__.py
@@ -3,13 +3,14 @@ Market Data Module
 Fetches stock prices and calculates prediction outcomes.
 """
 
-from shit.market_data.models import MarketPrice, PredictionOutcome
+from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
 from shit.market_data.client import MarketDataClient
 from shit.market_data.outcome_calculator import OutcomeCalculator
 
 __all__ = [
     "MarketPrice",
     "PredictionOutcome",
+    "TickerRegistry",
     "MarketDataClient",
     "OutcomeCalculator",
 ]

--- a/shit/market_data/cli.py
+++ b/shit/market_data/cli.py
@@ -490,5 +490,84 @@ def backfill_all_missing():
         raise click.Abort()
 
 
+@cli.command(name="ticker-registry")
+@click.option(
+    "--status",
+    "-s",
+    type=click.Choice(["active", "inactive", "invalid", "all"]),
+    default="all",
+    help="Filter by ticker status",
+)
+def ticker_registry_cmd(status: str):
+    """Show all tracked tickers in the registry."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+    from shit.market_data.models import TickerRegistry
+
+    try:
+        service = TickerRegistryService()
+        stats = service.get_registry_stats()
+
+        rprint(f"\n[bold]Ticker Registry Stats:[/bold]")
+        rprint(f"  Total: {stats['total']}")
+        rprint(f"  Active: [green]{stats['active']}[/green]")
+        rprint(f"  Invalid: [red]{stats['invalid']}[/red]")
+        rprint(f"  Inactive: [yellow]{stats['inactive']}[/yellow]")
+
+        with get_session() as session:
+            query = session.query(TickerRegistry)
+            if status != "all":
+                query = query.filter(TickerRegistry.status == status)
+            query = query.order_by(TickerRegistry.first_seen_date.desc())
+            tickers = query.all()
+
+            if not tickers:
+                print_info("No tickers found matching filter")
+                return
+
+            table = Table(title=f"Ticker Registry ({status})")
+            table.add_column("Symbol", style="cyan")
+            table.add_column("Status", style="green")
+            table.add_column("First Seen", style="yellow")
+            table.add_column("Last Update", style="white")
+            table.add_column("Records", style="magenta", justify="right")
+
+            for t in tickers:
+                table.add_row(
+                    t.symbol,
+                    t.status,
+                    str(t.first_seen_date),
+                    str(t.last_price_update.date()) if t.last_price_update else "Never",
+                    str(t.total_price_records),
+                )
+
+            console.print(table)
+
+    except Exception as e:
+        print_error(f"Error reading ticker registry: {e}")
+        raise click.Abort()
+
+
+@cli.command(name="register-tickers")
+@click.argument("symbols", nargs=-1, required=True)
+def register_tickers_cmd(symbols: tuple):
+    """Manually register tickers for tracking (e.g., register-tickers AAPL TSLA BTC-USD)."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+
+    try:
+        service = TickerRegistryService()
+        newly_registered, already_known = service.register_tickers(list(symbols))
+
+        if newly_registered:
+            print_success(
+                f"Registered {len(newly_registered)} new tickers: {', '.join(newly_registered)}"
+            )
+        if already_known:
+            print_info(f"Already registered: {', '.join(already_known)}")
+
+    except Exception as e:
+        print_error(f"Error registering tickers: {e}")
+        raise click.Abort()
+
+
 if __name__ == "__main__":
     cli()

--- a/shit/market_data/ticker_registry.py
+++ b/shit/market_data/ticker_registry.py
@@ -1,0 +1,213 @@
+"""
+Ticker Registry Service
+Manages the lifecycle of tracked ticker symbols.
+
+When the LLM analyzer identifies tickers in a prediction, this service:
+1. Checks if the ticker is already registered
+2. Registers new tickers with source_prediction_id
+3. Marks invalid tickers (ones yfinance cannot find)
+4. Provides the list of active tickers for the cron service to update
+"""
+
+from datetime import date, datetime
+from typing import List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+
+from shit.market_data.models import TickerRegistry, MarketPrice
+from shit.db.sync_session import get_session
+from shit.logging import get_service_logger
+
+logger = get_service_logger("ticker_registry")
+
+
+class TickerRegistryService:
+    """Manages the ticker registry for ongoing price tracking."""
+
+    def register_tickers(
+        self,
+        symbols: List[str],
+        source_prediction_id: Optional[int] = None,
+    ) -> Tuple[List[str], List[str]]:
+        """Register new tickers in the registry.
+
+        Args:
+            symbols: List of ticker symbols to register
+            source_prediction_id: ID of the prediction that introduced these tickers
+
+        Returns:
+            Tuple of (newly_registered, already_known) symbol lists
+        """
+        if not symbols:
+            return ([], [])
+
+        newly_registered = []
+        already_known = []
+
+        with get_session() as session:
+            for symbol in symbols:
+                symbol = symbol.strip().upper()
+
+                # Validate symbol format
+                if not symbol or len(symbol) > 20 or " " in symbol:
+                    logger.warning(f"Skipping invalid symbol format: '{symbol}'")
+                    continue
+
+                # Check if already registered
+                existing = (
+                    session.query(TickerRegistry)
+                    .filter(TickerRegistry.symbol == symbol)
+                    .first()
+                )
+
+                if existing:
+                    already_known.append(symbol)
+                    logger.debug(f"Ticker {symbol} already registered (status={existing.status})")
+                    continue
+
+                # Register new ticker
+                registry_entry = TickerRegistry(
+                    symbol=symbol,
+                    first_seen_date=date.today(),
+                    source_prediction_id=source_prediction_id,
+                    status="active",
+                    last_price_update=None,
+                    total_price_records=0,
+                )
+                session.add(registry_entry)
+                newly_registered.append(symbol)
+                logger.info(
+                    f"Registered new ticker: {symbol}",
+                    extra={"symbol": symbol, "source_prediction_id": source_prediction_id},
+                )
+
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                logger.info("IntegrityError during ticker registration, handling concurrent insert")
+
+        return (newly_registered, already_known)
+
+    def get_new_tickers(self, symbols: List[str]) -> List[str]:
+        """Identify which tickers from a list are NOT yet registered.
+
+        Args:
+            symbols: List of ticker symbols to check
+
+        Returns:
+            List of symbols not yet in the registry
+        """
+        if not symbols:
+            return []
+
+        with get_session() as session:
+            existing = (
+                session.query(TickerRegistry.symbol)
+                .filter(TickerRegistry.symbol.in_([s.strip().upper() for s in symbols]))
+                .all()
+            )
+            existing_set = {row[0] for row in existing}
+
+        return [s for s in symbols if s.strip().upper() not in existing_set]
+
+    def get_active_tickers(self) -> List[str]:
+        """Get all active tickers that should have prices updated.
+
+        Returns:
+            List of active ticker symbols
+        """
+        with get_session() as session:
+            results = (
+                session.query(TickerRegistry.symbol)
+                .filter(TickerRegistry.status == "active")
+                .all()
+            )
+            return [row[0] for row in results]
+
+    def mark_ticker_invalid(self, symbol: str, reason: str) -> None:
+        """Mark a ticker as invalid (e.g., yfinance cannot find it).
+
+        Args:
+            symbol: Ticker symbol
+            reason: Why it is being marked invalid
+        """
+        with get_session() as session:
+            entry = (
+                session.query(TickerRegistry)
+                .filter(TickerRegistry.symbol == symbol.strip().upper())
+                .first()
+            )
+
+            if entry:
+                entry.status = "invalid"
+                entry.status_reason = reason[:255]
+                session.commit()
+                logger.info(f"Marked ticker {symbol} as invalid: {reason}")
+
+    def update_price_metadata(self, symbol: str) -> None:
+        """Update a ticker's price metadata from the market_prices table.
+
+        Args:
+            symbol: Ticker symbol to update
+        """
+        from sqlalchemy import func
+
+        with get_session() as session:
+            entry = (
+                session.query(TickerRegistry)
+                .filter(TickerRegistry.symbol == symbol.strip().upper())
+                .first()
+            )
+
+            if not entry:
+                return
+
+            stats = (
+                session.query(
+                    func.min(MarketPrice.date).label("earliest"),
+                    func.max(MarketPrice.date).label("latest"),
+                    func.count(MarketPrice.id).label("count"),
+                )
+                .filter(MarketPrice.symbol == symbol)
+                .first()
+            )
+
+            if stats and stats.count > 0:
+                entry.price_data_start = stats.earliest
+                entry.price_data_end = stats.latest
+                entry.total_price_records = stats.count
+                entry.last_price_update = datetime.now(tz=None)
+                session.commit()
+
+    def get_registry_stats(self) -> dict:
+        """Get summary statistics about the ticker registry."""
+        from sqlalchemy import func
+
+        with get_session() as session:
+            total = session.query(func.count(TickerRegistry.id)).scalar() or 0
+            active = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "active")
+                .scalar()
+                or 0
+            )
+            invalid = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "invalid")
+                .scalar()
+                or 0
+            )
+            inactive = (
+                session.query(func.count(TickerRegistry.id))
+                .filter(TickerRegistry.status == "inactive")
+                .scalar()
+                or 0
+            )
+
+            return {
+                "total": total,
+                "active": active,
+                "invalid": invalid,
+                "inactive": inactive,
+            }

--- a/shit_tests/shit/market_data/test_auto_backfill_service.py
+++ b/shit_tests/shit/market_data/test_auto_backfill_service.py
@@ -1,0 +1,302 @@
+"""
+Tests for shit/market_data/auto_backfill_service.py - AutoBackfillService with registry integration.
+
+Tests the integration between AutoBackfillService and TickerRegistryService,
+including registration on process, metadata updates on backfill, and invalid marking.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+from datetime import date
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from shit.market_data.auto_backfill_service import (
+    AutoBackfillService,
+    auto_backfill_prediction,
+    auto_backfill_recent,
+    auto_backfill_all,
+)
+
+SESSION_PATCH = "shit.market_data.auto_backfill_service.get_session"
+CLIENT_PATCH = "shit.market_data.auto_backfill_service.MarketDataClient"
+CALC_PATCH = "shit.market_data.auto_backfill_service.OutcomeCalculator"
+REGISTRY_PATCH = "shit.market_data.auto_backfill_service.TickerRegistryService"
+
+
+def _mock_session():
+    """Create a mock session with context manager support."""
+    session = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=session)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx, session
+
+
+def _mock_client(prices=None):
+    """Create a mock MarketDataClient with context manager support."""
+    client = MagicMock()
+    client.fetch_price_history.return_value = prices or []
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    return client
+
+
+class TestBackfillTicker:
+    """Tests for AutoBackfillService.backfill_ticker."""
+
+    def test_successful_backfill_returns_true(self):
+        client = _mock_client(prices=[MagicMock()] * 100)
+        with patch(CLIENT_PATCH, return_value=client), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            result = service.backfill_ticker("AAPL")
+        assert result is True
+
+    def test_returns_false_for_no_data(self):
+        client = _mock_client(prices=[])
+        with patch(CLIENT_PATCH, return_value=client), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            result = service.backfill_ticker("FAKE")
+        assert result is False
+
+    def test_skips_invalid_symbols(self):
+        with patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            assert service.backfill_ticker("") is False
+            assert service.backfill_ticker("A" * 11) is False
+            assert service.backfill_ticker("HAS SPACE") is False
+
+    def test_skips_krx_symbols(self):
+        with patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            result = service.backfill_ticker("KRX:005930")
+        assert result is False
+
+    def test_handles_yfinance_exception(self):
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.fetch_price_history.side_effect = Exception("yfinance error")
+
+        with patch(CLIENT_PATCH, return_value=client), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            result = service.backfill_ticker("AAPL")
+        assert result is False
+
+    def test_updates_registry_on_success(self):
+        client = _mock_client(prices=[MagicMock()] * 50)
+        mock_registry = MagicMock()
+
+        with patch(CLIENT_PATCH, return_value=client), patch(REGISTRY_PATCH, return_value=mock_registry):
+            service = AutoBackfillService()
+            service.backfill_ticker("AAPL")
+
+        service.registry.update_price_metadata.assert_called_once_with("AAPL")
+
+    def test_marks_invalid_on_no_data(self):
+        client = _mock_client(prices=[])
+        mock_registry = MagicMock()
+
+        with patch(CLIENT_PATCH, return_value=client), patch(REGISTRY_PATCH, return_value=mock_registry):
+            service = AutoBackfillService()
+            service.backfill_ticker("FAKE")
+
+        service.registry.mark_ticker_invalid.assert_called_once_with(
+            "FAKE", "yfinance returned no price data"
+        )
+
+
+class TestProcessSinglePrediction:
+    """Tests for AutoBackfillService.process_single_prediction."""
+
+    def test_backfills_missing_tickers_and_calculates_outcome(self):
+        ctx, session = _mock_session()
+        prediction = MagicMock()
+        prediction.id = 1
+        prediction.assets = ["AAPL", "TSLA"]
+        session.query.return_value.filter.return_value.first.return_value = prediction
+
+        client = _mock_client(prices=[MagicMock()] * 10)
+        calc = MagicMock()
+        calc.calculate_outcome_for_prediction.return_value = [MagicMock()]
+        calc.__enter__ = MagicMock(return_value=calc)
+        calc.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(CLIENT_PATCH, return_value=client),
+            patch(CALC_PATCH, return_value=calc),
+            patch(REGISTRY_PATCH),
+        ):
+            service = AutoBackfillService()
+            # Mock get_missing_tickers to return one missing ticker
+            service.get_missing_tickers = MagicMock(return_value=["TSLA"])
+            backfilled, outcomes = service.process_single_prediction(1)
+
+        assert backfilled == 1
+        assert outcomes == 1
+
+    def test_registers_tickers_in_registry(self):
+        ctx, session = _mock_session()
+        prediction = MagicMock()
+        prediction.id = 42
+        prediction.assets = ["AAPL"]
+        session.query.return_value.filter.return_value.first.return_value = prediction
+
+        mock_registry = MagicMock()
+        mock_registry.register_tickers.return_value = (["AAPL"], [])
+
+        calc = MagicMock()
+        calc.calculate_outcome_for_prediction.return_value = []
+        calc.__enter__ = MagicMock(return_value=calc)
+        calc.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(CALC_PATCH, return_value=calc),
+            patch(REGISTRY_PATCH, return_value=mock_registry),
+        ):
+            service = AutoBackfillService()
+            service.get_missing_tickers = MagicMock(return_value=[])
+            service.process_single_prediction(42)
+
+        service.registry.register_tickers.assert_called_once_with(
+            ["AAPL"], source_prediction_id=42
+        )
+
+    def test_handles_prediction_not_found(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            backfilled, outcomes = service.process_single_prediction(999)
+
+        assert backfilled == 0
+        assert outcomes == 0
+
+    def test_handles_prediction_with_no_assets(self):
+        ctx, session = _mock_session()
+        prediction = MagicMock()
+        prediction.id = 1
+        prediction.assets = []
+        session.query.return_value.filter.return_value.first.return_value = prediction
+
+        with patch(SESSION_PATCH, return_value=ctx), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            backfilled, outcomes = service.process_single_prediction(1)
+
+        assert backfilled == 0
+        assert outcomes == 0
+
+    def test_handles_outcome_calculation_failure(self):
+        ctx, session = _mock_session()
+        prediction = MagicMock()
+        prediction.id = 1
+        prediction.assets = ["AAPL"]
+        session.query.return_value.filter.return_value.first.return_value = prediction
+
+        calc = MagicMock()
+        calc.calculate_outcome_for_prediction.side_effect = Exception("calc error")
+        calc.__enter__ = MagicMock(return_value=calc)
+        calc.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(CALC_PATCH, return_value=calc),
+            patch(REGISTRY_PATCH),
+        ):
+            service = AutoBackfillService()
+            service.get_missing_tickers = MagicMock(return_value=[])
+            backfilled, outcomes = service.process_single_prediction(1)
+
+        assert outcomes == 0
+
+
+class TestProcessNewPredictions:
+    """Tests for AutoBackfillService.process_new_predictions."""
+
+    def test_processes_recent_predictions(self):
+        ctx, session = _mock_session()
+        pred1 = MagicMock(id=1)
+        pred2 = MagicMock(id=2)
+        query = MagicMock()
+        query.all.return_value = [pred1, pred2]
+        session.query.return_value.filter.return_value.order_by.return_value = query
+
+        with patch(SESSION_PATCH, return_value=ctx), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            service.process_single_prediction = MagicMock(return_value=(1, 1))
+            stats = service.process_new_predictions(days_back=7)
+
+        assert stats["predictions_processed"] == 2
+
+    def test_respects_limit_parameter(self):
+        ctx, session = _mock_session()
+        pred1 = MagicMock(id=1)
+        query = MagicMock()
+        limited_query = MagicMock()
+        limited_query.all.return_value = [pred1]
+        query.limit.return_value = limited_query
+        session.query.return_value.filter.return_value.order_by.return_value = query
+
+        with patch(SESSION_PATCH, return_value=ctx), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            service.process_single_prediction = MagicMock(return_value=(0, 0))
+            stats = service.process_new_predictions(days_back=7, limit=1)
+
+        assert stats["predictions_processed"] == 1
+
+    def test_handles_errors_gracefully(self):
+        ctx, session = _mock_session()
+        pred1 = MagicMock(id=1)
+        query = MagicMock()
+        query.all.return_value = [pred1]
+        session.query.return_value.filter.return_value.order_by.return_value = query
+
+        with patch(SESSION_PATCH, return_value=ctx), patch(REGISTRY_PATCH):
+            service = AutoBackfillService()
+            service.process_single_prediction = MagicMock(
+                side_effect=Exception("processing error")
+            )
+            stats = service.process_new_predictions(days_back=7)
+
+        assert stats["errors"] == 1
+
+
+class TestConvenienceFunctions:
+    """Tests for module-level convenience functions."""
+
+    def test_auto_backfill_prediction_calls_service(self):
+        with patch(REGISTRY_PATCH):
+            with patch.object(
+                AutoBackfillService,
+                "process_single_prediction",
+                return_value=(1, 1),
+            ):
+                result = auto_backfill_prediction(42)
+        assert result is True
+
+    def test_auto_backfill_recent_calls_service(self):
+        expected = {"predictions_processed": 5, "assets_backfilled": 2}
+        with patch(REGISTRY_PATCH):
+            with patch.object(
+                AutoBackfillService,
+                "process_new_predictions",
+                return_value=expected,
+            ):
+                result = auto_backfill_recent(days=7)
+        assert result == expected
+
+    def test_auto_backfill_all_calls_service(self):
+        expected = {"total_assets": 10, "missing_assets": 3, "backfilled": 3, "failed": 0}
+        with patch(REGISTRY_PATCH):
+            with patch.object(
+                AutoBackfillService,
+                "process_all_missing_assets",
+                return_value=expected,
+            ):
+                result = auto_backfill_all()
+        assert result == expected

--- a/shit_tests/shit/market_data/test_ticker_registry.py
+++ b/shit_tests/shit/market_data/test_ticker_registry.py
@@ -1,0 +1,373 @@
+"""
+Tests for shit/market_data/ticker_registry.py - TickerRegistryService.
+
+All tests use mocked get_session to avoid database dependencies.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+from datetime import date, datetime
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from shit.market_data.ticker_registry import TickerRegistryService
+from shit.market_data.models import TickerRegistry, MarketPrice
+
+SESSION_PATCH = "shit.market_data.ticker_registry.get_session"
+
+
+def _mock_session():
+    """Create a mock session with context manager support."""
+    session = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=session)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx, session
+
+
+class TestRegisterTickers:
+    """Tests for TickerRegistryService.register_tickers."""
+
+    def test_registers_new_ticker_successfully(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL"])
+
+        assert newly == ["AAPL"]
+        assert known == []
+        session.add.assert_called_once()
+
+    def test_skips_already_registered_ticker(self):
+        ctx, session = _mock_session()
+        existing = MagicMock(status="active")
+        session.query.return_value.filter.return_value.first.return_value = existing
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL"])
+
+        assert newly == []
+        assert known == ["AAPL"]
+        session.add.assert_not_called()
+
+    def test_returns_newly_registered_and_already_known_lists(self):
+        ctx, session = _mock_session()
+        existing = MagicMock(status="active")
+        # First call returns None (new), second returns existing
+        session.query.return_value.filter.return_value.first.side_effect = [None, existing]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["NVDA", "AAPL"])
+
+        assert newly == ["NVDA"]
+        assert known == ["AAPL"]
+
+    def test_handles_empty_symbol_list(self):
+        service = TickerRegistryService()
+        newly, known = service.register_tickers([])
+        assert newly == []
+        assert known == []
+
+    def test_skips_invalid_symbol_format_space(self):
+        ctx, session = _mock_session()
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["THE ECONOMY"])
+
+        assert newly == []
+        assert known == []
+        session.add.assert_not_called()
+
+    def test_skips_invalid_symbol_format_too_long(self):
+        ctx, session = _mock_session()
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["A" * 21])
+
+        assert newly == []
+        assert known == []
+
+    def test_skips_empty_string_symbol(self):
+        ctx, session = _mock_session()
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers([""])
+
+        assert newly == []
+        assert known == []
+
+    def test_uppercases_symbols(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["aapl"])
+
+        assert newly == ["AAPL"]
+
+    def test_sets_source_prediction_id(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.register_tickers(["TSLA"], source_prediction_id=42)
+
+        added_obj = session.add.call_args[0][0]
+        assert added_obj.source_prediction_id == 42
+
+    def test_sets_first_seen_date_to_today(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.register_tickers(["MSFT"])
+
+        added_obj = session.add.call_args[0][0]
+        assert added_obj.first_seen_date == date.today()
+
+    def test_default_status_is_active(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.register_tickers(["GOOG"])
+
+        added_obj = session.add.call_args[0][0]
+        assert added_obj.status == "active"
+
+    def test_handles_integrity_error(self):
+        from sqlalchemy.exc import IntegrityError
+
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+        session.commit.side_effect = IntegrityError("dup", {}, None)
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL"])
+
+        # Should not raise, should rollback
+        session.rollback.assert_called_once()
+
+
+class TestGetNewTickers:
+    """Tests for TickerRegistryService.get_new_tickers."""
+
+    def test_returns_unknown_tickers(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.all.return_value = [("AAPL",)]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_new_tickers(["AAPL", "NVDA"])
+
+        assert result == ["NVDA"]
+
+    def test_returns_empty_when_all_known(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.all.return_value = [
+            ("AAPL",),
+            ("TSLA",),
+        ]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_new_tickers(["AAPL", "TSLA"])
+
+        assert result == []
+
+    def test_handles_empty_input(self):
+        service = TickerRegistryService()
+        result = service.get_new_tickers([])
+        assert result == []
+
+    def test_uppercases_before_comparison(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.all.return_value = [("AAPL",)]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_new_tickers(["aapl", "nvda"])
+
+        # aapl is known (uppercased match), nvda is new
+        assert result == ["nvda"]
+
+
+class TestGetActiveTickers:
+    """Tests for TickerRegistryService.get_active_tickers."""
+
+    def test_returns_only_active_tickers(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.all.return_value = [
+            ("AAPL",),
+            ("TSLA",),
+        ]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_active_tickers()
+
+        assert result == ["AAPL", "TSLA"]
+
+    def test_returns_empty_when_no_active(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.all.return_value = []
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_active_tickers()
+
+        assert result == []
+
+
+class TestMarkTickerInvalid:
+    """Tests for TickerRegistryService.mark_ticker_invalid."""
+
+    def test_marks_existing_ticker_invalid(self):
+        ctx, session = _mock_session()
+        entry = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = entry
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.mark_ticker_invalid("FAKE", "no data")
+
+        assert entry.status == "invalid"
+        assert entry.status_reason == "no data"
+
+    def test_sets_status_reason(self):
+        ctx, session = _mock_session()
+        entry = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = entry
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.mark_ticker_invalid("FAKE", "yfinance returned no price data")
+
+        assert entry.status_reason == "yfinance returned no price data"
+
+    def test_handles_nonexistent_ticker_gracefully(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            # Should not raise
+            service.mark_ticker_invalid("NOPE", "reason")
+
+        session.commit.assert_not_called()
+
+    def test_truncates_long_reason(self):
+        ctx, session = _mock_session()
+        entry = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = entry
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.mark_ticker_invalid("FAKE", "x" * 300)
+
+        assert len(entry.status_reason) == 255
+
+
+class TestUpdatePriceMetadata:
+    """Tests for TickerRegistryService.update_price_metadata."""
+
+    def test_updates_metadata_from_market_prices(self):
+        ctx, session = _mock_session()
+        entry = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = entry
+
+        stats_result = MagicMock()
+        stats_result.earliest = date(2024, 1, 1)
+        stats_result.latest = date(2024, 12, 31)
+        stats_result.count = 250
+
+        # First query returns entry, second returns stats
+        query_mock = MagicMock()
+        session.query.side_effect = [
+            # First query chain: TickerRegistry lookup
+            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=entry)))),
+            # Second query chain: stats lookup
+            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=stats_result)))),
+        ]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.update_price_metadata("AAPL")
+
+        assert entry.price_data_start == date(2024, 1, 1)
+        assert entry.price_data_end == date(2024, 12, 31)
+        assert entry.total_price_records == 250
+
+    def test_handles_nonexistent_ticker(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            # Should not raise
+            service.update_price_metadata("NOPE")
+
+    def test_handles_zero_price_records(self):
+        ctx, session = _mock_session()
+        entry = MagicMock()
+        stats_result = MagicMock()
+        stats_result.count = 0
+
+        session.query.side_effect = [
+            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=entry)))),
+            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=stats_result)))),
+        ]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            service.update_price_metadata("AAPL")
+
+        # Should not update since count is 0
+        session.commit.assert_not_called()
+
+
+class TestGetRegistryStats:
+    """Tests for TickerRegistryService.get_registry_stats."""
+
+    def test_returns_correct_counts(self):
+        ctx, session = _mock_session()
+        # Each scalar call returns a different count
+        session.query.return_value.scalar.return_value = 10
+        session.query.return_value.filter.return_value.scalar.side_effect = [5, 3, 2]
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_registry_stats()
+
+        assert result["total"] == 10
+        assert result["active"] == 5
+        assert result["invalid"] == 3
+        assert result["inactive"] == 2
+
+    def test_returns_zeros_when_empty(self):
+        ctx, session = _mock_session()
+        session.query.return_value.scalar.return_value = 0
+        session.query.return_value.filter.return_value.scalar.return_value = 0
+
+        with patch(SESSION_PATCH, return_value=ctx):
+            service = TickerRegistryService()
+            result = service.get_registry_stats()
+
+        assert result["total"] == 0
+        assert result["active"] == 0
+        assert result["invalid"] == 0
+        assert result["inactive"] == 0

--- a/shit_tests/shitpost_ai/test_reactive_backfill.py
+++ b/shit_tests/shitpost_ai/test_reactive_backfill.py
@@ -1,0 +1,149 @@
+"""
+Tests for reactive backfill integration in shitpost_ai/shitpost_analyzer.py.
+
+Tests the _trigger_reactive_backfill method and its integration with _analyze_shitpost.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer
+
+BACKFILL_PATCH = "shitpost_ai.shitpost_analyzer.auto_backfill_prediction"
+
+
+class TestTriggerReactiveBackfill:
+    """Tests for ShitpostAnalyzer._trigger_reactive_backfill."""
+
+    @pytest.fixture
+    def analyzer(self):
+        """Create an analyzer instance without initializing DB/LLM."""
+        with patch("shitpost_ai.shitpost_analyzer.settings") as mock_settings:
+            mock_settings.DATABASE_URL = "sqlite:///:memory:"
+            mock_settings.SYSTEM_LAUNCH_DATE = "2024-01-01"
+            a = ShitpostAnalyzer()
+        return a
+
+    @pytest.mark.asyncio
+    async def test_calls_auto_backfill_prediction_with_correct_id(self, analyzer):
+        with patch(BACKFILL_PATCH, return_value=True) as mock_bf:
+            await analyzer._trigger_reactive_backfill(42, ["AAPL", "TSLA"])
+        mock_bf.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_logs_success_on_backfill(self, analyzer):
+        with patch(BACKFILL_PATCH, return_value=True):
+            with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
+                await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+                # Should log info for successful backfill
+                mock_logger.info.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_logs_debug_when_no_new_data_needed(self, analyzer):
+        with patch(BACKFILL_PATCH, return_value=False):
+            with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
+                await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+                mock_logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_catches_exception_and_logs_warning(self, analyzer):
+        with patch(BACKFILL_PATCH, side_effect=Exception("boom")):
+            with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
+                # Should not raise
+                await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+                mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_propagate_backfill_errors(self, analyzer):
+        with patch(BACKFILL_PATCH, side_effect=RuntimeError("db down")):
+            # This should not raise any exceptions
+            await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+
+
+class TestAnalyzeShitpostReactiveIntegration:
+    """Tests for _analyze_shitpost integration with reactive backfill."""
+
+    @pytest.fixture
+    def analyzer(self):
+        """Create a fully mocked analyzer."""
+        with patch("shitpost_ai.shitpost_analyzer.settings") as mock_settings:
+            mock_settings.DATABASE_URL = "sqlite:///:memory:"
+            mock_settings.SYSTEM_LAUNCH_DATE = "2024-01-01"
+            a = ShitpostAnalyzer()
+
+        a.bypass_service = MagicMock()
+        a.bypass_service.should_bypass_post.return_value = (False, None)
+        a.llm_client = AsyncMock()
+        a.prediction_ops = AsyncMock()
+        return a
+
+    def _make_shitpost(self, shitpost_id="post_123"):
+        return {
+            "shitpost_id": shitpost_id,
+            "text": "AAPL is going to the moon!",
+            "username": "testuser",
+            "timestamp": "2024-01-15T12:00:00Z",
+            "replies_count": 10,
+            "reblogs_count": 5,
+            "favourites_count": 20,
+            "upvotes_count": 15,
+            "account_verified": True,
+            "account_followers_count": 1000,
+            "has_media": False,
+            "mentions": [],
+            "tags": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_triggers_backfill_after_successful_analysis(self, analyzer):
+        analysis = {"assets": ["AAPL"], "confidence": 0.85, "thesis": "bullish"}
+        analyzer.llm_client.analyze.return_value = analysis
+        analyzer.prediction_ops.store_analysis.return_value = "42"
+
+        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+            await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
+            mock_bf.assert_called_once_with(42, ["AAPL"])
+
+    @pytest.mark.asyncio
+    async def test_does_not_trigger_backfill_on_dry_run(self, analyzer):
+        analysis = {"assets": ["AAPL"], "confidence": 0.85}
+        analyzer.llm_client.analyze.return_value = analysis
+
+        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+            await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=True)
+            mock_bf.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_trigger_backfill_when_no_assets(self, analyzer):
+        analysis = {"assets": [], "confidence": 0.3}
+        analyzer.llm_client.analyze.return_value = analysis
+        analyzer.prediction_ops.store_analysis.return_value = "42"
+
+        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+            await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
+            mock_bf.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_trigger_backfill_when_store_fails(self, analyzer):
+        analysis = {"assets": ["AAPL"], "confidence": 0.85}
+        analyzer.llm_client.analyze.return_value = analysis
+        analyzer.prediction_ops.store_analysis.return_value = None
+
+        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+            await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
+            mock_bf.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_trigger_backfill_for_bypassed_posts(self, analyzer):
+        analyzer.bypass_service.should_bypass_post.return_value = (True, "retruth")
+        analyzer.prediction_ops.handle_no_text_prediction = AsyncMock()
+
+        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+            result = await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
+            mock_bf.assert_not_called()
+            assert result["analysis_status"] == "bypassed"


### PR DESCRIPTION
## Summary
- **TickerRegistry model + service**: New `ticker_registry` table tracks every ticker symbol the system encounters — status (active/inactive/invalid), source prediction, price metadata
- **Reactive backfill**: `ShitpostAnalyzer._trigger_reactive_backfill()` runs sync backfill in a thread executor immediately after storing a prediction with assets — closes the measurement gap
- **AutoBackfillService integration**: Registers tickers on process, updates registry metadata on successful backfill, marks tickers invalid when yfinance returns no data
- **CLI commands**: `ticker-registry` (view/filter tracked tickers) and `register-tickers` (manual registration)
- **Railway cron optimization**: Reduced `--days-back` from 30 to 7 since reactive backfill handles new predictions immediately
- **Planning docs**: Includes all 7 system-evolution phase design documents

## Test plan
- [x] 27 tests for `TickerRegistryService` (register, query, invalidate, metadata, stats)
- [x] 18 tests for `AutoBackfillService` with registry integration
- [x] 10 tests for reactive backfill in analyzer (success, dry-run, no assets, store failure, bypass)
- [x] 55 new tests total, 0 regressions (1448 passed, 10 pre-existing failures)
- [ ] Post-merge: verify `market-data` cron service on Railway dashboard
- [ ] Post-merge: run `CREATE TABLE ticker_registry ...` on Neon production DB (or `create_tables()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)