### PR TITLE
feat: add Grok/xAI provider and provider comparison tooling for LLM analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Grok/xAI LLM Provider** - Added xAI's Grok as a third LLM provider option
+  - Uses OpenAI-compatible API with custom `base_url` (`https://api.x.ai/v1`)
+  - Supports `grok-2` and `grok-2-mini` models
+  - Configure with `LLM_PROVIDER=grok` and `XAI_API_KEY`
+- **Provider Configuration Module** (`shit/llm/provider_config.py`) - Centralized provider metadata with model costs, rate limits, and recommendations
+- **Provider Comparison CLI** - Run `python -m shitpost_ai compare` to analyze content across multiple providers side-by-side
+  - Measures latency, asset extraction, sentiment agreement, and confidence spread
+  - Supports `--list-providers` to see all models and pricing
 - **Telegram Alert Deployment** - Deployed notification system to production
   - Notifications cron service in Railway (`*/2 * * * *`) for automated alert dispatch
   - Health check endpoint at `/telegram/health` for monitoring alert system status
@@ -37,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Escaped parentheses, dots, and other MarkdownV2 special characters in `format_telegram_alert()` template
 
 ### Changed
+- **LLMClient Multi-Provider Routing** - Refactored to use SDK-type routing instead of provider-name routing
+  - Grok routes through OpenAI SDK with custom `base_url`
+  - Added `base_url` parameter for OpenAI-compatible providers
+- **Anthropic SDK** - Updated minimum version from `0.7.0` to `0.40.0` for latest model support
 - **Logging Migration** - Migrated all remaining modules to centralized logging system (`get_service_logger`)
   - 15 files migrated from `logging.getLogger(__name__)` to `get_service_logger("name")`
   - 4 already-migrated shitvault files cleaned up (removed stale `import logging`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ boto3>=1.26.0
 
 # LLM providers
 openai>=1.0.0
-anthropic>=0.7.0
+anthropic>=0.40.0
 
 # Database
 psycopg[binary]>=3.2.0  # For PostgreSQL async support

--- a/shit/config/shitpost_settings.py
+++ b/shit/config/shitpost_settings.py
@@ -35,8 +35,10 @@ class Settings(BaseSettings):
     # LLM Configuration
     OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
     ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
-    LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic
+    XAI_API_KEY: Optional[str] = Field(default=None, env="XAI_API_KEY")
+    LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic, grok
     LLM_MODEL: str = Field(default="gpt-4", env="LLM_MODEL")
+    LLM_BASE_URL: Optional[str] = Field(default=None, env="LLM_BASE_URL")  # Custom base URL for OpenAI-compatible APIs
 
     # Truth Social Shitpost Configuration
     TRUTH_SOCIAL_USERNAME: str = Field(
@@ -125,8 +127,26 @@ class Settings(BaseSettings):
                     "ANTHROPIC_API_KEY is required when LLM_PROVIDER is 'anthropic'"
                 )
             return self.ANTHROPIC_API_KEY
+        elif self.LLM_PROVIDER == "grok":
+            if not self.XAI_API_KEY:
+                raise ValueError(
+                    "XAI_API_KEY is required when LLM_PROVIDER is 'grok'"
+                )
+            return self.XAI_API_KEY
         else:
             raise ValueError(f"Unsupported LLM provider: {self.LLM_PROVIDER}")
+
+    def get_llm_base_url(self) -> Optional[str]:
+        """Get the base URL for the LLM provider, if applicable.
+
+        Returns:
+            Base URL string for OpenAI-compatible providers, or None for native SDKs.
+        """
+        if self.LLM_BASE_URL:
+            return self.LLM_BASE_URL
+        if self.LLM_PROVIDER == "grok":
+            return "https://api.x.ai/v1"
+        return None
 
     def is_production(self) -> bool:
         """Check if running in production environment."""

--- a/shit/llm/__init__.py
+++ b/shit/llm/__init__.py
@@ -9,14 +9,18 @@ from .prompts import (
     get_detailed_analysis_prompt,
     get_sector_analysis_prompt,
     get_crypto_analysis_prompt,
-    get_alert_prompt
+    get_alert_prompt,
 )
+from .provider_config import PROVIDERS, get_provider, get_recommended_model
 
 __all__ = [
-    'LLMClient',
-    'get_analysis_prompt',
-    'get_detailed_analysis_prompt',
-    'get_sector_analysis_prompt',
-    'get_crypto_analysis_prompt',
-    'get_alert_prompt'
+    "LLMClient",
+    "get_analysis_prompt",
+    "get_detailed_analysis_prompt",
+    "get_sector_analysis_prompt",
+    "get_crypto_analysis_prompt",
+    "get_alert_prompt",
+    "PROVIDERS",
+    "get_provider",
+    "get_recommended_model",
 ]

--- a/shit/llm/compare_providers.py
+++ b/shit/llm/compare_providers.py
@@ -1,0 +1,255 @@
+"""
+LLM Provider Comparison
+Run the same content through multiple providers and compare results.
+"""
+
+import asyncio
+import time
+from typing import Dict, List, Optional
+from dataclasses import dataclass, field
+
+from shit.llm.llm_client import LLMClient
+from shit.llm.provider_config import PROVIDERS, get_provider, get_recommended_model
+from shit.logging import get_service_logger
+
+logger = get_service_logger("llm_compare")
+
+
+@dataclass
+class ProviderResult:
+    """Result from a single provider analysis."""
+    provider: str
+    model: str
+    assets: List[str] = field(default_factory=list)
+    market_impact: Dict[str, str] = field(default_factory=dict)
+    confidence: float = 0.0
+    thesis: str = ""
+    latency_ms: float = 0.0
+    success: bool = True
+    error: Optional[str] = None
+    raw_response: Optional[Dict] = None
+
+
+@dataclass
+class ComparisonResult:
+    """Comparison result across multiple providers."""
+    content: str
+    results: List[ProviderResult] = field(default_factory=list)
+    asset_agreement: float = 0.0  # 0.0-1.0, how much providers agree on assets
+    sentiment_agreement: float = 0.0  # 0.0-1.0, how much providers agree on sentiment
+    confidence_spread: float = 0.0  # Difference between max and min confidence
+
+
+class ProviderComparator:
+    """Compare LLM provider analysis results."""
+
+    def __init__(self, providers: Optional[List[str]] = None):
+        """Initialize comparator with provider list.
+
+        Args:
+            providers: List of provider IDs to compare.
+                       Defaults to all providers with available API keys.
+        """
+        self.provider_ids = providers or list(PROVIDERS.keys())
+        self.clients: Dict[str, LLMClient] = {}
+
+    async def initialize(self) -> List[str]:
+        """Initialize LLM clients for all specified providers.
+
+        Returns:
+            List of provider IDs that were successfully initialized.
+        """
+        initialized = []
+
+        for provider_id in self.provider_ids:
+            try:
+                provider_config = get_provider(provider_id)
+                # Determine API key from settings
+                from shit.config.shitpost_settings import Settings
+                s = Settings()
+
+                api_key = getattr(s, provider_config.api_key_env_var, None)
+                if not api_key:
+                    logger.warning(
+                        f"Skipping {provider_id}: no API key found "
+                        f"(set {provider_config.api_key_env_var})"
+                    )
+                    continue
+
+                model_config = get_recommended_model(provider_id)
+                model_id = model_config.model_id if model_config else None
+
+                base_url = provider_config.base_url
+
+                client = LLMClient(
+                    provider=provider_id,
+                    model=model_id,
+                    api_key=api_key,
+                    base_url=base_url,
+                )
+                await client.initialize()
+                self.clients[provider_id] = client
+                initialized.append(provider_id)
+                logger.info(f"Initialized {provider_id} with model {model_id}")
+
+            except Exception as e:
+                logger.warning(f"Failed to initialize {provider_id}: {e}")
+
+        return initialized
+
+    async def compare(self, content: str) -> ComparisonResult:
+        """Run content through all initialized providers and compare results.
+
+        Args:
+            content: Content to analyze
+
+        Returns:
+            ComparisonResult with per-provider results and agreement metrics
+        """
+        comparison = ComparisonResult(content=content)
+
+        # Run all providers concurrently
+        tasks = []
+        for provider_id, client in self.clients.items():
+            tasks.append(self._analyze_with_provider(provider_id, client, content))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error(f"Provider comparison error: {result}")
+                continue
+            comparison.results.append(result)
+
+        # Calculate agreement metrics
+        self._calculate_agreement(comparison)
+
+        return comparison
+
+    async def _analyze_with_provider(
+        self, provider_id: str, client: LLMClient, content: str
+    ) -> ProviderResult:
+        """Analyze content with a single provider, capturing timing."""
+        result = ProviderResult(provider=provider_id, model=client.model)
+
+        start_time = time.monotonic()
+        try:
+            analysis = await client.analyze(content)
+            result.latency_ms = (time.monotonic() - start_time) * 1000
+
+            if analysis:
+                result.assets = analysis.get("assets", [])
+                result.market_impact = analysis.get("market_impact", {})
+                result.confidence = analysis.get("confidence", 0.0)
+                result.thesis = analysis.get("thesis", "")
+                result.raw_response = analysis
+                result.success = True
+            else:
+                result.success = False
+                result.error = "Analysis returned None"
+
+        except Exception as e:
+            result.latency_ms = (time.monotonic() - start_time) * 1000
+            result.success = False
+            result.error = str(e)
+
+        return result
+
+    def _calculate_agreement(self, comparison: ComparisonResult) -> None:
+        """Calculate agreement metrics across providers."""
+        successful = [r for r in comparison.results if r.success]
+
+        if len(successful) < 2:
+            return
+
+        # Asset agreement: Jaccard similarity of asset sets
+        all_asset_sets = [set(r.assets) for r in successful]
+        if any(s for s in all_asset_sets):  # At least one non-empty
+            union = set().union(*all_asset_sets)
+            intersection = set(all_asset_sets[0])
+            for s in all_asset_sets[1:]:
+                intersection = intersection.intersection(s)
+            comparison.asset_agreement = (
+                len(intersection) / len(union) if union else 1.0
+            )
+        else:
+            comparison.asset_agreement = 1.0  # All agree: no assets
+
+        # Sentiment agreement: compare market_impact values
+        common_assets = set()
+        for r in successful:
+            common_assets.update(r.market_impact.keys())
+
+        if common_assets:
+            agreements = 0
+            comparisons = 0
+            for asset in common_assets:
+                sentiments = [
+                    r.market_impact.get(asset)
+                    for r in successful
+                    if asset in r.market_impact
+                ]
+                if len(sentiments) >= 2:
+                    for i in range(len(sentiments)):
+                        for j in range(i + 1, len(sentiments)):
+                            comparisons += 1
+                            if sentiments[i] == sentiments[j]:
+                                agreements += 1
+            comparison.sentiment_agreement = (
+                agreements / comparisons if comparisons else 1.0
+            )
+
+        # Confidence spread
+        confidences = [r.confidence for r in successful]
+        comparison.confidence_spread = max(confidences) - min(confidences)
+
+
+def format_comparison_report(comparison: ComparisonResult) -> str:
+    """Format a comparison result as a human-readable report.
+
+    Args:
+        comparison: ComparisonResult to format
+
+    Returns:
+        Formatted string report
+    """
+    lines = []
+    lines.append("=" * 70)
+    lines.append("LLM PROVIDER COMPARISON REPORT")
+    lines.append("=" * 70)
+    lines.append("")
+
+    content_preview = (
+        comparison.content[:100] + "..."
+        if len(comparison.content) > 100
+        else comparison.content
+    )
+    lines.append(f"Content: {content_preview}")
+    lines.append("")
+
+    for result in comparison.results:
+        lines.append(f"--- {result.provider.upper()} ({result.model}) ---")
+        if result.success:
+            lines.append(
+                f"  Assets:     {', '.join(result.assets) if result.assets else 'None'}"
+            )
+            lines.append(f"  Impact:     {result.market_impact}")
+            lines.append(f"  Confidence: {result.confidence:.1%}")
+            lines.append(f"  Latency:    {result.latency_ms:.0f}ms")
+            thesis_preview = (
+                result.thesis[:120] + "..."
+                if len(result.thesis) > 120
+                else result.thesis
+            )
+            lines.append(f"  Thesis:     {thesis_preview}")
+        else:
+            lines.append(f"  ERROR: {result.error}")
+        lines.append("")
+
+    lines.append("--- AGREEMENT METRICS ---")
+    lines.append(f"  Asset Agreement:     {comparison.asset_agreement:.1%}")
+    lines.append(f"  Sentiment Agreement: {comparison.sentiment_agreement:.1%}")
+    lines.append(f"  Confidence Spread:   {comparison.confidence_spread:.2f}")
+    lines.append("=" * 70)
+
+    return "\n".join(lines)

--- a/shit/llm/provider_config.py
+++ b/shit/llm/provider_config.py
@@ -1,0 +1,186 @@
+"""
+LLM Provider Configuration
+Centralized provider metadata for model selection and cost tracking.
+"""
+
+from typing import Dict, Optional, List
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a specific LLM model."""
+    model_id: str
+    display_name: str
+    input_cost_per_1m_tokens: float  # USD per 1M input tokens
+    output_cost_per_1m_tokens: float  # USD per 1M output tokens
+    max_output_tokens: int
+    context_window: int
+    recommended: bool = False
+    notes: str = ""
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for an LLM provider."""
+    provider_id: str  # 'openai', 'anthropic', 'grok'
+    display_name: str
+    base_url: Optional[str]  # None for providers with built-in SDK support
+    api_key_env_var: str  # Environment variable name for API key
+    sdk_type: str  # 'openai' or 'anthropic' -- which SDK to use
+    models: List[ModelConfig] = field(default_factory=list)
+    rate_limit_rpm: int = 60  # Requests per minute
+    notes: str = ""
+
+
+# --- Provider Definitions ---
+
+OPENAI_MODELS = [
+    ModelConfig(
+        model_id="gpt-4o",
+        display_name="GPT-4o",
+        input_cost_per_1m_tokens=2.50,
+        output_cost_per_1m_tokens=10.00,
+        max_output_tokens=16384,
+        context_window=128000,
+        recommended=True,
+        notes="Best balance of cost and quality for production use",
+    ),
+    ModelConfig(
+        model_id="gpt-4o-mini",
+        display_name="GPT-4o Mini",
+        input_cost_per_1m_tokens=0.15,
+        output_cost_per_1m_tokens=0.60,
+        max_output_tokens=16384,
+        context_window=128000,
+        notes="Cheapest OpenAI option, good for testing",
+    ),
+    ModelConfig(
+        model_id="gpt-4",
+        display_name="GPT-4",
+        input_cost_per_1m_tokens=30.00,
+        output_cost_per_1m_tokens=60.00,
+        max_output_tokens=8192,
+        context_window=8192,
+        notes="Legacy model, expensive. Consider migrating to gpt-4o",
+    ),
+]
+
+ANTHROPIC_MODELS = [
+    ModelConfig(
+        model_id="claude-sonnet-4-20250514",
+        display_name="Claude Sonnet 4",
+        input_cost_per_1m_tokens=3.00,
+        output_cost_per_1m_tokens=15.00,
+        max_output_tokens=8192,
+        context_window=200000,
+        recommended=True,
+        notes="Best quality/cost ratio for structured analysis",
+    ),
+    ModelConfig(
+        model_id="claude-haiku-3-5-20241022",
+        display_name="Claude 3.5 Haiku",
+        input_cost_per_1m_tokens=0.80,
+        output_cost_per_1m_tokens=4.00,
+        max_output_tokens=8192,
+        context_window=200000,
+        notes="Fast and cheap, good for high-volume analysis",
+    ),
+]
+
+GROK_MODELS = [
+    ModelConfig(
+        model_id="grok-2",
+        display_name="Grok 2",
+        input_cost_per_1m_tokens=2.00,
+        output_cost_per_1m_tokens=10.00,
+        max_output_tokens=8192,
+        context_window=131072,
+        recommended=True,
+        notes="Strong social media context, native X/Truth Social understanding",
+    ),
+    ModelConfig(
+        model_id="grok-2-mini",
+        display_name="Grok 2 Mini",
+        input_cost_per_1m_tokens=0.10,
+        output_cost_per_1m_tokens=0.40,
+        max_output_tokens=8192,
+        context_window=131072,
+        notes="Cheapest option, experimental quality",
+    ),
+]
+
+PROVIDERS: Dict[str, ProviderConfig] = {
+    "openai": ProviderConfig(
+        provider_id="openai",
+        display_name="OpenAI",
+        base_url=None,  # Uses default OpenAI API
+        api_key_env_var="OPENAI_API_KEY",
+        sdk_type="openai",
+        models=OPENAI_MODELS,
+        rate_limit_rpm=60,
+        notes="Current production provider",
+    ),
+    "anthropic": ProviderConfig(
+        provider_id="anthropic",
+        display_name="Anthropic",
+        base_url=None,  # Uses native Anthropic SDK
+        api_key_env_var="ANTHROPIC_API_KEY",
+        sdk_type="anthropic",
+        models=ANTHROPIC_MODELS,
+        rate_limit_rpm=60,
+        notes="Alternative provider with strong structured output",
+    ),
+    "grok": ProviderConfig(
+        provider_id="grok",
+        display_name="xAI (Grok)",
+        base_url="https://api.x.ai/v1",
+        api_key_env_var="XAI_API_KEY",
+        sdk_type="openai",  # Grok uses OpenAI-compatible API
+        models=GROK_MODELS,
+        rate_limit_rpm=60,
+        notes="xAI's model with strong social media/political context",
+    ),
+}
+
+
+def get_provider(provider_id: str) -> ProviderConfig:
+    """Get provider configuration by ID.
+
+    Args:
+        provider_id: Provider identifier ('openai', 'anthropic', 'grok')
+
+    Returns:
+        ProviderConfig for the specified provider
+
+    Raises:
+        ValueError: If provider_id is not supported
+    """
+    if provider_id not in PROVIDERS:
+        supported = ", ".join(PROVIDERS.keys())
+        raise ValueError(
+            f"Unsupported provider: '{provider_id}'. "
+            f"Supported providers: {supported}"
+        )
+    return PROVIDERS[provider_id]
+
+
+def get_recommended_model(provider_id: str) -> Optional[ModelConfig]:
+    """Get the recommended model for a provider.
+
+    Args:
+        provider_id: Provider identifier
+
+    Returns:
+        Recommended ModelConfig, or first model if none marked recommended
+    """
+    provider = get_provider(provider_id)
+    for model in provider.models:
+        if model.recommended:
+            return model
+    return provider.models[0] if provider.models else None
+
+
+def get_all_provider_ids() -> List[str]:
+    """Get list of all supported provider IDs."""
+    return list(PROVIDERS.keys())

--- a/shit_tests/conftest.py
+++ b/shit_tests/conftest.py
@@ -551,6 +551,7 @@ def setup_test_environment():
     os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
     os.environ['OPENAI_API_KEY'] = 'test_openai_key'
     os.environ['ANTHROPIC_API_KEY'] = 'test_anthropic_key'
+    os.environ['XAI_API_KEY'] = 'test_xai_key'
     os.environ['LLM_PROVIDER'] = 'openai'
     os.environ['LLM_MODEL'] = 'gpt-4'
     os.environ['TRUTH_SOCIAL_USERNAME'] = 'realDonaldTrump'
@@ -561,8 +562,8 @@ def setup_test_environment():
     yield
     
     # Cleanup
-    for key in ['ENVIRONMENT', 'DEBUG', 'DATABASE_URL', 'OPENAI_API_KEY', 
-                'ANTHROPIC_API_KEY', 'LLM_PROVIDER', 'LLM_MODEL', 
+    for key in ['ENVIRONMENT', 'DEBUG', 'DATABASE_URL', 'OPENAI_API_KEY',
+                'ANTHROPIC_API_KEY', 'XAI_API_KEY', 'LLM_PROVIDER', 'LLM_MODEL',
                 'TRUTH_SOCIAL_USERNAME', 'TRUTH_SOCIAL_MONITOR_INTERVAL',
                 'CONFIDENCE_THRESHOLD', 'MAX_POST_LENGTH']:
         if key in os.environ:

--- a/shit_tests/shit/llm/test_compare_providers.py
+++ b/shit_tests/shit/llm/test_compare_providers.py
@@ -1,0 +1,142 @@
+"""
+Tests for LLM provider comparison module.
+"""
+
+import pytest
+
+from shit.llm.compare_providers import (
+    ComparisonResult,
+    ProviderComparator,
+    ProviderResult,
+    format_comparison_report,
+)
+
+
+class TestProviderComparator:
+    """Test provider comparison logic."""
+
+    def test_calculate_agreement_identical_results(self):
+        """Perfect agreement when all providers return the same assets/sentiment."""
+        comparison = ComparisonResult(content="test")
+        comparison.results = [
+            ProviderResult(
+                provider="openai",
+                model="gpt-4o",
+                assets=["TSLA", "AAPL"],
+                market_impact={"TSLA": "bullish", "AAPL": "neutral"},
+                confidence=0.85,
+                success=True,
+            ),
+            ProviderResult(
+                provider="anthropic",
+                model="claude-sonnet-4",
+                assets=["TSLA", "AAPL"],
+                market_impact={"TSLA": "bullish", "AAPL": "neutral"},
+                confidence=0.80,
+                success=True,
+            ),
+        ]
+
+        comparator = ProviderComparator()
+        comparator._calculate_agreement(comparison)
+
+        assert comparison.asset_agreement == 1.0
+        assert comparison.sentiment_agreement == 1.0
+        assert comparison.confidence_spread == pytest.approx(0.05)
+
+    def test_calculate_agreement_different_assets(self):
+        """Partial agreement when providers return different assets."""
+        comparison = ComparisonResult(content="test")
+        comparison.results = [
+            ProviderResult(
+                provider="openai",
+                model="gpt-4o",
+                assets=["TSLA", "AAPL"],
+                market_impact={"TSLA": "bullish"},
+                confidence=0.85,
+                success=True,
+            ),
+            ProviderResult(
+                provider="anthropic",
+                model="claude-sonnet-4",
+                assets=["TSLA", "GOOG"],
+                market_impact={"TSLA": "bearish"},
+                confidence=0.70,
+                success=True,
+            ),
+        ]
+
+        comparator = ProviderComparator()
+        comparator._calculate_agreement(comparison)
+
+        # Jaccard: intersection={TSLA} / union={TSLA, AAPL, GOOG} = 1/3
+        assert comparison.asset_agreement == pytest.approx(1 / 3)
+        # Sentiment: TSLA is bullish vs bearish = 0 agreement
+        assert comparison.sentiment_agreement == 0.0
+        assert comparison.confidence_spread == pytest.approx(0.15)
+
+    def test_calculate_agreement_single_result(self):
+        """No agreement calculated with only one result."""
+        comparison = ComparisonResult(content="test")
+        comparison.results = [
+            ProviderResult(
+                provider="openai",
+                model="gpt-4o",
+                assets=["TSLA"],
+                confidence=0.85,
+                success=True,
+            ),
+        ]
+
+        comparator = ProviderComparator()
+        comparator._calculate_agreement(comparison)
+
+        # Defaults remain
+        assert comparison.asset_agreement == 0.0
+        assert comparison.sentiment_agreement == 0.0
+
+    def test_format_comparison_report(self):
+        """Report includes provider names, assets, and agreement metrics."""
+        comparison = ComparisonResult(content="Test content for report")
+        comparison.results = [
+            ProviderResult(
+                provider="openai",
+                model="gpt-4o",
+                assets=["TSLA"],
+                market_impact={"TSLA": "bullish"},
+                confidence=0.85,
+                thesis="Bullish on Tesla",
+                latency_ms=1200,
+                success=True,
+            ),
+        ]
+        comparison.asset_agreement = 1.0
+        comparison.sentiment_agreement = 1.0
+        comparison.confidence_spread = 0.0
+
+        report = format_comparison_report(comparison)
+
+        assert "OPENAI" in report
+        assert "gpt-4o" in report
+        assert "TSLA" in report
+        assert "85.0%" in report
+        assert "1200ms" in report
+        assert "Asset Agreement" in report
+
+    def test_format_report_with_error(self):
+        """Report handles failed provider results."""
+        comparison = ComparisonResult(content="Test")
+        comparison.results = [
+            ProviderResult(
+                provider="grok",
+                model="grok-2",
+                success=False,
+                error="API key invalid",
+            ),
+        ]
+
+        report = format_comparison_report(comparison)
+
+        assert "GROK" in report
+        assert "ERROR" in report
+        assert "API key invalid" in report

--- a/shit_tests/shit/llm/test_llm_client_grok.py
+++ b/shit_tests/shit/llm/test_llm_client_grok.py
@@ -1,0 +1,150 @@
+"""
+Tests for Grok/xAI provider path in LLMClient.
+Grok uses the OpenAI-compatible API with a custom base_url.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shit.llm.llm_client import LLMClient
+
+
+class TestGrokProvider:
+    """Test Grok provider initialization and routing."""
+
+    def test_grok_initialization(self):
+        """Grok provider creates an AsyncOpenAI client with base_url."""
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_openai.return_value = AsyncMock()
+
+            client = LLMClient(
+                provider="grok",
+                model="grok-2",
+                api_key="test-xai-key",
+                base_url="https://api.x.ai/v1",
+            )
+
+            mock_openai.assert_called_once_with(
+                api_key="test-xai-key",
+                base_url="https://api.x.ai/v1",
+            )
+            assert client.provider == "grok"
+            assert client.model == "grok-2"
+            assert client.base_url == "https://api.x.ai/v1"
+
+    def test_grok_uses_openai_sdk(self):
+        """Grok provider routes through the OpenAI SDK type."""
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_openai.return_value = AsyncMock()
+
+            client = LLMClient(
+                provider="grok",
+                model="grok-2",
+                api_key="test-xai-key",
+                base_url="https://api.x.ai/v1",
+            )
+
+            assert client._sdk_type == "openai"
+
+    @pytest.mark.asyncio
+    async def test_grok_call_llm(self):
+        """Grok call routes through OpenAI chat completions path."""
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.return_value = mock_client
+
+            # Mock init and call responses
+            mock_init_response = MagicMock()
+            mock_init_response.choices = [
+                MagicMock(message=MagicMock(content="OK"))
+            ]
+
+            mock_call_response = MagicMock()
+            mock_call_response.choices = [
+                MagicMock(message=MagicMock(content="Grok response"))
+            ]
+
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[mock_init_response, mock_call_response]
+            )
+
+            client = LLMClient(
+                provider="grok",
+                model="grok-2",
+                api_key="test-xai-key",
+                base_url="https://api.x.ai/v1",
+            )
+            await client.initialize()
+
+            result = await client._call_llm("Test prompt")
+            assert result == "Grok response"
+
+    @pytest.mark.asyncio
+    async def test_grok_analyze_produces_correct_metadata(self):
+        """Grok analysis includes provider='grok' in metadata."""
+        sample_response = {
+            "assets": ["TSLA"],
+            "market_impact": {"TSLA": "bullish"},
+            "confidence": 0.8,
+            "thesis": "Test thesis",
+        }
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.return_value = mock_client
+
+            mock_init_response = MagicMock()
+            mock_init_response.choices = [
+                MagicMock(message=MagicMock(content="OK"))
+            ]
+
+            mock_analysis_response = MagicMock()
+            mock_analysis_response.choices = [
+                MagicMock(
+                    message=MagicMock(content=json.dumps(sample_response))
+                )
+            ]
+
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[mock_init_response, mock_analysis_response]
+            )
+
+            client = LLMClient(
+                provider="grok",
+                model="grok-2",
+                api_key="test-xai-key",
+                base_url="https://api.x.ai/v1",
+            )
+            await client.initialize()
+
+            result = await client.analyze(
+                "Tesla is making great American cars!"
+            )
+
+            assert result is not None
+            assert result["llm_provider"] == "grok"
+            assert result["llm_model"] == "grok-2"
+
+    def test_grok_default_base_url_from_settings(self):
+        """Grok gets base_url from settings when not provided explicitly."""
+        with patch("shit.llm.llm_client.settings") as mock_settings:
+            mock_settings.LLM_PROVIDER = "grok"
+            mock_settings.LLM_MODEL = "grok-2"
+            mock_settings.get_llm_api_key.return_value = "test-xai-key"
+            mock_settings.get_llm_base_url.return_value = (
+                "https://api.x.ai/v1"
+            )
+            mock_settings.CONFIDENCE_THRESHOLD = 0.7
+
+            with patch("openai.AsyncOpenAI") as mock_openai:
+                mock_openai.return_value = AsyncMock()
+
+                client = LLMClient()
+
+                assert client.provider == "grok"
+                assert client.base_url == "https://api.x.ai/v1"
+                mock_openai.assert_called_once_with(
+                    api_key="test-xai-key",
+                    base_url="https://api.x.ai/v1",
+                )

--- a/shit_tests/shit/llm/test_provider_config.py
+++ b/shit_tests/shit/llm/test_provider_config.py
@@ -1,0 +1,100 @@
+"""
+Tests for LLM provider configuration module.
+"""
+
+import pytest
+
+from shit.llm.provider_config import (
+    PROVIDERS,
+    ModelConfig,
+    ProviderConfig,
+    get_all_provider_ids,
+    get_provider,
+    get_recommended_model,
+)
+
+
+class TestProviderConfig:
+    """Test provider configuration registry."""
+
+    def test_all_providers_defined(self):
+        """All expected providers exist in PROVIDERS dict."""
+        assert "openai" in PROVIDERS
+        assert "anthropic" in PROVIDERS
+        assert "grok" in PROVIDERS
+
+    def test_get_provider_valid(self):
+        """get_provider returns config for valid provider IDs."""
+        for provider_id in ["openai", "anthropic", "grok"]:
+            config = get_provider(provider_id)
+            assert isinstance(config, ProviderConfig)
+            assert config.provider_id == provider_id
+
+    def test_get_provider_invalid(self):
+        """get_provider raises ValueError for unknown provider."""
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            get_provider("nonexistent")
+
+    def test_grok_uses_openai_sdk(self):
+        """Grok provider uses the OpenAI SDK type."""
+        config = get_provider("grok")
+        assert config.sdk_type == "openai"
+
+    def test_anthropic_uses_anthropic_sdk(self):
+        """Anthropic provider uses the Anthropic SDK type."""
+        config = get_provider("anthropic")
+        assert config.sdk_type == "anthropic"
+
+    def test_each_provider_has_models(self):
+        """Every provider has at least one model defined."""
+        for provider_id, config in PROVIDERS.items():
+            assert len(config.models) > 0, f"{provider_id} has no models"
+
+    def test_each_provider_has_recommended_model(self):
+        """Every provider has a recommended model."""
+        for provider_id in PROVIDERS:
+            model = get_recommended_model(provider_id)
+            assert model is not None, f"{provider_id} has no recommended model"
+            assert isinstance(model, ModelConfig)
+
+    def test_get_all_provider_ids(self):
+        """get_all_provider_ids returns all provider keys."""
+        ids = get_all_provider_ids()
+        assert set(ids) == {"openai", "anthropic", "grok"}
+
+    def test_model_costs_are_positive(self):
+        """All model costs are positive numbers."""
+        for provider_id, config in PROVIDERS.items():
+            for model in config.models:
+                assert model.input_cost_per_1m_tokens > 0, (
+                    f"{provider_id}/{model.model_id} has non-positive input cost"
+                )
+                assert model.output_cost_per_1m_tokens > 0, (
+                    f"{provider_id}/{model.model_id} has non-positive output cost"
+                )
+
+    def test_provider_api_key_env_vars(self):
+        """Each provider has a valid API key env var name."""
+        expected = {
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+            "grok": "XAI_API_KEY",
+        }
+        for provider_id, env_var in expected.items():
+            config = get_provider(provider_id)
+            assert config.api_key_env_var == env_var
+
+    def test_grok_has_base_url(self):
+        """Grok provider has a base_url set."""
+        config = get_provider("grok")
+        assert config.base_url == "https://api.x.ai/v1"
+
+    def test_openai_has_no_base_url(self):
+        """OpenAI provider has no custom base_url."""
+        config = get_provider("openai")
+        assert config.base_url is None
+
+    def test_anthropic_has_no_base_url(self):
+        """Anthropic provider has no custom base_url."""
+        config = get_provider("anthropic")
+        assert config.base_url is None

--- a/shitpost_ai/__main__.py
+++ b/shitpost_ai/__main__.py
@@ -16,6 +16,11 @@ from shitpost_ai.cli import (
 from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer
 
 
+def _is_compare_command() -> bool:
+    """Check if the CLI was invoked with the 'compare' subcommand."""
+    return len(sys.argv) > 1 and sys.argv[1] == "compare"
+
+
 async def main():
     """CLI entry point for shitpost analysis."""
     parser = create_analyzer_parser(
@@ -83,4 +88,8 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    if _is_compare_command():
+        from shitpost_ai.compare_cli import compare_main
+        asyncio.run(compare_main())
+    else:
+        asyncio.run(main())

--- a/shitpost_ai/compare_cli.py
+++ b/shitpost_ai/compare_cli.py
@@ -1,0 +1,155 @@
+"""
+Provider Comparison CLI
+Compare LLM providers for shitpost analysis quality.
+"""
+
+import argparse
+import asyncio
+import sys
+from typing import List, Optional
+
+from shit.llm.compare_providers import ProviderComparator, format_comparison_report
+from shit.llm.provider_config import PROVIDERS, get_all_provider_ids
+from shit.logging import setup_cli_logging
+
+
+COMPARE_EXAMPLES = """
+Examples:
+  # Compare all available providers on sample content
+  python -m shitpost_ai compare --content "Tesla is destroying American jobs!"
+
+  # Compare specific providers
+  python -m shitpost_ai compare --providers openai anthropic --content "Tariffs on China!"
+
+  # Compare using a post from the database (by shitpost_id)
+  python -m shitpost_ai compare --shitpost-id 123456789
+
+  # List available providers and models
+  python -m shitpost_ai compare --list-providers
+"""
+
+
+def create_compare_parser() -> argparse.ArgumentParser:
+    """Create argument parser for comparison CLI."""
+    parser = argparse.ArgumentParser(
+        description="Compare LLM provider analysis results",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=COMPARE_EXAMPLES,
+    )
+
+    parser.add_argument(
+        "--content", type=str, help="Content text to analyze across providers"
+    )
+    parser.add_argument(
+        "--shitpost-id",
+        type=str,
+        help="Analyze a specific shitpost from the database by ID",
+    )
+    parser.add_argument(
+        "--providers",
+        nargs="+",
+        choices=get_all_provider_ids(),
+        help="Specific providers to compare (default: all available)",
+    )
+    parser.add_argument(
+        "--list-providers",
+        action="store_true",
+        help="List all available providers and their models",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    return parser
+
+
+def list_providers() -> None:
+    """Print all available providers and their models."""
+    print("\n=== Available LLM Providers ===\n")
+    for provider_id, config in PROVIDERS.items():
+        print(f"  {provider_id} ({config.display_name})")
+        print(f"    SDK: {config.sdk_type}")
+        print(f"    API Key Env: {config.api_key_env_var}")
+        if config.base_url:
+            print(f"    Base URL: {config.base_url}")
+        print("    Models:")
+        for model in config.models:
+            rec = " [RECOMMENDED]" if model.recommended else ""
+            print(f"      - {model.model_id}{rec}")
+            print(
+                f"        Cost: ${model.input_cost_per_1m_tokens}/1M in, "
+                f"${model.output_cost_per_1m_tokens}/1M out"
+            )
+            if model.notes:
+                print(f"        Note: {model.notes}")
+        print()
+
+
+async def run_comparison(
+    content: str, providers: Optional[List[str]] = None
+) -> None:
+    """Run comparison and print report."""
+    comparator = ProviderComparator(providers=providers)
+
+    initialized = await comparator.initialize()
+    if len(initialized) < 2:
+        print(
+            f"\nOnly {len(initialized)} provider(s) initialized. "
+            "Need at least 2 for comparison."
+        )
+        print("Check that API keys are set for the providers you want to compare.")
+        print("Run with --list-providers to see required environment variables.")
+        return
+
+    print(f"\nComparing {len(initialized)} providers: {', '.join(initialized)}")
+    print("Running analysis...\n")
+
+    result = await comparator.compare(content)
+    report = format_comparison_report(result)
+    print(report)
+
+
+async def compare_main() -> None:
+    """Main entry point for comparison CLI."""
+    parser = create_compare_parser()
+    args = parser.parse_args(sys.argv[2:])  # Skip 'compare' subcommand
+
+    setup_cli_logging(verbose=args.verbose)
+
+    if args.list_providers:
+        list_providers()
+        return
+
+    if args.shitpost_id:
+        # Fetch content from database
+        from shit.config.shitpost_settings import settings
+        from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
+        from shitvault.shitpost_operations import ShitpostOperations
+
+        db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
+        db_client = DatabaseClient(db_config)
+        await db_client.initialize()
+
+        async with db_client.get_session() as session:
+            db_ops = DatabaseOperations(session)
+            shitpost_ops = ShitpostOperations(db_ops)
+            shitpost = await shitpost_ops.get_shitpost_by_id(args.shitpost_id)
+
+            if not shitpost:
+                print(f"Shitpost {args.shitpost_id} not found in database")
+                return
+
+            content = shitpost.get("text", "")
+
+        await db_client.cleanup()
+
+    elif args.content:
+        content = args.content
+    else:
+        parser.error("Either --content or --shitpost-id is required")
+        return
+
+    await run_comparison(content, providers=args.providers)


### PR DESCRIPTION
## Summary
- **Grok/xAI provider**: Added as third LLM provider using OpenAI-compatible API with custom `base_url` (`https://api.x.ai/v1`). Configure with `LLM_PROVIDER=grok` and `XAI_API_KEY`.
- **SDK-type routing**: Refactored `LLMClient` to route via `_sdk_type` instead of provider name, so Grok flows through the existing OpenAI SDK path with a custom base URL.
- **Provider configuration module** (`shit/llm/provider_config.py`): Centralized metadata for all providers — model IDs, costs, rate limits, recommended models.
- **Comparison CLI** (`python -m shitpost_ai compare`): Run content through multiple providers side-by-side, measuring latency, asset agreement, sentiment agreement, and confidence spread.
- **23 new tests** across 3 new test files + 4 tests added to existing file. All 1480 tests pass (10 pre-existing failures unchanged).

## Files Changed
- **New**: `shit/llm/provider_config.py`, `shit/llm/compare_providers.py`, `shitpost_ai/compare_cli.py`
- **New tests**: `test_provider_config.py` (13), `test_llm_client_grok.py` (5), `test_compare_providers.py` (5)
- **Modified**: `shit/llm/llm_client.py`, `shit/config/shitpost_settings.py`, `shit/llm/__init__.py`, `shitpost_ai/__main__.py`, `requirements.txt`, `CHANGELOG.md`

## Test plan
- [x] All 109 LLM tests pass (`pytest -v shit_tests/shit/llm/`)
- [x] Full suite: 1480 passed, 10 failed (pre-existing)
- [x] `python -m shitpost_ai compare --list-providers` works correctly
- [x] Provider config imports cleanly from `shit.llm`
- [x] Grok routes through OpenAI SDK with `base_url`
- [x] Existing OpenAI/Anthropic paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)