### PR TITLE
feat: introduce source-agnostic Signal model for multi-platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Source-Agnostic Signal Model** - New `signals` table that can represent content from any platform
+  - Universal fields: text, author, timestamp, normalized engagement metrics (`likes_count`, `shares_count`)
+  - Platform-specific data stored as JSON (`platform_data` column)
+  - Content flags: `is_repost`, `is_reply`, `is_quote` for cross-platform bypass logic
+- **Signal Operations** (`shitvault/signal_operations.py`) - Source-agnostic CRUD with backward-compatible aliases
+- **Signal Transformer** (`shit/db/signal_utils.py`) - Pluggable per-source field mapping (`SignalTransformer.get_transformer()`)
+- **Dual-FK on Predictions** - `Prediction.signal_id` added alongside legacy `shitpost_id` with `content_id` property
+
+### Changed
+- **S3 Processor** - Now accepts `source` parameter and dual-writes to both `signals` and `truth_social_shitposts`
+- **Bypass Service** - `_is_retruth()` now checks `is_repost` flag before legacy `reblog` field
+- **Analyzer** - `_prepare_enhanced_content()` uses generic field names with fallback to legacy names
+- **Prediction Operations** - `store_analysis()`, `handle_no_text_prediction()`, `check_prediction_exists()` accept `use_signal` flag for dual-FK routing
+- **S3 Data Lake** - Storage metadata now uses dynamic source prefix instead of hardcoded `truth_social_api`
+- **sync_session** - `create_tables()` now imports and registers the `Signal` model
+
+### Deprecated
+- **ShitpostOperations** - Deprecated in favor of `SignalOperations`; emits `DeprecationWarning` on instantiation
+
 - **Grok/xAI LLM Provider** - Added xAI's Grok as a third LLM provider option
   - Uses OpenAI-compatible API with custom `base_url` (`https://api.x.ai/v1`)
   - Supports `grok-2` and `grok-2-mini` models

--- a/shit/content/bypass_service.py
+++ b/shit/content/bypass_service.py
@@ -129,7 +129,11 @@ class BypassService:
         Returns:
             True if post is a retruth
         """
-        # Check reblog field (JSON data indicating this is a reblog)
+        # Check source-agnostic flag first (Signal model)
+        if post_data.get('is_repost', False):
+            return True
+
+        # Legacy: check reblog field (Truth Social API)
         reblog_data = post_data.get('reblog')
         if reblog_data is not None:
             return True

--- a/shit/db/signal_utils.py
+++ b/shit/db/signal_utils.py
@@ -1,0 +1,140 @@
+"""
+Signal Transformation Utilities
+Transforms raw API data from any source into the generic Signal format.
+"""
+
+from typing import Dict, Any
+
+from shit.db.database_utils import DatabaseUtils
+from shit.logging.service_loggers import DatabaseLogger
+
+db_logger = DatabaseLogger("signal_utils")
+logger = db_logger.logger
+
+
+class SignalTransformer:
+    """Transforms raw API data from various sources into Signal format."""
+
+    @staticmethod
+    def transform_truth_social(s3_data: Dict) -> Dict[str, Any]:
+        """
+        Transform Truth Social S3 data into Signal format.
+
+        Maps Truth Social API fields to universal Signal fields.
+        Platform-specific fields are stored in platform_data JSON.
+
+        Args:
+            s3_data: Raw S3 storage data (contains raw_api_data key)
+
+        Returns:
+            Dictionary matching Signal model fields
+        """
+        raw_api_data = s3_data.get("raw_api_data", {})
+        account_data = raw_api_data.get("account", {})
+
+        # Determine content flags
+        reblog_data = raw_api_data.get("reblog")
+        is_repost = reblog_data is not None
+        is_reply = raw_api_data.get("in_reply_to_id") is not None
+        is_quote = raw_api_data.get("quote_id") is not None
+
+        # Build platform_data with all Truth Social-specific fields
+        platform_data = {
+            "upvotes_count": raw_api_data.get("upvotes_count", 0),
+            "downvotes_count": raw_api_data.get("downvotes_count", 0),
+            "account_following_count": account_data.get("following_count", 0),
+            "account_statuses_count": account_data.get("statuses_count", 0),
+            "account_website": account_data.get("website", ""),
+            "visibility": raw_api_data.get("visibility", "public"),
+            "sensitive": raw_api_data.get("sensitive", False),
+            "spoiler_text": raw_api_data.get("spoiler_text", ""),
+            "uri": raw_api_data.get("uri", ""),
+            "card": raw_api_data.get("card"),
+            "group": raw_api_data.get("group"),
+            "quote": raw_api_data.get("quote"),
+            "in_reply_to": raw_api_data.get("in_reply_to"),
+            "reblog": raw_api_data.get("reblog"),
+            "sponsored": raw_api_data.get("sponsored", False),
+            "reaction": raw_api_data.get("reaction"),
+            "favourited": raw_api_data.get("favourited", False),
+            "reblogged": raw_api_data.get("reblogged", False),
+            "muted": raw_api_data.get("muted", False),
+            "pinned": raw_api_data.get("pinned", False),
+            "bookmarked": raw_api_data.get("bookmarked", False),
+            "poll": raw_api_data.get("poll"),
+            "emojis": raw_api_data.get("emojis", []),
+            "votable": raw_api_data.get("votable", False),
+            "editable": raw_api_data.get("editable", False),
+            "version": raw_api_data.get("version", ""),
+            "media_attachments": raw_api_data.get("media_attachments", []),
+            "mentions": raw_api_data.get("mentions", []),
+            "tags": raw_api_data.get("tags", []),
+            "in_reply_to_id": raw_api_data.get("in_reply_to_id"),
+            "quote_id": raw_api_data.get("quote_id"),
+            "in_reply_to_account_id": raw_api_data.get("in_reply_to_account_id"),
+            "edited_at": raw_api_data.get("edited_at"),
+        }
+
+        return {
+            # Universal identifiers
+            "signal_id": str(raw_api_data.get("id")),
+            "source": "truth_social",
+            "source_url": raw_api_data.get("url", ""),
+            # Universal content
+            "text": raw_api_data.get("text", ""),
+            "content_html": raw_api_data.get("content", ""),
+            "title": raw_api_data.get("title", ""),
+            "language": raw_api_data.get("language", ""),
+            # Universal author
+            "author_id": str(account_data.get("id", "")),
+            "author_username": account_data.get("username", ""),
+            "author_display_name": account_data.get("display_name", ""),
+            "author_verified": account_data.get("verified", False),
+            "author_followers": account_data.get("followers_count", 0),
+            # Universal timestamp
+            "published_at": DatabaseUtils.parse_timestamp(
+                raw_api_data.get("created_at", "")
+            ),
+            # Normalized engagement
+            "likes_count": raw_api_data.get("favourites_count", 0),
+            "shares_count": raw_api_data.get("reblogs_count", 0),
+            "replies_count": raw_api_data.get("replies_count", 0),
+            "views_count": 0,  # Truth Social does not expose views
+            # Content flags
+            "has_media": len(raw_api_data.get("media_attachments", [])) > 0,
+            "is_repost": is_repost,
+            "is_reply": is_reply,
+            "is_quote": is_quote,
+            # Platform-specific data
+            "platform_data": platform_data,
+            "raw_api_data": raw_api_data,
+        }
+
+    @staticmethod
+    def get_transformer(source: str):
+        """
+        Get the appropriate transformer function for a given source.
+
+        Args:
+            source: Source platform name ("truth_social", "twitter", "rss", etc.)
+
+        Returns:
+            Transformer function
+
+        Raises:
+            ValueError: If source is not supported
+        """
+        transformers = {
+            "truth_social": SignalTransformer.transform_truth_social,
+            # Future sources:
+            # "twitter": SignalTransformer.transform_twitter,
+            # "rss": SignalTransformer.transform_rss,
+        }
+
+        transformer = transformers.get(source)
+        if transformer is None:
+            raise ValueError(
+                f"Unsupported source: {source}. "
+                f"Supported sources: {list(transformers.keys())}"
+            )
+        return transformer

--- a/shit/db/sync_session.py
+++ b/shit/db/sync_session.py
@@ -78,5 +78,6 @@ def create_tables():
         TelegramSubscription,
     )
     from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
+    from shitvault.signal_models import Signal
 
     Base.metadata.create_all(engine)

--- a/shit/s3/s3_data_lake.py
+++ b/shit/s3/s3_data_lake.py
@@ -97,9 +97,9 @@ class S3DataLake:
                 raw_api_data=raw_data,
                 metadata={
                     'stored_at': datetime.now().isoformat(),
-                    'source': 'truth_social_api',
+                    'source': self.config.prefix,
                     'version': '1.0',
-                    'harvester': 'truth_social_s3_harvester'
+                    'harvester': f'{self.config.prefix}_harvester'
                 }
             )
             

--- a/shit_tests/shit/db/test_signal_utils.py
+++ b/shit_tests/shit/db/test_signal_utils.py
@@ -1,0 +1,201 @@
+"""
+Tests for shit/db/signal_utils.py - Signal transformation utilities.
+"""
+
+import pytest
+from datetime import datetime
+
+from shit.db.signal_utils import SignalTransformer
+
+
+def _make_truth_social_s3_data(**overrides):
+    """Helper to create Truth Social S3 data for testing."""
+    raw_api_data = {
+        "id": "112233",
+        "url": "https://truthsocial.com/@user/112233",
+        "text": "Buy Tesla stock!",
+        "content": "<p>Buy Tesla stock!</p>",
+        "title": "",
+        "language": "en",
+        "created_at": "2025-01-15T12:00:00.000Z",
+        "replies_count": 10,
+        "reblogs_count": 5,
+        "favourites_count": 20,
+        "upvotes_count": 8,
+        "downvotes_count": 1,
+        "visibility": "public",
+        "sensitive": False,
+        "spoiler_text": "",
+        "uri": "https://truthsocial.com/users/user/statuses/112233",
+        "reblog": None,
+        "in_reply_to_id": None,
+        "quote_id": None,
+        "in_reply_to_account_id": None,
+        "media_attachments": [],
+        "mentions": [],
+        "tags": [],
+        "card": None,
+        "group": None,
+        "quote": None,
+        "in_reply_to": None,
+        "sponsored": False,
+        "reaction": None,
+        "favourited": False,
+        "reblogged": False,
+        "muted": False,
+        "pinned": False,
+        "bookmarked": False,
+        "poll": None,
+        "emojis": [],
+        "votable": False,
+        "editable": False,
+        "version": "",
+        "edited_at": None,
+        "account": {
+            "id": "acct_1",
+            "username": "testuser",
+            "display_name": "Test User",
+            "verified": True,
+            "followers_count": 5000,
+            "following_count": 100,
+            "statuses_count": 250,
+            "website": "https://example.com",
+        },
+    }
+    raw_api_data.update(overrides)
+    return {"raw_api_data": raw_api_data}
+
+
+class TestTransformTruthSocial:
+    """Tests for SignalTransformer.transform_truth_social."""
+
+    def test_basic_transformation(self):
+        """Test basic field mapping from Truth Social to Signal format."""
+        s3_data = _make_truth_social_s3_data()
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["signal_id"] == "112233"
+        assert result["source"] == "truth_social"
+        assert result["source_url"] == "https://truthsocial.com/@user/112233"
+        assert result["text"] == "Buy Tesla stock!"
+        assert result["content_html"] == "<p>Buy Tesla stock!</p>"
+        assert result["language"] == "en"
+
+    def test_author_mapping(self):
+        """Test author field mapping."""
+        s3_data = _make_truth_social_s3_data()
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["author_id"] == "acct_1"
+        assert result["author_username"] == "testuser"
+        assert result["author_display_name"] == "Test User"
+        assert result["author_verified"] is True
+        assert result["author_followers"] == 5000
+
+    def test_engagement_mapping(self):
+        """Test that Truth Social engagement maps to generic names."""
+        s3_data = _make_truth_social_s3_data()
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        # favourites_count -> likes_count
+        assert result["likes_count"] == 20
+        # reblogs_count -> shares_count
+        assert result["shares_count"] == 5
+        assert result["replies_count"] == 10
+        assert result["views_count"] == 0  # Truth Social doesn't expose views
+
+    def test_repost_detection(self):
+        """Test that reblog presence sets is_repost=True."""
+        s3_data = _make_truth_social_s3_data(reblog={"id": "999", "content": "Original"})
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["is_repost"] is True
+
+    def test_reply_detection(self):
+        """Test that in_reply_to_id presence sets is_reply=True."""
+        s3_data = _make_truth_social_s3_data(in_reply_to_id="555")
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["is_reply"] is True
+        assert result["is_repost"] is False
+
+    def test_quote_detection(self):
+        """Test that quote_id presence sets is_quote=True."""
+        s3_data = _make_truth_social_s3_data(quote_id="777")
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["is_quote"] is True
+        assert result["is_repost"] is False
+
+    def test_platform_data_contains_ts_specific_fields(self):
+        """Test that platform_data preserves Truth Social-specific fields."""
+        s3_data = _make_truth_social_s3_data(
+            upvotes_count=42,
+            downvotes_count=3,
+            visibility="public",
+            sponsored=True,
+        )
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        pd = result["platform_data"]
+        assert pd["upvotes_count"] == 42
+        assert pd["downvotes_count"] == 3
+        assert pd["visibility"] == "public"
+        assert pd["sponsored"] is True
+
+    def test_media_detection(self):
+        """Test has_media flag based on media_attachments."""
+        s3_data = _make_truth_social_s3_data(
+            media_attachments=[{"type": "image", "url": "https://img.example.com/1.jpg"}]
+        )
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["has_media"] is True
+
+    def test_no_media(self):
+        """Test has_media is False when no attachments."""
+        s3_data = _make_truth_social_s3_data(media_attachments=[])
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["has_media"] is False
+
+    def test_null_fields_handled(self):
+        """Test that missing/null fields produce sensible defaults."""
+        s3_data = {"raw_api_data": {"id": "bare_min", "account": {}}}
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["signal_id"] == "bare_min"
+        assert result["source"] == "truth_social"
+        assert result["text"] == ""
+        assert result["author_username"] == ""
+        assert result["likes_count"] == 0
+        assert result["shares_count"] == 0
+        assert result["is_repost"] is False
+        assert result["has_media"] is False
+
+    def test_raw_api_data_preserved(self):
+        """Test that the full raw API data is passed through."""
+        s3_data = _make_truth_social_s3_data()
+        result = SignalTransformer.transform_truth_social(s3_data)
+
+        assert result["raw_api_data"]["id"] == "112233"
+        assert "account" in result["raw_api_data"]
+
+
+class TestGetTransformer:
+    """Tests for SignalTransformer.get_transformer."""
+
+    def test_valid_source(self):
+        """Test getting transformer for supported source."""
+        transformer = SignalTransformer.get_transformer("truth_social")
+        assert transformer is SignalTransformer.transform_truth_social
+
+    def test_invalid_source_raises(self):
+        """Test that unsupported source raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported source"):
+            SignalTransformer.get_transformer("tiktok")
+
+    def test_invalid_source_lists_supported(self):
+        """Test that error message lists supported sources."""
+        with pytest.raises(ValueError, match="truth_social"):
+            SignalTransformer.get_transformer("unknown")

--- a/shit_tests/shitvault/test_prediction_operations.py
+++ b/shit_tests/shitvault/test_prediction_operations.py
@@ -75,11 +75,11 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         result = await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
-        
+
         assert result == '1'
         mock_db_ops.session.add.assert_called_once()
         mock_db_ops.session.commit.assert_called_once()
@@ -90,16 +90,16 @@ class TestPredictionOperations:
         """Test storing analysis without shitpost data."""
         mock_prediction = MagicMock()
         mock_prediction.id = 1
-        
+
         def mock_add(prediction):
             prediction.id = 1
-        
+
         mock_db_ops.session.add.side_effect = mock_add
-        
+
         result = await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=None
+            content_data=None
         )
         
         assert result == '1'
@@ -118,11 +118,11 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
-        
+
         # Verify engagement score calculation
         # (replies + reblogs + favourites) / followers
         # (100 + 500 + 1000) / 5000000 = 0.00032
@@ -143,11 +143,11 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
-        
+
         # Verify viral score calculation
         # reblogs / favourites = 500 / 1000 = 0.5
         assert captured_prediction is not None
@@ -169,9 +169,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         # Engagement score should be None when followers is 0
@@ -192,9 +192,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         # Viral score should be None when favourites is 0
@@ -213,9 +213,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         assert captured_prediction.analysis_status == 'completed'
@@ -234,9 +234,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         assert captured_prediction.has_media is False
@@ -257,9 +257,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         assert captured_prediction.replies_at_analysis == 100
@@ -280,9 +280,9 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         assert captured_prediction.llm_provider == 'openai'
@@ -295,9 +295,9 @@ class TestPredictionOperations:
         mock_db_ops.session.commit.side_effect = Exception("Database error")
         
         result = await prediction_ops.store_analysis(
-            shitpost_id='123456789',
+            content_id='123456789',
             analysis_data=sample_analysis_data,
-            shitpost_data=sample_shitpost_data
+            content_data=sample_shitpost_data
         )
         
         assert result is None
@@ -316,8 +316,8 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         result = await prediction_ops.handle_no_text_prediction(
-            shitpost_id='123456789',
-            shitpost_data=sample_shitpost_data
+            content_id='123456789',
+            content_data=sample_shitpost_data
         )
         
         assert result == '1'
@@ -339,8 +339,8 @@ class TestPredictionOperations:
         mock_db_ops.session.add.side_effect = mock_add
         
         await prediction_ops.handle_no_text_prediction(
-            shitpost_id='123456789',
-            shitpost_data=sample_shitpost_data
+            content_id='123456789',
+            content_data=sample_shitpost_data
         )
         
         assert captured_prediction.analysis_status == 'bypassed'
@@ -381,8 +381,8 @@ class TestPredictionOperations:
             }
             
             await prediction_ops.handle_no_text_prediction(
-                shitpost_id='123',
-                shitpost_data=shitpost_data
+                content_id='123',
+                content_data=shitpost_data
             )
             
             assert captured_prediction.analysis_comment == expected_reason
@@ -393,8 +393,8 @@ class TestPredictionOperations:
         mock_db_ops.session.commit.side_effect = Exception("Database error")
         
         result = await prediction_ops.handle_no_text_prediction(
-            shitpost_id='123456789',
-            shitpost_data=sample_shitpost_data
+            content_id='123456789',
+            content_data=sample_shitpost_data
         )
         
         assert result is None

--- a/shit_tests/shitvault/test_signal_models.py
+++ b/shit_tests/shitvault/test_signal_models.py
@@ -1,0 +1,274 @@
+"""
+Tests for shitvault/signal_models.py - Source-agnostic Signal model.
+"""
+
+import pytest
+from datetime import datetime
+
+from shitvault.signal_models import Signal, signal_to_dict
+from shit.db.data_models import Base
+
+
+class TestSignalModel:
+    """Test cases for the Signal model."""
+
+    def test_signal_creation_minimal(self):
+        """Test creating a Signal with only required fields."""
+        signal = Signal(
+            signal_id="post_123",
+            source="truth_social",
+            author_username="testuser",
+            published_at=datetime(2025, 1, 15, 12, 0, 0),
+        )
+
+        assert signal.signal_id == "post_123"
+        assert signal.source == "truth_social"
+        assert signal.author_username == "testuser"
+        assert signal.published_at == datetime(2025, 1, 15, 12, 0, 0)
+
+    def test_signal_creation_all_fields(self):
+        """Test creating a Signal with all fields populated."""
+        now = datetime(2025, 6, 1, 10, 0, 0)
+        signal = Signal(
+            signal_id="post_456",
+            source="twitter",
+            source_url="https://twitter.com/user/status/456",
+            text="Market is moving!",
+            content_html="<p>Market is moving!</p>",
+            title="Breaking News",
+            language="en",
+            author_id="acct_789",
+            author_username="trader",
+            author_display_name="Top Trader",
+            author_verified=True,
+            author_followers=50000,
+            published_at=now,
+            likes_count=100,
+            shares_count=50,
+            replies_count=25,
+            views_count=10000,
+            has_media=True,
+            is_repost=False,
+            is_reply=False,
+            is_quote=True,
+            platform_data={"quote_id": "111"},
+            raw_api_data={"id": "456", "full_text": "Market is moving!"},
+        )
+
+        assert signal.signal_id == "post_456"
+        assert signal.source == "twitter"
+        assert signal.source_url == "https://twitter.com/user/status/456"
+        assert signal.text == "Market is moving!"
+        assert signal.content_html == "<p>Market is moving!</p>"
+        assert signal.title == "Breaking News"
+        assert signal.language == "en"
+        assert signal.author_id == "acct_789"
+        assert signal.author_display_name == "Top Trader"
+        assert signal.author_verified is True
+        assert signal.author_followers == 50000
+        assert signal.likes_count == 100
+        assert signal.shares_count == 50
+        assert signal.replies_count == 25
+        assert signal.views_count == 10000
+        assert signal.has_media is True
+        assert signal.is_repost is False
+        assert signal.is_reply is False
+        assert signal.is_quote is True
+        assert signal.platform_data == {"quote_id": "111"}
+
+    def test_signal_default_values(self):
+        """Test that defaults are applied for optional numeric fields."""
+        signal = Signal(
+            signal_id="post_999",
+            source="rss",
+            author_username="feed",
+            published_at=datetime(2025, 1, 1),
+            likes_count=0,
+            shares_count=0,
+            replies_count=0,
+            views_count=0,
+            has_media=False,
+            is_repost=False,
+            is_reply=False,
+            is_quote=False,
+        )
+
+        assert signal.likes_count == 0
+        assert signal.shares_count == 0
+        assert signal.replies_count == 0
+        assert signal.views_count == 0
+        assert signal.has_media is False
+        assert signal.is_repost is False
+
+    def test_signal_total_engagement(self):
+        """Test total_engagement property sums likes + shares + replies."""
+        signal = Signal(
+            signal_id="eng_1",
+            source="truth_social",
+            author_username="user",
+            published_at=datetime(2025, 1, 1),
+            likes_count=100,
+            shares_count=50,
+            replies_count=25,
+        )
+
+        assert signal.total_engagement == 175
+
+    def test_signal_total_engagement_with_none(self):
+        """Test total_engagement handles None values gracefully."""
+        signal = Signal(
+            signal_id="eng_2",
+            source="truth_social",
+            author_username="user",
+            published_at=datetime(2025, 1, 1),
+            likes_count=None,
+            shares_count=50,
+            replies_count=None,
+        )
+
+        assert signal.total_engagement == 50
+
+    def test_signal_engagement_rate(self):
+        """Test engagement_rate returns ratio to followers."""
+        signal = Signal(
+            signal_id="rate_1",
+            source="truth_social",
+            author_username="influencer",
+            published_at=datetime(2025, 1, 1),
+            author_followers=1000,
+            likes_count=50,
+            shares_count=30,
+            replies_count=20,
+        )
+
+        # total_engagement = 100, followers = 1000
+        assert signal.engagement_rate == 0.1
+
+    def test_signal_engagement_rate_zero_followers(self):
+        """Test engagement_rate returns 0.0 when author has no followers."""
+        signal = Signal(
+            signal_id="rate_2",
+            source="truth_social",
+            author_username="newuser",
+            published_at=datetime(2025, 1, 1),
+            author_followers=0,
+            likes_count=10,
+            shares_count=5,
+            replies_count=2,
+        )
+
+        assert signal.engagement_rate == 0.0
+
+    def test_signal_repr(self):
+        """Test __repr__ output."""
+        signal = Signal(
+            signal_id="repr_1",
+            source="truth_social",
+            author_username="testuser",
+            published_at=datetime(2025, 1, 1),
+            text="Short text",
+        )
+
+        repr_str = repr(signal)
+        assert "Signal" in repr_str
+        assert "truth_social" in repr_str
+        assert "testuser" in repr_str
+
+    def test_signal_table_name(self):
+        """Test the model's __tablename__."""
+        assert Signal.__tablename__ == "signals"
+
+    def test_signal_platform_data_json(self):
+        """Test that platform_data stores complex JSON structures."""
+        platform_data = {
+            "upvotes_count": 42,
+            "downvotes_count": 3,
+            "mentions": [{"id": "1", "username": "foo"}],
+            "tags": [{"name": "stocks"}],
+            "visibility": "public",
+            "card": {"title": "Link Preview", "url": "https://example.com"},
+        }
+
+        signal = Signal(
+            signal_id="json_1",
+            source="truth_social",
+            author_username="user",
+            published_at=datetime(2025, 1, 1),
+            platform_data=platform_data,
+        )
+
+        assert signal.platform_data["upvotes_count"] == 42
+        assert len(signal.platform_data["mentions"]) == 1
+        assert signal.platform_data["card"]["title"] == "Link Preview"
+
+
+class TestSignalToDict:
+    """Test the signal_to_dict utility function."""
+
+    def test_signal_to_dict_basic(self):
+        """Test converting a signal to dict includes key fields."""
+        signal = Signal(
+            signal_id="dict_1",
+            source="truth_social",
+            author_username="user",
+            published_at=datetime(2025, 1, 1),
+            text="Test content",
+        )
+
+        result = signal_to_dict(signal)
+        assert isinstance(result, dict)
+        assert result["signal_id"] == "dict_1"
+        assert result["source"] == "truth_social"
+        assert result["text"] == "Test content"
+
+
+class TestPredictionDualFK:
+    """Test the dual-FK (shitpost_id + signal_id) on Prediction."""
+
+    def test_prediction_with_shitpost_id(self):
+        """Test creating a Prediction with legacy shitpost_id."""
+        from shitvault.shitpost_models import Prediction
+
+        pred = Prediction(
+            shitpost_id="legacy_123",
+            signal_id=None,
+            confidence=0.8,
+            thesis="Bullish",
+            assets=["TSLA"],
+            market_impact={"TSLA": "bullish"},
+            analysis_status="completed",
+        )
+
+        assert pred.shitpost_id == "legacy_123"
+        assert pred.signal_id is None
+        assert pred.content_id == "legacy_123"
+
+    def test_prediction_with_signal_id(self):
+        """Test creating a Prediction with new signal_id."""
+        from shitvault.shitpost_models import Prediction
+
+        pred = Prediction(
+            shitpost_id=None,
+            signal_id="signal_456",
+            confidence=0.9,
+            thesis="Bearish",
+            assets=["AAPL"],
+            market_impact={"AAPL": "bearish"},
+            analysis_status="completed",
+        )
+
+        assert pred.shitpost_id is None
+        assert pred.signal_id == "signal_456"
+        assert pred.content_id == "signal_456"
+
+    def test_prediction_content_id_prefers_signal(self):
+        """Test that content_id prefers signal_id when both are set."""
+        from shitvault.shitpost_models import Prediction
+
+        pred = Prediction(
+            shitpost_id="legacy_123",
+            signal_id="signal_456",
+            analysis_status="completed",
+        )
+
+        assert pred.content_id == "signal_456"

--- a/shit_tests/shitvault/test_signal_operations.py
+++ b/shit_tests/shitvault/test_signal_operations.py
@@ -1,0 +1,205 @@
+"""
+Tests for shitvault/signal_operations.py - Signal CRUD operations.
+"""
+
+import pytest
+import pytest_asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shitvault.signal_operations import SignalOperations
+from shitvault.signal_models import Signal
+
+
+def _make_signal_data(**overrides):
+    """Helper to create a signal data dict for testing."""
+    data = {
+        "signal_id": "sig_001",
+        "source": "truth_social",
+        "source_url": "https://truthsocial.com/@user/001",
+        "text": "Market update!",
+        "content_html": "<p>Market update!</p>",
+        "title": "",
+        "language": "en",
+        "author_id": "acct_1",
+        "author_username": "testuser",
+        "author_display_name": "Test User",
+        "author_verified": True,
+        "author_followers": 5000,
+        "published_at": datetime(2025, 6, 1, 12, 0, 0),
+        "likes_count": 20,
+        "shares_count": 5,
+        "replies_count": 10,
+        "views_count": 0,
+        "has_media": False,
+        "is_repost": False,
+        "is_reply": False,
+        "is_quote": False,
+        "platform_data": {"upvotes_count": 3},
+        "raw_api_data": {"id": "001"},
+    }
+    data.update(overrides)
+    return data
+
+
+class TestStoreSignal:
+    """Tests for SignalOperations.store_signal."""
+
+    @pytest.mark.asyncio
+    async def test_store_signal_new(self):
+        """Test storing a new signal succeeds."""
+        mock_db_ops = AsyncMock()
+        mock_db_ops.read_one = AsyncMock(return_value=None)
+
+        # Mock session.add, commit, refresh
+        mock_signal = MagicMock()
+        mock_signal.id = 42
+        mock_signal.signal_id = "sig_001"
+        mock_signal.source = "truth_social"
+
+        mock_db_ops.session = AsyncMock()
+        mock_db_ops.session.add = MagicMock()
+        mock_db_ops.session.commit = AsyncMock()
+        mock_db_ops.session.refresh = AsyncMock()
+
+        ops = SignalOperations(mock_db_ops)
+
+        with patch("shitvault.signal_operations.Signal") as MockSignal:
+            mock_instance = MagicMock()
+            mock_instance.id = 42
+            mock_instance.signal_id = "sig_001"
+            mock_instance.source = "truth_social"
+            MockSignal.return_value = mock_instance
+
+            result = await ops.store_signal(_make_signal_data())
+
+        assert result == "42"
+        mock_db_ops.session.add.assert_called_once()
+        mock_db_ops.session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_store_signal_duplicate_returns_existing_id(self):
+        """Test that storing a duplicate signal returns the existing ID."""
+        existing = MagicMock()
+        existing.id = 99
+
+        mock_db_ops = AsyncMock()
+        mock_db_ops.read_one = AsyncMock(return_value=existing)
+        mock_db_ops.session = AsyncMock()
+
+        ops = SignalOperations(mock_db_ops)
+        result = await ops.store_signal(_make_signal_data())
+
+        assert result == "99"
+        # Should not attempt to add/commit
+        mock_db_ops.session.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_store_signal_integrity_error_returns_none(self):
+        """Test that IntegrityError returns None."""
+        from sqlalchemy.exc import IntegrityError
+
+        mock_db_ops = AsyncMock()
+        mock_db_ops.read_one = AsyncMock(return_value=None)
+        mock_db_ops.session = AsyncMock()
+        mock_db_ops.session.add = MagicMock()
+        mock_db_ops.session.commit = AsyncMock(
+            side_effect=IntegrityError("dup", {}, Exception())
+        )
+        mock_db_ops.session.rollback = AsyncMock()
+
+        ops = SignalOperations(mock_db_ops)
+
+        with patch("shitvault.signal_operations.Signal") as MockSignal:
+            MockSignal.return_value = MagicMock()
+            result = await ops.store_signal(_make_signal_data())
+
+        assert result is None
+        mock_db_ops.session.rollback.assert_awaited_once()
+
+
+class TestGetUnprocessedSignals:
+    """Tests for SignalOperations.get_unprocessed_signals."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_signals(self):
+        """Test returns empty list when no unprocessed signals exist."""
+        mock_db_ops = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db_ops.session.execute = AsyncMock(return_value=mock_result)
+
+        ops = SignalOperations(mock_db_ops)
+        result = await ops.get_unprocessed_signals(launch_date="2025-01-01")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_aliases(self):
+        """Test that returned dicts include backward-compatible aliases."""
+        mock_signal = MagicMock(spec=Signal)
+        mock_signal.id = 1
+        mock_signal.signal_id = "sig_100"
+        mock_signal.source = "truth_social"
+        mock_signal.source_url = "https://example.com"
+        mock_signal.text = "Test content"
+        mock_signal.content_html = "<p>Test content</p>"
+        mock_signal.title = ""
+        mock_signal.language = "en"
+        mock_signal.author_id = "acct_1"
+        mock_signal.author_username = "testuser"
+        mock_signal.author_display_name = "Test"
+        mock_signal.author_verified = True
+        mock_signal.author_followers = 1000
+        mock_signal.published_at = datetime(2025, 6, 1)
+        mock_signal.likes_count = 10
+        mock_signal.shares_count = 5
+        mock_signal.replies_count = 3
+        mock_signal.views_count = 0
+        mock_signal.has_media = False
+        mock_signal.is_repost = False
+        mock_signal.is_reply = False
+        mock_signal.is_quote = False
+        mock_signal.platform_data = {"upvotes_count": 2, "downvotes_count": 0}
+        mock_signal.raw_api_data = {}
+        mock_signal.created_at = datetime(2025, 6, 1)
+        mock_signal.updated_at = datetime(2025, 6, 1)
+
+        mock_db_ops = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_signal]
+        mock_db_ops.session.execute = AsyncMock(return_value=mock_result)
+
+        ops = SignalOperations(mock_db_ops)
+        results = await ops.get_unprocessed_signals(launch_date="2025-01-01")
+
+        assert len(results) == 1
+        d = results[0]
+
+        # Universal fields
+        assert d["signal_id"] == "sig_100"
+        assert d["source"] == "truth_social"
+        assert d["likes_count"] == 10
+        assert d["shares_count"] == 5
+
+        # Backward-compatible aliases
+        assert d["shitpost_id"] == "sig_100"
+        assert d["username"] == "testuser"
+        assert d["platform"] == "truth_social"
+        assert d["content"] == "<p>Test content</p>"
+        assert d["reblogs_count"] == 5  # shares_count alias
+        assert d["favourites_count"] == 10  # likes_count alias
+        assert d["account_verified"] is True
+        assert d["account_followers_count"] == 1000
+        assert d["upvotes_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_error_propagates(self):
+        """Test that unexpected errors are re-raised."""
+        mock_db_ops = AsyncMock()
+        mock_db_ops.session.execute = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        ops = SignalOperations(mock_db_ops)
+
+        with pytest.raises(RuntimeError, match="DB down"):
+            await ops.get_unprocessed_signals(launch_date="2025-01-01")

--- a/shitty_ui/data.py
+++ b/shitty_ui/data.py
@@ -16,6 +16,9 @@ from shit.logging import get_service_logger
 
 logger = get_service_logger("dashboard_data")
 
+# Table reference -- will be changed to "signals" after full migration
+SIGNALS_TABLE = "truth_social_shitposts"
+
 
 # Simple TTL cache decorator
 def ttl_cache(ttl_seconds: int = 300):

--- a/shitvault/shitpost_operations.py
+++ b/shitvault/shitpost_operations.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from sqlalchemy import select, and_, not_, exists
 from sqlalchemy.exc import IntegrityError
 
+import warnings
+
 from shit.db.database_operations import DatabaseOperations
 from shitvault.shitpost_models import TruthSocialShitpost, Prediction
 
@@ -20,10 +22,21 @@ from shit.logging.service_loggers import DatabaseLogger
 db_logger = DatabaseLogger("shitpost_operations")
 logger = db_logger.logger
 
+_DEPRECATION_MSG = (
+    "ShitpostOperations is deprecated. Use SignalOperations for new code. "
+    "ShitpostOperations will be removed once all consumers are migrated."
+)
+
+
 class ShitpostOperations:
-    """Operations for managing shitposts."""
-    
+    """Operations for managing shitposts.
+
+    .. deprecated::
+        Use :class:`shitvault.signal_operations.SignalOperations` instead.
+    """
+
     def __init__(self, db_ops: DatabaseOperations):
+        warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
         self.db_ops = db_ops
     
     async def store_shitpost(self, shitpost_data: Dict[str, Any]) -> Optional[str]:

--- a/shitvault/signal_models.py
+++ b/shitvault/signal_models.py
@@ -1,0 +1,111 @@
+"""
+Source-Agnostic Signal Model
+SQLAlchemy model for signals from ANY social media or news source.
+Platform-specific data is stored in a JSON blob.
+"""
+
+from typing import Dict, Any
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    Boolean,
+    Float,
+    JSON,
+    Index,
+)
+from sqlalchemy.orm import relationship
+
+from shit.db.data_models import Base, TimestampMixin, IDMixin, model_to_dict
+
+
+class Signal(Base, IDMixin, TimestampMixin):
+    """
+    Source-agnostic signal model.
+
+    Represents a content signal from ANY platform (Truth Social, Twitter/X,
+    RSS, news feeds, etc.). Platform-specific fields are stored in the
+    `platform_data` JSON column.
+
+    Universal fields capture the data every downstream consumer needs:
+    text, author, timestamp, source, and normalized engagement metrics.
+    """
+
+    __tablename__ = "signals"
+
+    # --- Universal Identifiers ---
+    signal_id = Column(String(255), unique=True, index=True, nullable=False)
+    source = Column(String(50), nullable=False, index=True)
+    source_url = Column(String(1000), nullable=True)
+
+    # --- Universal Content ---
+    text = Column(Text, nullable=True)
+    content_html = Column(Text, nullable=True)
+    title = Column(String(500), nullable=True)
+    language = Column(String(10), nullable=True)
+
+    # --- Universal Author ---
+    author_id = Column(String(255), nullable=True)
+    author_username = Column(String(200), nullable=False)
+    author_display_name = Column(String(200), nullable=True)
+    author_verified = Column(Boolean, default=False)
+    author_followers = Column(Integer, default=0)
+
+    # --- Universal Timestamps ---
+    published_at = Column(DateTime, nullable=False, index=True)
+
+    # --- Normalized Engagement (source-agnostic names) ---
+    likes_count = Column(Integer, default=0)
+    shares_count = Column(Integer, default=0)
+    replies_count = Column(Integer, default=0)
+    views_count = Column(Integer, default=0)
+
+    # --- Content Flags ---
+    has_media = Column(Boolean, default=False)
+    is_repost = Column(Boolean, default=False)
+    is_reply = Column(Boolean, default=False)
+    is_quote = Column(Boolean, default=False)
+
+    # --- Platform-Specific Data (JSON blob) ---
+    platform_data = Column(JSON, default=dict)
+
+    # --- Raw API Response ---
+    raw_api_data = Column(JSON, nullable=True)
+
+    # --- Relationships ---
+    predictions = relationship(
+        "Prediction", back_populates="signal", foreign_keys="Prediction.signal_id"
+    )
+
+    # --- Indexes ---
+    __table_args__ = (
+        Index("ix_signals_source_published", "source", "published_at"),
+        Index("ix_signals_author", "author_username"),
+    )
+
+    def __repr__(self):
+        text_preview = (self.text or "")[:50]
+        return f"<Signal(id={self.id}, source='{self.source}', author='{self.author_username}', text='{text_preview}...')>"
+
+    @property
+    def total_engagement(self) -> int:
+        """Sum of all engagement metrics."""
+        return (
+            (self.likes_count or 0)
+            + (self.shares_count or 0)
+            + (self.replies_count or 0)
+        )
+
+    @property
+    def engagement_rate(self) -> float:
+        """Engagement rate relative to author followers."""
+        if not self.author_followers or self.author_followers == 0:
+            return 0.0
+        return self.total_engagement / self.author_followers
+
+
+def signal_to_dict(signal: Signal) -> Dict[str, Any]:
+    """Convert Signal to dictionary."""
+    return model_to_dict(signal)

--- a/shitvault/signal_operations.py
+++ b/shitvault/signal_operations.py
@@ -1,0 +1,187 @@
+"""
+Signal Operations
+Source-agnostic operations for managing signals from any platform.
+"""
+
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+from sqlalchemy import select, and_, not_, exists
+from sqlalchemy.exc import IntegrityError
+
+from shit.db.database_operations import DatabaseOperations
+from shitvault.signal_models import Signal
+from shitvault.shitpost_models import Prediction
+
+from shit.logging.service_loggers import DatabaseLogger
+
+db_logger = DatabaseLogger("signal_operations")
+logger = db_logger.logger
+
+
+class SignalOperations:
+    """CRUD operations for source-agnostic signals."""
+
+    def __init__(self, db_ops: DatabaseOperations):
+        self.db_ops = db_ops
+
+    async def store_signal(self, signal_data: Dict[str, Any]) -> Optional[str]:
+        """Store a signal in the database.
+
+        Args:
+            signal_data: Dictionary matching Signal model fields.
+
+        Returns:
+            String ID of stored signal, or None on integrity error.
+        """
+        try:
+            signal_id = signal_data.get("signal_id")
+
+            existing = await self.db_ops.read_one(Signal, {"signal_id": signal_id})
+            if existing:
+                logger.debug(f"Signal {signal_id} already exists, skipping")
+                return str(existing.id)
+
+            signal = Signal(**signal_data)
+            self.db_ops.session.add(signal)
+            await self.db_ops.session.commit()
+            await self.db_ops.session.refresh(signal)
+
+            logger.info(
+                f"Stored signal {signal.signal_id} (source={signal.source}) with ID: {signal.id}"
+            )
+            return str(signal.id)
+
+        except IntegrityError as e:
+            await self.db_ops.session.rollback()
+            logger.warning(
+                f"Integrity error storing signal {signal_data.get('signal_id')}: {e}"
+            )
+            return None
+        except Exception as e:
+            await self.db_ops.session.rollback()
+            logger.error(
+                f"Error storing signal {signal_data.get('signal_id')}: {e}"
+            )
+            raise
+
+    async def get_unprocessed_signals(
+        self, launch_date: str, limit: int = 10, source: Optional[str] = None
+    ) -> List[Dict]:
+        """
+        Get signals that need LLM analysis.
+
+        Criteria:
+        1. Signal published_at is after launch date
+        2. No existing prediction for this signal
+        3. Optionally filtered by source
+
+        Args:
+            launch_date: ISO date string for minimum timestamp
+            limit: Maximum signals to return
+            source: Optional source filter
+
+        Returns:
+            List of signal dictionaries (includes backward-compatible aliases)
+        """
+        try:
+            launch_datetime = datetime.fromisoformat(
+                launch_date.replace("Z", "+00:00")
+            )
+
+            prediction_exists = select(Prediction.id).where(
+                Prediction.signal_id == Signal.signal_id
+            )
+
+            conditions = [
+                Signal.published_at >= launch_datetime,
+                not_(exists(prediction_exists)),
+            ]
+
+            if source:
+                conditions.append(Signal.source == source)
+
+            stmt = (
+                select(Signal)
+                .where(and_(*conditions))
+                .order_by(Signal.published_at.desc())
+                .limit(limit)
+            )
+
+            result = await self.db_ops.session.execute(stmt)
+            signals = result.scalars().all()
+
+            signal_dicts = []
+            for sig in signals:
+                signal_dict = {
+                    # Universal fields
+                    "id": sig.id,
+                    "signal_id": sig.signal_id,
+                    "source": sig.source,
+                    "source_url": sig.source_url,
+                    "text": sig.text,
+                    "content_html": sig.content_html,
+                    "title": sig.title,
+                    "language": sig.language,
+                    "author_id": sig.author_id,
+                    "author_username": sig.author_username,
+                    "author_display_name": sig.author_display_name,
+                    "author_verified": sig.author_verified,
+                    "author_followers": sig.author_followers,
+                    "published_at": sig.published_at,
+                    "likes_count": sig.likes_count,
+                    "shares_count": sig.shares_count,
+                    "replies_count": sig.replies_count,
+                    "views_count": sig.views_count,
+                    "has_media": sig.has_media,
+                    "is_repost": sig.is_repost,
+                    "is_reply": sig.is_reply,
+                    "is_quote": sig.is_quote,
+                    "platform_data": sig.platform_data,
+                    "raw_api_data": sig.raw_api_data,
+                    "created_at": sig.created_at,
+                    "updated_at": sig.updated_at,
+                    # Backward-compatible aliases (for analyzer, bypass service, etc.)
+                    "shitpost_id": sig.signal_id,
+                    "timestamp": sig.published_at,
+                    "username": sig.author_username,
+                    "platform": sig.source,
+                    "content": sig.content_html,
+                    "reblog": (
+                        sig.platform_data.get("reblog")
+                        if sig.platform_data
+                        else None
+                    ),
+                    "mentions": (
+                        sig.platform_data.get("mentions", [])
+                        if sig.platform_data
+                        else []
+                    ),
+                    "tags": (
+                        sig.platform_data.get("tags", [])
+                        if sig.platform_data
+                        else []
+                    ),
+                    "reblogs_count": sig.shares_count,
+                    "favourites_count": sig.likes_count,
+                    "upvotes_count": (
+                        sig.platform_data.get("upvotes_count", 0)
+                        if sig.platform_data
+                        else 0
+                    ),
+                    "downvotes_count": (
+                        sig.platform_data.get("downvotes_count", 0)
+                        if sig.platform_data
+                        else 0
+                    ),
+                    "account_verified": sig.author_verified,
+                    "account_followers_count": sig.author_followers,
+                    "account_display_name": sig.author_display_name,
+                }
+                signal_dicts.append(signal_dict)
+
+            logger.info(f"Retrieved {len(signal_dicts)} unprocessed signals")
+            return signal_dicts
+
+        except Exception as e:
+            logger.error(f"Error retrieving unprocessed signals: {e}")
+            raise


### PR DESCRIPTION
## Summary
- Adds a generic `signals` table with normalized engagement metrics, content flags (`is_repost`, `is_reply`, `is_quote`), and a `platform_data` JSON blob for platform-specific fields
- `Prediction` model gains dual-FK (`shitpost_id` + `signal_id`) with a `content_id` property for backward compatibility
- S3Processor dual-writes to both `signals` and `truth_social_shitposts` during the migration period
- `SignalTransformer` provides pluggable per-source field mapping (Truth Social implemented, extensible to Twitter/RSS)
- Bypass service, analyzer, and prediction operations updated to work with both Signal and legacy Shitpost data formats
- `ShitpostOperations` deprecated in favor of `SignalOperations`

## Files Changed
**New files (6):** `shitvault/signal_models.py`, `shitvault/signal_operations.py`, `shit/db/signal_utils.py`, `shit_tests/shitvault/test_signal_models.py`, `shit_tests/shitvault/test_signal_operations.py`, `shit_tests/shit/db/test_signal_utils.py`

**Modified files (12):** `shitvault/shitpost_models.py`, `shitvault/prediction_operations.py`, `shitvault/s3_processor.py`, `shitvault/shitpost_operations.py`, `shit/content/bypass_service.py`, `shitpost_ai/shitpost_analyzer.py`, `shitty_ui/data.py`, `shit/s3/s3_data_lake.py`, `shit/db/sync_session.py`, test files, `CHANGELOG.md`

## Test plan
- [x] 34 new tests across 3 files (signal models, operations, transformer)
- [x] All existing tests updated for new method signatures
- [x] Full suite: **1514 passed**, 10 pre-existing failures (unchanged)
- [x] Zero regressions introduced

## Design doc
`documentation/planning/phases/system-evolution_2026-02-11/02_source-agnostic-data-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)