### PR TITLE
feat(ui): add signal-over-trend chart view with price overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Signal-Over-Trend Chart View** - New `/trends` page showing prediction signals overlaid on candlestick price charts
+  - Sentiment-colored markers (green=bullish, red=bearish, gray=neutral)
+  - Marker size scales with prediction confidence
+  - Rich tooltips with thesis text, confidence score, and outcome
+  - Optional 7-day evaluation window overlays
+  - Asset selector and time range controls (30D/90D/180D/1Y)
+  - Signal summary statistics panel below chart
+- **Reusable Chart Component** (`shitty_ui/components/charts.py`) - `build_signal_over_trend_chart()` shared between trends and asset pages
+- **Enhanced Asset Page Chart** - Existing asset page now uses the improved signal overlay component
+- **New navigation link** - "Trends" added to top navigation bar
 - **Source-Agnostic Signal Model** - New `signals` table that can represent content from any platform
   - Universal fields: text, author, timestamp, normalized engagement metrics (`likes_count`, `shares_count`)
   - Platform-specific data stored as JSON (`platform_data` column)

--- a/shit_tests/shitty_ui/test_charts.py
+++ b/shit_tests/shitty_ui/test_charts.py
@@ -1,0 +1,219 @@
+"""Tests for shitty_ui/components/charts.py - Reusable chart builders."""
+
+import sys
+import os
+
+# Add shitty_ui to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+import pytest
+import pandas as pd
+import plotly.graph_objects as go
+from datetime import datetime
+
+from components.charts import build_signal_over_trend_chart, build_empty_signal_chart
+
+
+def _make_prices_df():
+    """Create a sample prices DataFrame for testing."""
+    return pd.DataFrame({
+        "date": pd.to_datetime(["2025-06-01", "2025-06-02", "2025-06-03", "2025-06-04"]),
+        "open": [100.0, 101.0, 102.0, 103.0],
+        "high": [105.0, 106.0, 107.0, 108.0],
+        "low": [99.0, 100.0, 101.0, 102.0],
+        "close": [103.0, 104.0, 105.0, 106.0],
+        "volume": [1000, 1100, 1200, 1300],
+    })
+
+
+def _make_signals_df(**overrides):
+    """Create a sample signals DataFrame for testing."""
+    data = {
+        "prediction_date": pd.to_datetime(["2025-06-02"]),
+        "prediction_sentiment": ["bullish"],
+        "prediction_confidence": [0.85],
+        "thesis": ["Strong earnings expected"],
+        "correct_t7": [True],
+        "return_t7": [2.5],
+        "pnl_t7": [250.0],
+        "post_text": ["Tariffs are great for business"],
+        "price_at_prediction": [104.0],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+class TestBuildSignalOverTrendChart:
+    """Tests for build_signal_over_trend_chart."""
+
+    def test_returns_figure_with_valid_data(self):
+        """Test that a go.Figure is returned with valid price and signal data."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(),
+            symbol="TEST",
+        )
+        assert isinstance(fig, go.Figure)
+        # Should have candlestick + signal marker + 3 legend traces
+        assert len(fig.data) >= 2
+
+    def test_returns_figure_with_empty_signals(self):
+        """Test that chart renders with prices only when signals are empty."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=pd.DataFrame(),
+            symbol="TEST",
+        )
+        assert isinstance(fig, go.Figure)
+        # Candlestick + 3 legend traces (no signal markers)
+        assert len(fig.data) >= 1
+
+    def test_returns_figure_with_empty_prices(self):
+        """Test that chart renders gracefully with no price data."""
+        fig = build_signal_over_trend_chart(
+            prices_df=pd.DataFrame(),
+            signals_df=_make_signals_df(),
+            symbol="TEST",
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_marker_color_matches_sentiment(self):
+        """Test that bullish signals get green markers."""
+        from constants import SENTIMENT_COLORS
+
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(prediction_sentiment=["bullish"]),
+            symbol="TEST",
+        )
+        # Find the scatter trace (not candlestick, not legend traces)
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        assert len(scatter_traces) >= 1
+        assert scatter_traces[0].marker.color == SENTIMENT_COLORS["bullish"]
+
+    def test_bearish_marker_color(self):
+        """Test that bearish signals get red markers."""
+        from constants import SENTIMENT_COLORS
+
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(prediction_sentiment=["bearish"]),
+            symbol="TEST",
+        )
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        assert len(scatter_traces) >= 1
+        assert scatter_traces[0].marker.color == SENTIMENT_COLORS["bearish"]
+
+    def test_marker_size_scales_with_confidence(self):
+        """Test that higher confidence = larger marker."""
+        from constants import MARKER_CONFIG
+
+        # High confidence
+        fig_high = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(prediction_confidence=[0.95]),
+            symbol="TEST",
+        )
+        # Low confidence
+        fig_low = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(prediction_confidence=[0.1]),
+            symbol="TEST",
+        )
+
+        high_traces = [t for t in fig_high.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        low_traces = [t for t in fig_low.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+
+        assert high_traces[0].marker.size > low_traces[0].marker.size
+
+    def test_timeframe_windows_added_when_enabled(self):
+        """Test that vrects are added when show_timeframe_windows=True."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(),
+            symbol="TEST",
+            show_timeframe_windows=True,
+        )
+        # Should have at least one shape (vrect)
+        shapes = fig.layout.shapes
+        assert shapes is not None
+        assert len(shapes) >= 1
+
+    def test_timeframe_windows_not_added_when_disabled(self):
+        """Test that no vrects when show_timeframe_windows=False."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(),
+            symbol="TEST",
+            show_timeframe_windows=False,
+        )
+        shapes = fig.layout.shapes
+        assert shapes is None or len(shapes) == 0
+
+    def test_hover_template_contains_confidence(self):
+        """Test that hover text includes the confidence value."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(prediction_confidence=[0.85]),
+            symbol="TEST",
+        )
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        assert "85%" in scatter_traces[0].hovertemplate
+
+    def test_hover_template_contains_thesis(self):
+        """Test that hover text includes thesis text."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(thesis=["My investment thesis"]),
+            symbol="TEST",
+        )
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        assert "My investment thesis" in scatter_traces[0].hovertemplate
+
+    def test_sentiment_legend_traces_added(self):
+        """Test that legend traces are present for all sentiments."""
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=_make_signals_df(),
+            symbol="TEST",
+        )
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert "Bullish" in legend_names
+        assert "Bearish" in legend_names
+        assert "Neutral" in legend_names
+
+    def test_signal_on_weekend_skipped(self):
+        """Test that a signal on a date with no price data is gracefully skipped."""
+        # Signal date doesn't match any price date
+        signals = _make_signals_df(
+            prediction_date=pd.to_datetime(["2025-06-07"])  # Saturday
+        )
+        fig = build_signal_over_trend_chart(
+            prices_df=_make_prices_df(),
+            signals_df=signals,
+            symbol="TEST",
+        )
+        # Should only have candlestick + 3 legend traces (no marker since no match)
+        scatter_with_data = [t for t in fig.data if isinstance(t, go.Scatter) and t.x[0] is not None]
+        assert len(scatter_with_data) == 0
+
+
+class TestBuildEmptySignalChart:
+    """Tests for build_empty_signal_chart."""
+
+    def test_returns_figure(self):
+        """Test that an empty chart returns a go.Figure."""
+        fig = build_empty_signal_chart()
+        assert isinstance(fig, go.Figure)
+
+    def test_contains_annotation_message(self):
+        """Test that the annotation contains the provided message."""
+        fig = build_empty_signal_chart("Custom message here")
+        annotations = fig.layout.annotations
+        assert len(annotations) == 1
+        assert annotations[0].text == "Custom message here"
+
+    def test_default_message(self):
+        """Test that the default message is 'No data available'."""
+        fig = build_empty_signal_chart()
+        assert fig.layout.annotations[0].text == "No data available"

--- a/shit_tests/shitty_ui/test_trends.py
+++ b/shit_tests/shitty_ui/test_trends.py
@@ -1,0 +1,115 @@
+"""Tests for shitty_ui/pages/trends.py - Trends page layout and callbacks."""
+
+import sys
+import os
+
+# Add shitty_ui to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+import pytest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+from datetime import datetime
+
+from dash import html
+import dash_bootstrap_components as dbc
+
+from pages.trends import create_trends_page, register_trends_callbacks, _build_signal_summary
+
+
+class TestCreateTrendsPage:
+    """Tests for create_trends_page layout."""
+
+    def test_returns_html_div(self):
+        """Test that the page returns an html.Div."""
+        page = create_trends_page()
+        assert isinstance(page, html.Div)
+
+    def test_contains_asset_dropdown(self):
+        """Test that the page contains the asset selector dropdown."""
+        page = create_trends_page()
+        html_str = str(page)
+        assert "trends-asset-selector" in html_str
+
+    def test_contains_range_buttons(self):
+        """Test that the page contains the time range buttons."""
+        page = create_trends_page()
+        html_str = str(page)
+        assert "trends-range-30d" in html_str
+        assert "trends-range-90d" in html_str
+        assert "trends-range-180d" in html_str
+        assert "trends-range-1y" in html_str
+
+    def test_contains_chart_graph(self):
+        """Test that the page contains the chart graph component."""
+        page = create_trends_page()
+        html_str = str(page)
+        assert "trends-signal-chart" in html_str
+
+    def test_contains_options_checklist(self):
+        """Test that the page contains the options checklist."""
+        page = create_trends_page()
+        html_str = str(page)
+        assert "trends-options-checklist" in html_str
+
+    def test_contains_summary_section(self):
+        """Test that the page contains the signal summary section."""
+        page = create_trends_page()
+        html_str = str(page)
+        assert "trends-signal-summary" in html_str
+
+
+class TestRegisterTrendsCallbacks:
+    """Tests for register_trends_callbacks."""
+
+    def test_callbacks_registered_without_error(self):
+        """Test that callbacks register without raising exceptions."""
+        mock_app = MagicMock()
+        mock_app.callback = MagicMock(return_value=lambda f: f)
+        register_trends_callbacks(mock_app)
+        # Should have registered 3 callbacks
+        assert mock_app.callback.call_count == 3
+
+
+class TestBuildSignalSummary:
+    """Tests for _build_signal_summary helper."""
+
+    def test_empty_signals_shows_message(self):
+        """Test that empty signals show a 'no signals' message."""
+        result = _build_signal_summary("TEST", pd.DataFrame())
+        assert isinstance(result, html.Div)
+        html_str = str(result)
+        assert "No prediction signals found" in html_str
+
+    def test_valid_signals_returns_row(self):
+        """Test that valid signals produce a summary row."""
+        signals_df = pd.DataFrame({
+            "prediction_sentiment": ["bullish", "bearish", "bullish"],
+            "prediction_confidence": [0.8, 0.6, 0.9],
+            "correct_t7": [True, False, None],
+        })
+        result = _build_signal_summary("TEST", signals_df)
+        assert isinstance(result, dbc.Row)
+
+    def test_accuracy_calculation(self):
+        """Test that accuracy is calculated correctly."""
+        signals_df = pd.DataFrame({
+            "prediction_sentiment": ["bullish", "bearish", "bullish", "bearish"],
+            "prediction_confidence": [0.8, 0.6, 0.9, 0.7],
+            "correct_t7": [True, True, False, None],
+        })
+        result = _build_signal_summary("TEST", signals_df)
+        # 2 correct out of 3 evaluated = 67%
+        html_str = str(result)
+        assert "67%" in html_str
+
+    def test_all_pending_shows_zero_accuracy(self):
+        """Test that all-pending signals show 0% accuracy."""
+        signals_df = pd.DataFrame({
+            "prediction_sentiment": ["bullish", "bearish"],
+            "prediction_confidence": [0.8, 0.6],
+            "correct_t7": [None, None],
+        })
+        result = _build_signal_summary("TEST", signals_df)
+        html_str = str(result)
+        assert "0%" in html_str

--- a/shitty_ui/components/charts.py
+++ b/shitty_ui/components/charts.py
@@ -1,0 +1,218 @@
+"""Reusable Plotly chart builders for the Shitty UI dashboard."""
+
+from datetime import timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from constants import COLORS, SENTIMENT_COLORS, MARKER_CONFIG, TIMEFRAME_COLORS
+
+
+def build_signal_over_trend_chart(
+    prices_df: pd.DataFrame,
+    signals_df: pd.DataFrame,
+    symbol: str = "",
+    show_timeframe_windows: bool = False,
+    chart_height: int = 500,
+) -> go.Figure:
+    """
+    Build a candlestick chart with prediction signal markers overlaid.
+
+    Args:
+        prices_df: DataFrame with columns: date, open, high, low, close, volume
+        signals_df: DataFrame with columns: prediction_date, prediction_sentiment,
+                    prediction_confidence, thesis, correct_t7, return_t7, pnl_t7,
+                    post_text, price_at_prediction
+        symbol: Ticker symbol for chart title
+        show_timeframe_windows: If True, draw shaded regions for t7 windows
+        chart_height: Height of the chart in pixels
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph
+    """
+    fig = go.Figure()
+
+    # --- Trace 1: Candlestick ---
+    if not prices_df.empty:
+        fig.add_trace(
+            go.Candlestick(
+                x=prices_df["date"],
+                open=prices_df["open"],
+                high=prices_df["high"],
+                low=prices_df["low"],
+                close=prices_df["close"],
+                name=symbol or "Price",
+                increasing_line_color=COLORS["success"],
+                decreasing_line_color=COLORS["danger"],
+                showlegend=False,
+            )
+        )
+
+    # --- Trace 2: Signal Markers ---
+    if not signals_df.empty and not prices_df.empty:
+        for _, signal in signals_df.iterrows():
+            pred_date = signal["prediction_date"]
+            sentiment = (signal.get("prediction_sentiment") or "neutral").lower()
+            confidence = signal.get("prediction_confidence") or 0.5
+            thesis = signal.get("thesis") or ""
+            correct_t7 = signal.get("correct_t7")
+            return_t7 = signal.get("return_t7")
+            pnl_t7 = signal.get("pnl_t7")
+            post_text = signal.get("post_text") or ""
+
+            # Find the price at this date for y-placement
+            price_row = prices_df[prices_df["date"].dt.date == pred_date.date()]
+            if price_row.empty:
+                continue
+
+            y_val = float(price_row.iloc[0]["high"]) * 1.03
+
+            # Color from sentiment
+            marker_color = SENTIMENT_COLORS.get(sentiment, SENTIMENT_COLORS["neutral"])
+
+            # Size from confidence (scale min_size to max_size)
+            size_range = MARKER_CONFIG["max_size"] - MARKER_CONFIG["min_size"]
+            marker_size = MARKER_CONFIG["min_size"] + (confidence * size_range)
+
+            # Shape from sentiment
+            marker_symbol = MARKER_CONFIG["symbols"].get(
+                sentiment, MARKER_CONFIG["symbols"]["neutral"]
+            )
+
+            # Outcome text for tooltip
+            if correct_t7 is True:
+                outcome_text = "CORRECT"
+            elif correct_t7 is False:
+                outcome_text = "INCORRECT"
+            else:
+                outcome_text = "PENDING"
+
+            # Build hover text
+            thesis_preview = (thesis[:100] + "...") if len(thesis) > 100 else thesis
+            post_preview = (post_text[:80] + "...") if len(post_text) > 80 else post_text
+
+            hover_parts = [
+                f"<b>{pred_date.strftime('%Y-%m-%d')}</b>",
+                f"Sentiment: <b>{sentiment.upper()}</b>",
+                f"Confidence: <b>{confidence:.0%}</b>",
+                f"Outcome: <b>{outcome_text}</b>",
+            ]
+            if return_t7 is not None:
+                hover_parts.append(f"7d Return: <b>{return_t7:+.2f}%</b>")
+            if pnl_t7 is not None:
+                hover_parts.append(f"P&L: <b>${pnl_t7:+,.0f}</b>")
+            if thesis_preview:
+                hover_parts.append(f"<br><i>{thesis_preview}</i>")
+
+            hover_text = "<br>".join(hover_parts)
+
+            fig.add_trace(
+                go.Scatter(
+                    x=[pred_date],
+                    y=[y_val],
+                    mode="markers",
+                    marker=dict(
+                        size=marker_size,
+                        color=marker_color,
+                        symbol=marker_symbol,
+                        opacity=MARKER_CONFIG["opacity"],
+                        line=dict(
+                            width=MARKER_CONFIG["border_width"],
+                            color=COLORS["text"],
+                        ),
+                    ),
+                    hovertemplate=hover_text + "<extra></extra>",
+                    showlegend=False,
+                    name=f"{sentiment} signal",
+                )
+            )
+
+            # --- Optional: Timeframe windows ---
+            if show_timeframe_windows and not price_row.empty:
+                _add_timeframe_window(fig, pred_date)
+
+    # --- Layout ---
+    fig.update_layout(
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font_color=COLORS["text"],
+        margin=dict(l=50, r=20, t=30, b=40),
+        xaxis=dict(
+            gridcolor=COLORS["border"],
+            rangeslider=dict(visible=False),
+        ),
+        yaxis=dict(
+            gridcolor=COLORS["border"],
+            title="Price ($)",
+        ),
+        height=chart_height,
+        showlegend=False,
+        hovermode="closest",
+    )
+
+    # Add a custom legend for sentiment markers
+    _add_sentiment_legend(fig)
+
+    return fig
+
+
+def _add_timeframe_window(
+    fig: go.Figure,
+    pred_date: pd.Timestamp,
+) -> None:
+    """Add a shaded rectangle for the 7-day evaluation window."""
+    t7_end = pred_date + timedelta(days=7)
+    fig.add_vrect(
+        x0=pred_date,
+        x1=t7_end,
+        fillcolor=TIMEFRAME_COLORS["t7"],
+        layer="below",
+        line_width=0,
+    )
+
+
+def _add_sentiment_legend(fig: go.Figure) -> None:
+    """Add invisible traces to serve as a sentiment color legend."""
+    for sentiment, color in SENTIMENT_COLORS.items():
+        symbol = MARKER_CONFIG["symbols"][sentiment]
+        fig.add_trace(
+            go.Scatter(
+                x=[None],
+                y=[None],
+                mode="markers",
+                marker=dict(size=10, color=color, symbol=symbol),
+                name=sentiment.capitalize(),
+                showlegend=True,
+            )
+        )
+
+    fig.update_layout(
+        showlegend=True,
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+            font=dict(color=COLORS["text_muted"], size=11),
+        ),
+    )
+
+
+def build_empty_signal_chart(message: str = "No data available") -> go.Figure:
+    """Build an empty chart with a centered message."""
+    fig = go.Figure()
+    fig.add_annotation(
+        text=message,
+        showarrow=False,
+        font=dict(color=COLORS["text_muted"], size=14),
+    )
+    fig.update_layout(
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font_color=COLORS["text_muted"],
+        height=400,
+        xaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+        yaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+    )
+    return fig

--- a/shitty_ui/components/header.py
+++ b/shitty_ui/components/header.py
@@ -61,6 +61,14 @@ def create_header():
                             ),
                             dcc.Link(
                                 [
+                                    html.I(className="fas fa-chart-area me-1"),
+                                    "Trends",
+                                ],
+                                href="/trends",
+                                className="nav-link-custom",
+                            ),
+                            dcc.Link(
+                                [
                                     html.I(className="fas fa-chart-pie me-1"),
                                     "Performance",
                                 ],

--- a/shitty_ui/constants.py
+++ b/shitty_ui/constants.py
@@ -13,3 +13,31 @@ COLORS = {
     "text_muted": "#94a3b8",  # Slate 400 - secondary text
     "border": "#334155",  # Slate 700 - borders
 }
+
+# Sentiment-specific color mapping for chart overlays
+SENTIMENT_COLORS = {
+    "bullish": "#10b981",   # Emerald 500 (same as COLORS["success"])
+    "bearish": "#ef4444",   # Red 500 (same as COLORS["danger"])
+    "neutral": "#94a3b8",   # Slate 400 (same as COLORS["text_muted"])
+}
+
+# Marker configuration for signal overlays
+MARKER_CONFIG = {
+    "min_size": 8,          # Minimum marker size (pixels)
+    "max_size": 22,         # Maximum marker size (pixels)
+    "opacity": 0.85,        # Default marker opacity
+    "border_width": 1.5,    # Marker border width
+    "symbols": {
+        "bullish": "triangle-up",
+        "bearish": "triangle-down",
+        "neutral": "circle",
+    },
+}
+
+# Timeframe window colors (for shaded regions)
+TIMEFRAME_COLORS = {
+    "t1": "rgba(59, 130, 246, 0.06)",   # Blue, very light
+    "t3": "rgba(59, 130, 246, 0.04)",
+    "t7": "rgba(245, 158, 11, 0.04)",   # Amber, very light
+    "t30": "rgba(245, 158, 11, 0.02)",
+}

--- a/shitty_ui/layout.py
+++ b/shitty_ui/layout.py
@@ -35,6 +35,7 @@ from pages.dashboard import (
 )
 from pages.assets import create_asset_page, create_asset_header, register_asset_callbacks
 from pages.signals import create_signal_feed_page, register_signal_callbacks
+from pages.trends import create_trends_page, register_trends_callbacks
 from callbacks.alerts import (
     create_alert_config_panel,
     create_alert_history_panel,
@@ -283,10 +284,14 @@ def register_callbacks(app: Dash):
         if pathname == "/signals":
             return create_signal_feed_page()
 
+        if pathname == "/trends":
+            return create_trends_page()
+
         return create_dashboard_page()
 
     # Delegate to page/callback modules
     register_dashboard_callbacks(app)
     register_asset_callbacks(app)
     register_signal_callbacks(app)
+    register_trends_callbacks(app)
     register_alert_callbacks(app)

--- a/shitty_ui/pages/trends.py
+++ b/shitty_ui/pages/trends.py
@@ -1,0 +1,327 @@
+"""Signal-over-trend page layout and callbacks for /trends route."""
+
+import traceback
+
+from dash import Dash, html, dcc, Input, Output, callback_context, no_update
+import dash_bootstrap_components as dbc
+
+from constants import COLORS
+from components.cards import create_error_card
+from components.charts import build_signal_over_trend_chart, build_empty_signal_chart
+from data import get_price_with_signals, get_active_assets_from_db
+
+
+def create_trends_page() -> html.Div:
+    """Create the /trends page layout."""
+    return html.Div(
+        [
+            # Page header
+            html.Div(
+                [
+                    html.H2(
+                        [
+                            html.I(className="fas fa-chart-area me-2"),
+                            "Signal Over Trend",
+                        ],
+                        style={"margin": 0, "fontWeight": "bold"},
+                    ),
+                    html.P(
+                        "Prediction signals overlaid on market price charts",
+                        style={
+                            "color": COLORS["text_muted"],
+                            "margin": 0,
+                            "fontSize": "0.9rem",
+                        },
+                    ),
+                ],
+                style={"marginBottom": "20px"},
+            ),
+            # Controls row
+            dbc.Card(
+                dbc.CardBody(
+                    dbc.Row(
+                        [
+                            # Asset selector
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Asset",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    dcc.Dropdown(
+                                        id="trends-asset-selector",
+                                        options=[],
+                                        placeholder="Select an asset...",
+                                        style={"fontSize": "0.9rem"},
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                            # Time range buttons
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Time Range",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    html.Div(
+                                        dbc.ButtonGroup(
+                                            [
+                                                dbc.Button("30D", id="trends-range-30d", color="secondary", outline=True, size="sm"),
+                                                dbc.Button("90D", id="trends-range-90d", color="primary", size="sm"),
+                                                dbc.Button("180D", id="trends-range-180d", color="secondary", outline=True, size="sm"),
+                                                dbc.Button("1Y", id="trends-range-1y", color="secondary", outline=True, size="sm"),
+                                            ],
+                                            size="sm",
+                                        ),
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                            # Timeframe window toggle
+                            dbc.Col(
+                                [
+                                    html.Label(
+                                        "Options",
+                                        className="small",
+                                        style={"color": COLORS["text_muted"]},
+                                    ),
+                                    dbc.Checklist(
+                                        options=[{"label": " Show 7-day windows", "value": "show_windows"}],
+                                        value=[],
+                                        id="trends-options-checklist",
+                                        switch=True,
+                                        style={"fontSize": "0.85rem"},
+                                    ),
+                                ],
+                                xs=12, sm=6, md=4,
+                            ),
+                        ],
+                        className="g-3",
+                    ),
+                ),
+                style={
+                    "backgroundColor": COLORS["secondary"],
+                    "border": f"1px solid {COLORS['border']}",
+                    "marginBottom": "20px",
+                },
+            ),
+            # Chart card
+            dbc.Card(
+                [
+                    dbc.CardHeader(
+                        [
+                            html.I(className="fas fa-chart-area me-2"),
+                            html.Span(id="trends-chart-title", children="Select an asset to view chart"),
+                        ],
+                        className="fw-bold",
+                    ),
+                    dbc.CardBody(
+                        dcc.Loading(
+                            type="circle",
+                            color=COLORS["accent"],
+                            children=dcc.Graph(
+                                id="trends-signal-chart",
+                                config={"displayModeBar": True, "displaylogo": False},
+                            ),
+                        ),
+                    ),
+                ],
+                style={"backgroundColor": COLORS["secondary"]},
+                className="mb-4",
+            ),
+            # Signal summary stats row
+            dcc.Loading(
+                type="default",
+                color=COLORS["accent"],
+                children=html.Div(id="trends-signal-summary", className="mb-4"),
+            ),
+        ],
+        style={"padding": "20px", "maxWidth": "1400px", "margin": "0 auto"},
+    )
+
+
+def register_trends_callbacks(app: Dash):
+    """Register all /trends page callbacks."""
+
+    @app.callback(
+        Output("trends-asset-selector", "options"),
+        [Input("url", "pathname")],
+    )
+    def populate_trends_assets(pathname):
+        if pathname != "/trends":
+            return no_update
+        assets = get_active_assets_from_db()
+        return [{"label": a, "value": a} for a in assets]
+
+    @app.callback(
+        [
+            Output("trends-signal-chart", "figure"),
+            Output("trends-chart-title", "children"),
+            Output("trends-signal-summary", "children"),
+        ],
+        [
+            Input("trends-asset-selector", "value"),
+            Input("trends-range-30d", "n_clicks"),
+            Input("trends-range-90d", "n_clicks"),
+            Input("trends-range-180d", "n_clicks"),
+            Input("trends-range-1y", "n_clicks"),
+            Input("trends-options-checklist", "value"),
+        ],
+    )
+    def update_trends_chart(symbol, n30, n90, n180, n1y, options):
+        if not symbol:
+            return (
+                build_empty_signal_chart("Select an asset to view the chart"),
+                "Select an asset to view chart",
+                html.Div(),
+            )
+
+        ctx = callback_context
+        days = 90
+        if ctx.triggered:
+            button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+            if button_id == "trends-range-30d":
+                days = 30
+            elif button_id == "trends-range-90d":
+                days = 90
+            elif button_id == "trends-range-180d":
+                days = 180
+            elif button_id == "trends-range-1y":
+                days = 365
+
+        show_windows = "show_windows" in (options or [])
+
+        try:
+            data = get_price_with_signals(symbol, days=days)
+            prices_df = data["prices"]
+            signals_df = data["signals"]
+
+            if prices_df.empty:
+                return (
+                    build_empty_signal_chart(f"No price data for {symbol}"),
+                    f"{symbol} - No Price Data",
+                    html.Div(),
+                )
+
+            fig = build_signal_over_trend_chart(
+                prices_df=prices_df,
+                signals_df=signals_df,
+                symbol=symbol,
+                show_timeframe_windows=show_windows,
+                chart_height=500,
+            )
+
+            title = f"{symbol} Price with Prediction Signals"
+            summary = _build_signal_summary(symbol, signals_df)
+
+            return fig, title, summary
+
+        except Exception as e:
+            print(f"Error in trends chart: {traceback.format_exc()}")
+            return (
+                build_empty_signal_chart(f"Error: {str(e)[:60]}"),
+                f"{symbol} - Error",
+                create_error_card(f"Error loading data for {symbol}", str(e)),
+            )
+
+    @app.callback(
+        [
+            Output("trends-range-30d", "color"),
+            Output("trends-range-30d", "outline"),
+            Output("trends-range-90d", "color"),
+            Output("trends-range-90d", "outline"),
+            Output("trends-range-180d", "color"),
+            Output("trends-range-180d", "outline"),
+            Output("trends-range-1y", "color"),
+            Output("trends-range-1y", "outline"),
+        ],
+        [
+            Input("trends-range-30d", "n_clicks"),
+            Input("trends-range-90d", "n_clicks"),
+            Input("trends-range-180d", "n_clicks"),
+            Input("trends-range-1y", "n_clicks"),
+        ],
+    )
+    def update_trends_range_buttons(n30, n90, n180, n1y):
+        ctx = callback_context
+        if not ctx.triggered:
+            return "secondary", True, "primary", False, "secondary", True, "secondary", True
+
+        button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+        styles = ["secondary", True, "secondary", True, "secondary", True, "secondary", True]
+        if button_id == "trends-range-30d":
+            styles[0:2] = ["primary", False]
+        elif button_id == "trends-range-90d":
+            styles[2:4] = ["primary", False]
+        elif button_id == "trends-range-180d":
+            styles[4:6] = ["primary", False]
+        elif button_id == "trends-range-1y":
+            styles[6:8] = ["primary", False]
+        else:
+            styles[2:4] = ["primary", False]
+        return tuple(styles)
+
+
+def _build_signal_summary(symbol: str, signals_df) -> html.Div:
+    """Build a summary stats row for the signals shown on the chart."""
+    if signals_df.empty:
+        return html.Div(
+            html.P(
+                f"No prediction signals found for {symbol} in this period.",
+                style={"color": COLORS["text_muted"], "textAlign": "center", "padding": "15px"},
+            )
+        )
+
+    total = len(signals_df)
+    bullish = (signals_df["prediction_sentiment"].str.lower() == "bullish").sum()
+    bearish = (signals_df["prediction_sentiment"].str.lower() == "bearish").sum()
+    avg_conf = signals_df["prediction_confidence"].mean() if "prediction_confidence" in signals_df.columns else 0
+
+    correct_col = signals_df.get("correct_t7")
+    if correct_col is not None:
+        evaluated = correct_col.notna().sum()
+        correct = (correct_col == True).sum()  # noqa: E712
+        accuracy = (correct / evaluated * 100) if evaluated > 0 else 0
+    else:
+        evaluated = 0
+        correct = 0
+        accuracy = 0
+
+    return dbc.Row(
+        [
+            dbc.Col(_mini_stat("Total Signals", str(total), COLORS["accent"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Bullish", str(bullish), COLORS["success"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Bearish", str(bearish), COLORS["danger"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Avg Confidence", f"{avg_conf:.0%}", COLORS["warning"]), md=2, xs=4),
+            dbc.Col(_mini_stat("Evaluated", str(evaluated), COLORS["text_muted"]), md=2, xs=4),
+            dbc.Col(
+                _mini_stat(
+                    "Accuracy",
+                    f"{accuracy:.0f}%",
+                    COLORS["success"] if accuracy > 50 else COLORS["danger"],
+                ),
+                md=2, xs=4,
+            ),
+        ],
+        className="g-2",
+    )
+
+
+def _mini_stat(label: str, value: str, color: str) -> html.Div:
+    """Small stat display for the summary row."""
+    return html.Div(
+        [
+            html.Div(value, style={"fontSize": "1.2rem", "fontWeight": "bold", "color": color}),
+            html.Div(label, style={"fontSize": "0.75rem", "color": COLORS["text_muted"]}),
+        ],
+        style={
+            "textAlign": "center",
+            "padding": "10px",
+            "backgroundColor": COLORS["secondary"],
+            "borderRadius": "8px",
+            "border": f"1px solid {COLORS['border']}",
+        },
+    )


### PR DESCRIPTION
## Summary
- New `/trends` page with candlestick price charts overlaid with prediction signal markers
- Reusable `build_signal_over_trend_chart()` component shared between `/trends` and `/assets` pages
- Sentiment-colored markers (green=bullish, red=bearish, gray=neutral), confidence-scaled size, and rich tooltips with thesis/outcome/P&L
- Asset selector dropdown, time range controls (30D/90D/180D/1Y), optional 7-day window overlays, and signal summary stats panel
- Asset page chart upgraded from basic correctness markers to enhanced signal overlay component

## Files Changed
**Created:**
- `shitty_ui/components/charts.py` - Reusable chart builders
- `shitty_ui/pages/trends.py` - /trends page layout + callbacks
- `shit_tests/shitty_ui/test_charts.py` - 15 chart component tests
- `shit_tests/shitty_ui/test_trends.py` - 11 trends page tests

**Modified:**
- `shitty_ui/constants.py` - SENTIMENT_COLORS, MARKER_CONFIG, TIMEFRAME_COLORS
- `shitty_ui/data.py` - `get_price_with_signals()`, `get_multi_asset_signals()`
- `shitty_ui/layout.py` - Route + callback registration for /trends
- `shitty_ui/components/header.py` - "Trends" nav link
- `shitty_ui/pages/assets.py` - Upgraded to use new chart component
- `CHANGELOG.md`

## Test plan
- [x] 26 new tests pass (15 chart + 11 trends)
- [x] Full suite: 1540 passed, 10 pre-existing failures (unchanged)
- [ ] Manual: Navigate to `/trends`, select asset, verify chart renders with markers
- [ ] Manual: Test 30D/90D/180D/1Y range buttons
- [ ] Manual: Toggle "Show 7-day windows" checkbox
- [ ] Manual: Navigate to `/assets/AAPL`, verify enhanced chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)