### PR TITLE
feat: deploy Telegram alert system to production (bot + cron + webhook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Telegram Alert Deployment** - Deployed notification system to production
+  - Notifications cron service in Railway (`*/2 * * * *`) for automated alert dispatch
+  - Health check endpoint at `/telegram/health` for monitoring alert system status
+  - `TelegramSubscription` added to `create_tables()` for automatic table creation
 - **Reactive Ticker Lifecycle** - LLM analyzer now triggers market data backfill immediately when a prediction contains new tickers
   - New `ticker_registry` database table tracks all ticker symbols the system has ever encountered
   - `TickerRegistryService` manages ticker lifecycle (active/inactive/invalid status)
@@ -27,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `test_client.py` (22 tests) — init, context manager, `_get_existing_prices`, `fetch_price_history`, `get_price_on_date`, `get_latest_price`, `update_prices_for_symbols`, `get_price_stats`; coverage 76%
   - `test_sync_session.py` (9 tests) — `get_session()` commit/rollback/close lifecycle, operation ordering, exception re-raise, `create_tables()`; coverage 97%
   - `test_models.py` (25 tests) — `PredictionOutcome.calculate_return()`, `.is_correct()`, `.calculate_pnl()` with edge cases and boundary values
+
+### Fixed
+- **Telegram Markdown Parsing** - Changed default `parse_mode` from `Markdown` (v1) to `MarkdownV2` in `send_telegram_message()` to match bot response escaping
+  - Escaped parentheses, dots, and other MarkdownV2 special characters in `format_telegram_alert()` template
 
 ### Changed
 - **Logging Migration** - Migrated all remaining modules to centralized logging system (`get_service_logger`)

--- a/documentation/TELEGRAM_SETUP_GUIDE.md
+++ b/documentation/TELEGRAM_SETUP_GUIDE.md
@@ -178,7 +178,7 @@ In `railway.json`, add a service:
 }
 ```
 
-> **Note (2026-02-10)**: This cron service is not yet added to `railway.json`. The webhook endpoint works (commands are processed when users message the bot), but automated alert dispatch requires adding this cron service to Railway.
+> **Deployed (2026-02-11)**: The notifications cron service is active in `railway.json` running every 2 minutes. The health check endpoint is available at `/telegram/health`.
 
 ---
 
@@ -369,6 +369,30 @@ python -m notifications stats
 | Channel not receiving alerts | Ensure bot is admin with Post Messages permission, and the channel `chat_id` is in the DB |
 | `consecutive_errors` too high | Reset in DB: `UPDATE telegram_subscriptions SET consecutive_errors = 0 WHERE chat_id = 'xxx'` |
 | Webhook SSL error | Telegram requires HTTPS. Railway provides this automatically. For local dev, use ngrok. |
+
+---
+
+## Health Check
+
+Monitor the alert system status:
+
+```bash
+curl https://<dashboard-domain>.railway.app/telegram/health
+```
+
+Response:
+```json
+{
+  "ok": true,
+  "service": "telegram_alerts",
+  "bot_configured": true,
+  "subscribers": {"total": 5, "active": 3},
+  "last_alert_check": "2026-02-11T10:30:00",
+  "total_alerts_sent": 42
+}
+```
+
+A `200` status with `"ok": true` means the system is healthy. A `503` status indicates a problem (database unreachable, missing token, etc.).
 
 ---
 

--- a/notifications/telegram_sender.py
+++ b/notifications/telegram_sender.py
@@ -26,7 +26,7 @@ def get_bot_token() -> Optional[str]:
 def send_telegram_message(
     chat_id: str,
     text: str,
-    parse_mode: str = "Markdown",
+    parse_mode: str = "MarkdownV2",
     disable_notification: bool = False,
     reply_markup: Optional[Dict] = None,
 ) -> Tuple[bool, Optional[str]]:
@@ -36,7 +36,7 @@ def send_telegram_message(
     Args:
         chat_id: Telegram chat ID.
         text: Message text (supports Markdown).
-        parse_mode: "Markdown" or "HTML".
+        parse_mode: "MarkdownV2", "Markdown", or "HTML".
         disable_notification: Send silently.
         reply_markup: Optional inline keyboard.
 
@@ -125,9 +125,9 @@ def format_telegram_alert(alert: Dict[str, Any]) -> str:
     """
     sentiment = alert.get("sentiment", "neutral").upper()
     confidence = alert.get("confidence", 0)
-    confidence_pct = f"{confidence:.0%}" if confidence else "N/A"
+    confidence_pct = escape_markdown(f"{confidence:.0%}") if confidence else "N/A"
     assets = alert.get("assets", [])
-    assets_str = ", ".join(assets[:5]) if assets else "None specified"
+    assets_str = escape_markdown(", ".join(assets[:5])) if assets else "None specified"
     text = alert.get("text", "")[:300]
     thesis = alert.get("thesis", "")[:200]
 
@@ -141,7 +141,7 @@ def format_telegram_alert(alert: Dict[str, Any]) -> str:
     message = f"""
 {emoji} *SHITPOST ALPHA ALERT*
 
-*Sentiment:* {sentiment} ({confidence_pct} confidence)
+*Sentiment:* {sentiment} \\({confidence_pct} confidence\\)
 *Assets:* {assets_str}
 
 \U0001f4dd *Post:*
@@ -150,7 +150,7 @@ _{escape_markdown(text)}_
 \U0001f4a1 *Thesis:*
 {escape_markdown(thesis)}
 
-\u26a0\ufe0f _This is NOT financial advice. For entertainment only._
+\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
 """
     return message.strip()
 

--- a/railway.json
+++ b/railway.json
@@ -29,6 +29,11 @@
       "source": ".",
       "startCommand": "python -m shit.market_data auto-pipeline --days-back 7",
       "cronSchedule": "*/15 * * * *"
+    },
+    "notifications": {
+      "source": ".",
+      "startCommand": "python -m notifications check-alerts",
+      "cronSchedule": "*/2 * * * *"
     }
   }
 }

--- a/shit/db/sync_session.py
+++ b/shit/db/sync_session.py
@@ -74,7 +74,8 @@ def create_tables():
         Prediction,
         MarketMovement,
         Subscriber,
-        LLMFeedback
+        LLMFeedback,
+        TelegramSubscription,
     )
     from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
 


### PR DESCRIPTION
## Summary
- **Fixed MarkdownV2 parse mode bug** — Changed default `parse_mode` from `Markdown` (v1) to `MarkdownV2` in `send_telegram_message()`, escaped parentheses/dots/special chars in `format_telegram_alert()` template
- **Added notifications cron service** to `railway.json` (`*/2 * * * *`) for automated alert dispatch
- **Added `/telegram/health` endpoint** to the dashboard for monitoring alert system status (bot config, subscriber counts, last check time)
- **Added `TelegramSubscription`** to `create_tables()` import list in `sync_session.py`
- **Updated setup guide** — deployment status note, added Health Check section

## Files Changed
| File | Change |
|------|--------|
| `notifications/telegram_sender.py` | Fix parse_mode default, escape MarkdownV2 special chars |
| `railway.json` | Add notifications cron service |
| `shitty_ui/app.py` | Add `/telegram/health` endpoint |
| `shit/db/sync_session.py` | Add TelegramSubscription to create_tables |
| `documentation/TELEGRAM_SETUP_GUIDE.md` | Update deployment status, add health check docs |
| `CHANGELOG.md` | Add deployment and fix entries |
| `shit_tests/notifications/test_telegram_sender.py` | 5 new tests for MarkdownV2 behavior |

## Test plan
- [x] All 102 notification tests pass
- [x] All 32 shitty_ui telegram tests pass
- [x] Full suite: 1453 passed (10 pre-existing failures unchanged)
- [x] New tests verify: default parse_mode is MarkdownV2, explicit v1 override works, parentheses escaped, dots escaped, special chars in assets escaped

## Post-merge deployment steps
- [ ] Create bot via BotFather and get token
- [ ] Set `TELEGRAM_BOT_TOKEN` in Railway env vars (both dashboard and notifications services)
- [ ] Verify `telegram_subscriptions` table exists in production
- [ ] Register webhook: `python -m notifications set-webhook https://<url>/telegram/webhook`
- [ ] Verify health endpoint: `curl https://<url>/telegram/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)