### PR TITLE
feat: harvester abstraction layer with registry pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Harvester Abstraction Layer** - Multi-source harvesting interface
+  - `SignalHarvester` abstract base class with standardized lifecycle (init, connect, harvest, cleanup)
+  - `HarvesterRegistry` for config-driven source management with `create_default_registry()`
+  - Shared data models: `HarvestResult`, `HarvestSummary`, `HarvesterConfig`
+  - Skeleton `TwitterHarvester` as template for future source implementations
+  - `--source` CLI flag for harvester and `--sources` for orchestrator
+  - `ENABLED_HARVESTERS` environment variable for source selection
 - **Signal-Over-Trend Chart View** - New `/trends` page showing prediction signals overlaid on candlestick price charts
   - Sentiment-colored markers (green=bullish, red=bearish, gray=neutral)
   - Marker size scales with prediction confidence
@@ -27,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dual-FK on Predictions** - `Prediction.signal_id` added alongside legacy `shitpost_id` with `content_id` property
 
 ### Changed
+- **TruthSocialS3Harvester** now implements `SignalHarvester` interface
+  - Backward-compatible: `harvest_shitposts()` still works for existing callers
+  - Harvest loop logic moved to shared base class
+  - S3 prefix preserved as `truth-social` (hyphenated) for existing data compatibility
+- **Orchestrator** updated to support running multiple harvesters sequentially via `--sources` flag
 - **S3 Processor** - Now accepts `source` parameter and dual-writes to both `signals` and `truth_social_shitposts`
 - **Bypass Service** - `_is_retruth()` now checks `is_repost` flag before legacy `reblog` field
 - **Analyzer** - `_prepare_enhanced_content()` uses generic field names with fallback to legacy names

--- a/shit/config/shitpost_settings.py
+++ b/shit/config/shitpost_settings.py
@@ -104,6 +104,20 @@ class Settings(BaseSettings):
     )
     AWS_REGION: str = Field(default="us-east-1", env="AWS_REGION")
 
+    # Multi-Source Harvester Configuration
+    ENABLED_HARVESTERS: str = Field(
+        default="truth_social",
+        env="ENABLED_HARVESTERS",
+    )  # Comma-separated list of enabled harvester source names
+
+    # Twitter/X Configuration (Future)
+    TWITTER_API_KEY: Optional[str] = Field(default=None, env="TWITTER_API_KEY")
+    TWITTER_API_SECRET: Optional[str] = Field(default=None, env="TWITTER_API_SECRET")
+    TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None, env="TWITTER_BEARER_TOKEN")
+    TWITTER_TARGET_USERS: str = Field(
+        default="", env="TWITTER_TARGET_USERS"
+    )  # Comma-separated Twitter usernames to monitor
+
     # Logging
     LOG_LEVEL: str = Field(default="INFO", env="LOG_LEVEL")
     FILE_LOGGING: bool = Field(default=False, env="FILE_LOGGING")
@@ -147,6 +161,10 @@ class Settings(BaseSettings):
         if self.LLM_PROVIDER == "grok":
             return "https://api.x.ai/v1"
         return None
+
+    def get_enabled_harvester_names(self) -> list[str]:
+        """Parse ENABLED_HARVESTERS into a list of source names."""
+        return [h.strip() for h in self.ENABLED_HARVESTERS.split(",") if h.strip()]
 
     def is_production(self) -> bool:
         """Check if running in production environment."""

--- a/shit_tests/shitposts/test_base_harvester.py
+++ b/shit_tests/shitposts/test_base_harvester.py
@@ -1,0 +1,407 @@
+"""
+Tests for SignalHarvester abstract base class.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvestResult, HarvestSummary, HarvesterStatus
+
+
+# Concrete test implementation
+class MockHarvester(SignalHarvester):
+    """Minimal concrete implementation for testing the base class."""
+
+    def __init__(self, items=None, **kwargs):
+        super().__init__(**kwargs)
+        self._items = items or []
+        self._batch_index = 0
+        self._connection_tested = False
+
+    def get_source_name(self) -> str:
+        return "mock_source"
+
+    async def _test_connection(self) -> None:
+        self._connection_tested = True
+
+    async def _fetch_batch(self, cursor=None):
+        if self._batch_index >= len(self._items):
+            return [], None
+        batch = self._items[self._batch_index]
+        self._batch_index += 1
+        next_cursor = str(self._batch_index) if self._batch_index < len(self._items) else None
+        return batch, next_cursor
+
+    def _extract_item_id(self, item):
+        return item.get("id", "")
+
+    def _extract_timestamp(self, item):
+        return datetime.fromisoformat(item.get("created_at", "2024-01-01T00:00:00"))
+
+    def _extract_content_preview(self, item):
+        return item.get("text", "")[:100]
+
+
+class TestSignalHarvesterInterface:
+    """Test that abstract interface is enforced."""
+
+    def test_cannot_instantiate_abstract_class(self):
+        with pytest.raises(TypeError):
+            SignalHarvester()
+
+    def test_concrete_implementation_instantiates(self):
+        harvester = MockHarvester()
+        assert harvester.get_source_name() == "mock_source"
+
+    def test_default_parameters(self):
+        harvester = MockHarvester()
+        assert harvester.mode == "incremental"
+        assert harvester.start_date is None
+        assert harvester.end_date is None
+        assert harvester.limit is None
+
+    def test_custom_parameters(self):
+        harvester = MockHarvester(
+            mode="range",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            limit=100
+        )
+        assert harvester.mode == "range"
+        assert harvester.start_datetime == datetime(2024, 1, 1)
+        assert harvester.limit == 100
+
+    def test_s3_prefix_default(self):
+        harvester = MockHarvester()
+        assert harvester._get_s3_prefix() == "mock_source"
+
+    def test_api_call_count_starts_zero(self):
+        harvester = MockHarvester()
+        assert harvester.api_call_count == 0
+
+    def test_start_time_initially_none(self):
+        harvester = MockHarvester()
+        assert harvester._start_time is None
+
+    def test_s3_data_lake_initially_none(self):
+        harvester = MockHarvester()
+        assert harvester.s3_data_lake is None
+
+    def test_date_parsing_start(self):
+        harvester = MockHarvester(start_date="2024-06-15")
+        assert harvester.start_datetime == datetime(2024, 6, 15)
+
+    def test_date_parsing_end(self):
+        harvester = MockHarvester(end_date="2024-06-15")
+        assert harvester.end_datetime == datetime(2024, 6, 15)
+
+    def test_end_date_defaults_to_today(self):
+        harvester = MockHarvester()
+        assert harvester.end_datetime is not None
+        assert harvester.end_datetime.hour == 23
+        assert harvester.end_datetime.minute == 59
+
+
+class TestSignalHarvesterInitialize:
+    """Test the initialize() method."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_dry_run(self):
+        harvester = MockHarvester()
+        await harvester.initialize(dry_run=True)
+        assert harvester._connection_tested is True
+        assert harvester.s3_data_lake is None
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_s3(self):
+        harvester = MockHarvester()
+        with patch('shitposts.base_harvester.S3DataLake') as mock_s3_class, \
+             patch('shitposts.base_harvester.settings') as mock_settings:
+            mock_settings.S3_BUCKET_NAME = "test-bucket"
+            mock_settings.AWS_REGION = "us-east-1"
+            mock_settings.AWS_ACCESS_KEY_ID = "key"
+            mock_settings.AWS_SECRET_ACCESS_KEY = "secret"
+            mock_s3 = AsyncMock()
+            mock_s3_class.return_value = mock_s3
+
+            await harvester.initialize(dry_run=False)
+
+            assert harvester.s3_data_lake is not None
+            mock_s3.initialize.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_initialize_sets_start_time(self):
+        harvester = MockHarvester()
+        await harvester.initialize(dry_run=True)
+        assert harvester._start_time is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_calls_test_connection(self):
+        harvester = MockHarvester()
+        await harvester.initialize(dry_run=True)
+        assert harvester._connection_tested is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_propagates_connection_error(self):
+        class FailingHarvester(MockHarvester):
+            async def _test_connection(self):
+                raise ConnectionError("Cannot connect")
+
+        harvester = FailingHarvester()
+        with pytest.raises(ConnectionError, match="Cannot connect"):
+            await harvester.initialize(dry_run=True)
+
+
+class TestSignalHarvesterHarvest:
+    """Test the harvest() generator."""
+
+    @pytest.mark.asyncio
+    async def test_harvest_yields_results(self):
+        items = [[
+            {"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Hello"},
+            {"id": "002", "created_at": "2024-01-15T11:00:00", "text": "World"},
+        ]]
+        harvester = MockHarvester(items=items, mode="backfill")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="mock/raw/2024/01/15/001.json")
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="mock/raw/2024/01/15/001.json")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 2
+        assert isinstance(results[0], HarvestResult)
+        assert results[0].source_name == "mock_source"
+        assert results[0].source_post_id == "001"
+
+    @pytest.mark.asyncio
+    async def test_harvest_respects_limit(self):
+        items = [[
+            {"id": "001", "created_at": "2024-01-15T10:00:00", "text": "A"},
+            {"id": "002", "created_at": "2024-01-15T11:00:00", "text": "B"},
+            {"id": "003", "created_at": "2024-01-15T12:00:00", "text": "C"},
+        ]]
+        harvester = MockHarvester(items=items, limit=2, mode="backfill")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_harvest_dry_run_skips_s3(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Test"}]]
+        harvester = MockHarvester(items=items)
+
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+
+        assert len(results) == 1
+        assert harvester.s3_data_lake is None
+
+    @pytest.mark.asyncio
+    async def test_harvest_dry_run_generates_key(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Test"}]]
+        harvester = MockHarvester(items=items)
+
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+
+        assert "mock_source/raw/2024/01/15/001.json" in results[0].s3_key
+
+    @pytest.mark.asyncio
+    async def test_harvest_incremental_stops_on_existing(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Exists"}]]
+        harvester = MockHarvester(items=items, mode="incremental")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.check_object_exists = AsyncMock(return_value=True)
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 0  # Should stop, not yield
+
+    @pytest.mark.asyncio
+    async def test_harvest_incremental_processes_new(self):
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "New post"}]]
+        harvester = MockHarvester(items=items, mode="incremental")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.check_object_exists = AsyncMock(return_value=False)
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_harvest_empty_batch(self):
+        harvester = MockHarvester(items=[])
+
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_harvest_multiple_batches(self):
+        items = [
+            [{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Batch 1"}],
+            [{"id": "002", "created_at": "2024-01-15T11:00:00", "text": "Batch 2"}],
+        ]
+        harvester = MockHarvester(items=items, mode="backfill")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_harvest_date_filtering_skips_future(self):
+        """Items after end_date are skipped (cursor continues)."""
+        items = [[
+            {"id": "001", "created_at": "2025-06-01T10:00:00", "text": "Future"},
+            {"id": "002", "created_at": "2024-06-15T10:00:00", "text": "In range"},
+        ]]
+        harvester = MockHarvester(
+            items=items,
+            mode="range",
+            start_date="2024-01-01",
+            end_date="2024-12-31"
+        )
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        assert len(results) == 1
+        assert results[0].source_post_id == "002"
+
+    @pytest.mark.asyncio
+    async def test_harvest_date_filtering_stops_on_past(self):
+        """Items before start_date cause the harvest to stop."""
+        items = [[
+            {"id": "001", "created_at": "2023-06-01T10:00:00", "text": "Too old"},
+        ]]
+        harvester = MockHarvester(
+            items=items,
+            mode="range",
+            start_date="2024-01-01",
+            end_date="2024-12-31"
+        )
+
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_harvest_result_fields(self):
+        items = [[{"id": "XYZ", "created_at": "2024-03-10T15:30:00", "text": "Hello world"}]]
+        harvester = MockHarvester(items=items)
+
+        results = []
+        async for result in harvester.harvest(dry_run=True):
+            results.append(result)
+
+        r = results[0]
+        assert r.source_name == "mock_source"
+        assert r.source_post_id == "XYZ"
+        assert r.timestamp == "2024-03-10T15:30:00"
+        assert r.content_preview == "Hello world"
+        assert r.stored_at is not None
+
+    @pytest.mark.asyncio
+    async def test_harvest_s3_timeout_continues(self):
+        """S3 check timeout should not stop the harvest."""
+        import asyncio
+        items = [[{"id": "001", "created_at": "2024-01-15T10:00:00", "text": "Test"}]]
+        harvester = MockHarvester(items=items, mode="incremental")
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.check_object_exists = AsyncMock(side_effect=asyncio.TimeoutError)
+        harvester.s3_data_lake._generate_s3_key = MagicMock(return_value="key")
+        harvester.s3_data_lake.store_raw_data = AsyncMock(return_value="key")
+
+        results = []
+        async for result in harvester.harvest():
+            results.append(result)
+
+        # Should process the item despite timeout
+        assert len(results) == 1
+
+
+class TestSignalHarvesterCleanup:
+    """Test cleanup method."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_with_s3(self):
+        harvester = MockHarvester()
+        harvester.s3_data_lake = AsyncMock()
+        harvester.s3_data_lake.cleanup = AsyncMock()
+
+        await harvester.cleanup()
+
+        harvester.s3_data_lake.cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_s3(self):
+        harvester = MockHarvester()
+        harvester.s3_data_lake = None
+
+        # Should not raise
+        await harvester.cleanup()
+
+
+class TestSignalHarvesterSummary:
+    """Test get_summary method."""
+
+    def test_get_summary_success(self):
+        harvester = MockHarvester()
+        harvester._start_time = "2024-01-15T10:00:00"
+        harvester.api_call_count = 5
+
+        summary = harvester.get_summary(
+            total_harvested=42,
+            status=HarvesterStatus.SUCCESS,
+        )
+
+        assert isinstance(summary, HarvestSummary)
+        assert summary.source_name == "mock_source"
+        assert summary.total_harvested == 42
+        assert summary.total_api_calls == 5
+        assert summary.status == HarvesterStatus.SUCCESS
+        assert summary.error_message is None
+
+    def test_get_summary_with_error(self):
+        harvester = MockHarvester()
+
+        summary = harvester.get_summary(
+            total_harvested=0,
+            status=HarvesterStatus.FAILED,
+            error="Connection refused",
+        )
+
+        assert summary.status == HarvesterStatus.FAILED
+        assert summary.error_message == "Connection refused"

--- a/shit_tests/shitposts/test_harvester_registry.py
+++ b/shit_tests/shitposts/test_harvester_registry.py
@@ -1,0 +1,199 @@
+"""
+Tests for HarvesterRegistry and create_default_registry.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from typing import Dict, List, Optional
+from datetime import datetime
+
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_registry import HarvesterRegistry, create_default_registry
+from shitposts.harvester_models import HarvesterConfig
+
+
+# Minimal concrete implementation for registry tests
+class FakeHarvesterA(SignalHarvester):
+    def get_source_name(self):
+        return "fake_a"
+    async def _test_connection(self):
+        pass
+    async def _fetch_batch(self, cursor=None):
+        return [], None
+    def _extract_item_id(self, item):
+        return item.get("id", "")
+    def _extract_timestamp(self, item):
+        return datetime(2024, 1, 1)
+    def _extract_content_preview(self, item):
+        return ""
+
+
+class FakeHarvesterB(SignalHarvester):
+    def get_source_name(self):
+        return "fake_b"
+    async def _test_connection(self):
+        pass
+    async def _fetch_batch(self, cursor=None):
+        return [], None
+    def _extract_item_id(self, item):
+        return item.get("id", "")
+    def _extract_timestamp(self, item):
+        return datetime(2024, 1, 1)
+    def _extract_content_preview(self, item):
+        return ""
+
+
+class TestHarvesterRegistry:
+    """Tests for HarvesterRegistry."""
+
+    def test_register_valid_class(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        assert "fake_a" in registry.list_sources()
+
+    def test_register_with_config(self):
+        registry = HarvesterRegistry()
+        config = HarvesterConfig(source_name="fake_a", enabled=False)
+        registry.register("fake_a", FakeHarvesterA, config=config)
+        assert registry.get_config("fake_a").enabled is False
+
+    def test_register_without_config_creates_default(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        config = registry.get_config("fake_a")
+        assert config is not None
+        assert config.source_name == "fake_a"
+        assert config.enabled is True
+
+    def test_register_invalid_class(self):
+        registry = HarvesterRegistry()
+        with pytest.raises(TypeError, match="must be a subclass of SignalHarvester"):
+            registry.register("bad", dict)
+
+    def test_register_overwrites_existing(self):
+        registry = HarvesterRegistry()
+        registry.register("source", FakeHarvesterA)
+        registry.register("source", FakeHarvesterB)
+        assert registry.get_class("source") is FakeHarvesterB
+
+    def test_unregister(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        registry.unregister("fake_a")
+        assert "fake_a" not in registry.list_sources()
+
+    def test_unregister_nonexistent(self):
+        registry = HarvesterRegistry()
+        # Should not raise
+        registry.unregister("nonexistent")
+
+    def test_get_class(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        assert registry.get_class("fake_a") is FakeHarvesterA
+
+    def test_get_class_unknown(self):
+        registry = HarvesterRegistry()
+        assert registry.get_class("unknown") is None
+
+    def test_get_config(self):
+        registry = HarvesterRegistry()
+        config = HarvesterConfig(source_name="fake_a", limit=50)
+        registry.register("fake_a", FakeHarvesterA, config=config)
+        assert registry.get_config("fake_a").limit == 50
+
+    def test_get_config_unknown(self):
+        registry = HarvesterRegistry()
+        assert registry.get_config("unknown") is None
+
+    def test_list_sources(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        registry.register("fake_b", FakeHarvesterB)
+        sources = registry.list_sources()
+        assert "fake_a" in sources
+        assert "fake_b" in sources
+
+    def test_list_sources_empty(self):
+        registry = HarvesterRegistry()
+        assert registry.list_sources() == []
+
+    def test_list_enabled_sources(self):
+        registry = HarvesterRegistry()
+        registry.register("enabled", FakeHarvesterA, HarvesterConfig(source_name="enabled", enabled=True))
+        registry.register("disabled", FakeHarvesterB, HarvesterConfig(source_name="disabled", enabled=False))
+        enabled = registry.list_enabled_sources()
+        assert "enabled" in enabled
+        assert "disabled" not in enabled
+
+    def test_create_harvester(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA)
+        harvester = registry.create_harvester("fake_a", mode="backfill", limit=10)
+        assert isinstance(harvester, FakeHarvesterA)
+        assert harvester.mode == "backfill"
+        assert harvester.limit == 10
+
+    def test_create_harvester_unknown_source(self):
+        registry = HarvesterRegistry()
+        with pytest.raises(KeyError, match="Unknown source"):
+            registry.create_harvester("nonexistent")
+
+    def test_create_all_enabled(self):
+        registry = HarvesterRegistry()
+        registry.register("enabled", FakeHarvesterA, HarvesterConfig(source_name="enabled", enabled=True))
+        registry.register("disabled", FakeHarvesterB, HarvesterConfig(source_name="disabled", enabled=False))
+
+        harvesters = registry.create_all_enabled(mode="incremental")
+
+        assert len(harvesters) == 1
+        assert isinstance(harvesters[0], FakeHarvesterA)
+
+    def test_create_all_enabled_empty(self):
+        registry = HarvesterRegistry()
+        assert registry.create_all_enabled() == []
+
+    def test_create_all_enabled_passes_params(self):
+        registry = HarvesterRegistry()
+        registry.register("fake_a", FakeHarvesterA, HarvesterConfig(source_name="fake_a", enabled=True))
+
+        harvesters = registry.create_all_enabled(
+            mode="range",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            limit=50,
+        )
+
+        assert len(harvesters) == 1
+        h = harvesters[0]
+        assert h.mode == "range"
+        assert h.start_date == "2024-01-01"
+        assert h.end_date == "2024-12-31"
+        assert h.limit == 50
+
+
+class TestCreateDefaultRegistry:
+    """Tests for create_default_registry factory."""
+
+    def test_includes_truth_social(self):
+        with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
+            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_API_KEY = "test_key"
+            registry = create_default_registry()
+            assert "truth_social" in registry.list_sources()
+
+    def test_truth_social_is_enabled(self):
+        with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
+            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_API_KEY = "test_key"
+            registry = create_default_registry()
+            assert "truth_social" in registry.list_enabled_sources()
+
+    def test_creates_truth_social_harvester(self):
+        from shitposts.truth_social_s3_harvester import TruthSocialS3Harvester
+        with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
+            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_API_KEY = "test_key"
+            registry = create_default_registry()
+            harvester = registry.create_harvester("truth_social")
+            assert isinstance(harvester, TruthSocialS3Harvester)

--- a/shit_tests/shitposts/test_shitposts_cli.py
+++ b/shit_tests/shitposts/test_shitposts_cli.py
@@ -257,14 +257,14 @@ class TestPrintFunctions:
         print_harvest_start("incremental", limit=None)
         
         captured = capsys.readouterr()
-        assert "🚀 Starting Truth Social S3 harvesting in incremental mode..." in captured.out
+        assert "Starting Truth Social S3 harvesting in incremental mode..." in captured.out
 
     def test_print_harvest_start_with_limit(self, capsys):
         """Test print_harvest_start with limit."""
         print_harvest_start("backfill", limit=100)
-        
+
         captured = capsys.readouterr()
-        assert "🚀 Starting Truth Social S3 harvesting in backfill mode (limit: 100)..." in captured.out
+        assert "Starting Truth Social S3 harvesting in backfill mode (limit: 100)..." in captured.out
 
     def test_print_harvest_progress(self, capsys):
         """Test print_harvest_progress function."""

--- a/shit_tests/shitposts/test_twitter_harvester.py
+++ b/shit_tests/shitposts/test_twitter_harvester.py
@@ -1,0 +1,104 @@
+"""
+Tests for TwitterHarvester skeleton.
+"""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from shitposts.twitter_harvester import TwitterHarvester
+from shitposts.base_harvester import SignalHarvester
+from datetime import datetime
+
+
+class TestTwitterHarvester:
+    """Tests for the TwitterHarvester skeleton implementation."""
+
+    @pytest.fixture
+    def harvester(self):
+        with patch('shitposts.twitter_harvester.settings') as mock_settings:
+            mock_settings.TWITTER_BEARER_TOKEN = "test_token"
+            mock_settings.TWITTER_TARGET_USERS = "user1,user2"
+            return TwitterHarvester()
+
+    def test_is_signal_harvester(self, harvester):
+        """Test that TwitterHarvester is a SignalHarvester subclass."""
+        assert isinstance(harvester, SignalHarvester)
+
+    def test_source_name(self, harvester):
+        """Test that get_source_name returns 'twitter'."""
+        assert harvester.get_source_name() == "twitter"
+
+    def test_parse_target_users(self, harvester):
+        """Test that target users are parsed from settings."""
+        assert harvester.target_users == ["user1", "user2"]
+
+    def test_custom_target_users(self):
+        """Test that custom target users override settings."""
+        with patch('shitposts.twitter_harvester.settings') as mock_settings:
+            mock_settings.TWITTER_BEARER_TOKEN = "test_token"
+            mock_settings.TWITTER_TARGET_USERS = ""
+            harvester = TwitterHarvester(target_users=["custom_user"])
+            assert harvester.target_users == ["custom_user"]
+
+    @pytest.mark.asyncio
+    async def test_test_connection_raises_not_implemented(self, harvester):
+        """Test that _test_connection raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match="skeleton"):
+            await harvester._test_connection()
+
+    @pytest.mark.asyncio
+    async def test_test_connection_without_token(self):
+        """Test that _test_connection raises ValueError without token."""
+        with patch('shitposts.twitter_harvester.settings') as mock_settings:
+            mock_settings.TWITTER_BEARER_TOKEN = None
+            mock_settings.TWITTER_TARGET_USERS = ""
+            harvester = TwitterHarvester()
+            with pytest.raises(ValueError, match="TWITTER_BEARER_TOKEN"):
+                await harvester._test_connection()
+
+    @pytest.mark.asyncio
+    async def test_fetch_batch_raises_not_implemented(self, harvester):
+        """Test that _fetch_batch raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match="skeleton"):
+            await harvester._fetch_batch()
+
+    def test_extract_item_id(self, harvester):
+        """Test tweet ID extraction."""
+        assert harvester._extract_item_id({"id": "12345"}) == "12345"
+        assert harvester._extract_item_id({}) == ""
+
+    def test_extract_timestamp(self, harvester):
+        """Test tweet timestamp extraction."""
+        ts = harvester._extract_timestamp({"created_at": "2024-01-15T10:30:00Z"})
+        assert ts == datetime(2024, 1, 15, 10, 30, 0)
+        assert ts.tzinfo is None
+
+    def test_extract_content_preview(self, harvester):
+        """Test tweet content preview extraction."""
+        assert harvester._extract_content_preview({"text": "Hello"}) == "Hello"
+        assert harvester._extract_content_preview({}) == "No content"
+
+        long_text = "A" * 200
+        preview = harvester._extract_content_preview({"text": long_text})
+        assert len(preview) == 103  # 100 + "..."
+        assert preview.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_session(self, harvester):
+        """Test that cleanup closes the aiohttp session."""
+        harvester.session = AsyncMock()
+        harvester.session.close = AsyncMock()
+        harvester.s3_data_lake = None
+
+        await harvester.cleanup()
+
+        harvester.session.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_session(self, harvester):
+        """Test cleanup when session is None."""
+        harvester.session = None
+        harvester.s3_data_lake = None
+
+        # Should not raise
+        await harvester.cleanup()

--- a/shitposts/__init__.py
+++ b/shitposts/__init__.py
@@ -1,0 +1,17 @@
+"""
+Shitposts Package
+Signal harvesting from multiple data sources.
+"""
+
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_registry import HarvesterRegistry, create_default_registry
+from shitposts.harvester_models import HarvestResult, HarvestSummary, HarvesterConfig
+
+__all__ = [
+    "SignalHarvester",
+    "HarvesterRegistry",
+    "create_default_registry",
+    "HarvestResult",
+    "HarvestSummary",
+    "HarvesterConfig",
+]

--- a/shitposts/__main__.py
+++ b/shitposts/__main__.py
@@ -1,5 +1,10 @@
 """
 CLI entry point for shitposts package.
+
+Supports:
+    python -m shitposts                          # Truth Social (default)
+    python -m shitposts --source truth_social    # Explicit source
+    python -m shitposts --source twitter         # Future: Twitter source
 """
 import asyncio
 from shitposts.truth_social_s3_harvester import main

--- a/shitposts/base_harvester.py
+++ b/shitposts/base_harvester.py
@@ -1,0 +1,315 @@
+"""
+Signal Harvester Base Class
+Abstract interface for all data source harvesters.
+"""
+
+import abc
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator, Dict, Optional, List
+
+from shit.s3 import S3DataLake, S3Config
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+from shitposts.harvester_models import (
+    HarvestResult,
+    HarvestSummary,
+    HarvesterStatus,
+)
+
+logger = get_service_logger("harvester")
+
+
+class SignalHarvester(abc.ABC):
+    """Abstract base class for all signal harvesters.
+
+    Every data source (Truth Social, Twitter, SEC filings, news feeds, etc.)
+    implements this interface. The orchestrator and registry interact only
+    through these methods.
+
+    Lifecycle:
+        1. __init__(config) -- configure mode, dates, limits
+        2. initialize(dry_run) -- establish connections, verify API access
+        3. harvest(dry_run) -- yield HarvestResult items
+        4. cleanup() -- release resources
+    """
+
+    def __init__(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+    ):
+        """Initialize the harvester with common parameters.
+
+        Args:
+            mode: Harvesting mode - "incremental", "backfill", "range", "from_date"
+            start_date: Start date for range/from_date modes (YYYY-MM-DD)
+            end_date: End date for range mode (YYYY-MM-DD)
+            limit: Maximum number of posts to harvest (optional)
+        """
+        self.mode = mode
+        self.start_date = start_date
+        self.end_date = end_date
+        self.limit = limit
+
+        # Parse dates if provided
+        self.start_datetime: Optional[datetime] = None
+        self.end_datetime: Optional[datetime] = None
+
+        if start_date:
+            self.start_datetime = datetime.fromisoformat(start_date).replace(tzinfo=None)
+        if end_date:
+            self.end_datetime = datetime.fromisoformat(end_date).replace(tzinfo=None)
+        else:
+            self.end_datetime = datetime.now().replace(
+                hour=23, minute=59, second=59, microsecond=999999
+            )
+
+        # S3 Data Lake (initialized in initialize())
+        self.s3_data_lake: Optional[S3DataLake] = None
+
+        # Tracking
+        self.api_call_count = 0
+        self._start_time: Optional[str] = None
+
+    # -- Abstract methods (must be implemented by each source) --
+
+    @abc.abstractmethod
+    def get_source_name(self) -> str:
+        """Return the unique source identifier.
+
+        Returns:
+            Source name string, e.g. "truth_social", "twitter", "sec_filings"
+        """
+        ...
+
+    @abc.abstractmethod
+    async def _test_connection(self) -> None:
+        """Test connectivity to the source API.
+
+        Raises:
+            Exception: If connection test fails.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def _fetch_batch(self, cursor: Optional[str] = None) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of items from the source API.
+
+        Args:
+            cursor: Pagination cursor (source-specific). None for first page.
+
+        Returns:
+            Tuple of (list of raw items, next cursor or None if done).
+        """
+        ...
+
+    @abc.abstractmethod
+    def _extract_item_id(self, item: Dict) -> str:
+        """Extract the unique item ID from a raw API response item."""
+        ...
+
+    @abc.abstractmethod
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        """Extract the creation timestamp from a raw API response item."""
+        ...
+
+    @abc.abstractmethod
+    def _extract_content_preview(self, item: Dict) -> str:
+        """Extract a short text preview for logging purposes."""
+        ...
+
+    # -- Concrete methods (shared by all harvesters) --
+
+    def _get_s3_prefix(self) -> str:
+        """Get the S3 prefix for this harvester's data.
+
+        Returns:
+            S3 prefix string for this source.
+        """
+        return self.get_source_name()
+
+    async def initialize(self, dry_run: bool = False) -> None:
+        """Initialize the harvester: verify API access and prepare S3.
+
+        Args:
+            dry_run: If True, skip S3 initialization.
+        """
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"INITIALIZING HARVESTER: {self.get_source_name()}")
+        logger.info("=" * 59)
+
+        self._start_time = datetime.now().isoformat()
+
+        # Source-specific connection test
+        await self._test_connection()
+        logger.info(f"API connection successful for {self.get_source_name()}")
+
+        # Initialize S3 Data Lake
+        if not dry_run:
+            logger.info("Initializing S3 Data Lake...")
+            s3_config = S3Config(
+                bucket_name=settings.S3_BUCKET_NAME,
+                prefix=self._get_s3_prefix(),
+                region=settings.AWS_REGION,
+                access_key_id=settings.AWS_ACCESS_KEY_ID,
+                secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            )
+            self.s3_data_lake = S3DataLake(s3_config)
+            await self.s3_data_lake.initialize()
+            logger.info("S3 Data Lake initialized successfully")
+        else:
+            logger.info("Dry run mode - skipping S3 initialization")
+
+        logger.info(f"Harvester {self.get_source_name()} initialized successfully")
+
+    async def harvest(self, dry_run: bool = False) -> AsyncGenerator[HarvestResult, None]:
+        """Harvest items from the source. Main entry point.
+
+        Args:
+            dry_run: If True, do not store to S3.
+
+        Yields:
+            HarvestResult for each successfully processed item.
+        """
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"HARVESTING FROM {self.get_source_name().upper()}")
+        logger.info("=" * 59)
+
+        incremental_mode = (self.mode == "incremental")
+        start_date = self.start_datetime if self.mode in ("range", "from_date") else None
+        end_date = self.end_datetime if self.mode in ("range", "from_date") else None
+
+        if incremental_mode:
+            logger.info("Mode: Incremental (will stop when encountering existing items in S3)")
+        elif start_date and end_date:
+            logger.info(f"Mode: Date Range ({start_date.date()} to {end_date.date()})")
+        else:
+            logger.info("Mode: Full Backfill")
+
+        cursor: Optional[str] = None
+        total_harvested = 0
+
+        while True:
+            try:
+                items, next_cursor = await self._fetch_batch(cursor)
+
+                if not items:
+                    logger.debug("No more items to harvest")
+                    break
+
+                if self.limit and total_harvested >= self.limit:
+                    break
+
+                for item in items:
+                    try:
+                        item_id = self._extract_item_id(item)
+                        item_timestamp = self._extract_timestamp(item)
+
+                        # Date filtering
+                        if start_date and item_timestamp < start_date:
+                            logger.debug("Reached items before start date, stopping")
+                            return
+                        if end_date and item_timestamp > end_date:
+                            cursor = next_cursor
+                            continue
+
+                        # Incremental check: stop if item already in S3
+                        if incremental_mode and not dry_run and self.s3_data_lake:
+                            expected_key = self.s3_data_lake._generate_s3_key(
+                                item_id, item_timestamp
+                            )
+                            try:
+                                exists = await asyncio.wait_for(
+                                    self.s3_data_lake.check_object_exists(expected_key),
+                                    timeout=15,
+                                )
+                                if exists:
+                                    logger.info(
+                                        f"Incremental: found existing item {item_id}, "
+                                        f"stopping. Harvested {total_harvested} new items."
+                                    )
+                                    return
+                            except asyncio.TimeoutError:
+                                logger.warning(f"S3 check timed out for {item_id}, assuming new")
+                            except Exception as e:
+                                logger.warning(f"S3 check failed for {item_id}: {e}, assuming new")
+
+                        # Store to S3
+                        if dry_run:
+                            s3_key = f"{self._get_s3_prefix()}/raw/{item_timestamp.strftime('%Y/%m/%d')}/{item_id}.json"
+                        else:
+                            s3_key = await self.s3_data_lake.store_raw_data(item)
+                            logger.info(f"Stored {item_id} to S3: {s3_key}")
+
+                        result = HarvestResult(
+                            source_name=self.get_source_name(),
+                            source_post_id=item_id,
+                            s3_key=s3_key,
+                            timestamp=item_timestamp.isoformat() if isinstance(item_timestamp, datetime) else str(item_timestamp),
+                            content_preview=self._extract_content_preview(item),
+                            stored_at=datetime.now().isoformat(),
+                        )
+
+                        yield result
+                        total_harvested += 1
+
+                        if self.limit and total_harvested >= self.limit:
+                            logger.debug(f"Reached limit of {self.limit}")
+                            return
+
+                    except Exception as e:
+                        logger.error(f"Error processing item: {e}")
+                        continue
+
+                cursor = next_cursor
+                if cursor is None:
+                    break
+
+                logger.info(f"Progress: {total_harvested} items harvested from {self.get_source_name()}")
+                await asyncio.sleep(1)  # Rate limiting
+
+            except Exception as e:
+                logger.error(f"Error in harvest loop: {e}")
+                import traceback
+                logger.error(f"Full traceback: {traceback.format_exc()}")
+                break
+
+        logger.info("")
+        logger.info("=" * 59)
+        logger.info(f"HARVEST SUMMARY ({self.get_source_name()})")
+        logger.info("=" * 59)
+        logger.info(f"Total items harvested: {total_harvested}")
+        logger.info(f"Total API calls made: {self.api_call_count}")
+
+    async def get_s3_stats(self) -> Dict:
+        """Get S3 storage statistics for this source."""
+        if not self.s3_data_lake:
+            return {"error": "S3 Data Lake not initialized"}
+        return await self.s3_data_lake.get_data_stats()
+
+    async def cleanup(self) -> None:
+        """Release all resources held by this harvester.
+
+        Subclasses should override to close API sessions, then call super().
+        """
+        if self.s3_data_lake:
+            await self.s3_data_lake.cleanup()
+        logger.debug(f"{self.get_source_name()} harvester cleaned up")
+
+    def get_summary(self, total_harvested: int, status: HarvesterStatus, error: Optional[str] = None) -> HarvestSummary:
+        """Build a HarvestSummary for this run."""
+        return HarvestSummary(
+            source_name=self.get_source_name(),
+            mode=self.mode,
+            status=status,
+            total_harvested=total_harvested,
+            total_api_calls=self.api_call_count,
+            started_at=self._start_time or datetime.now().isoformat(),
+            completed_at=datetime.now().isoformat(),
+            error_message=error,
+        )

--- a/shitposts/cli.py
+++ b/shitposts/cli.py
@@ -68,11 +68,17 @@ def create_harvester_parser(description: str, epilog: str = None) -> argparse.Ar
         help="Enable verbose logging"
     )
     parser.add_argument(
-        "--max-id", 
+        "--max-id",
         type=str,
         help="Start harvesting from this post ID (for resuming backfill)"
     )
-    
+    parser.add_argument(
+        "--source",
+        type=str,
+        default=None,
+        help="Harvester source name (e.g., truth_social, twitter). Default: all enabled."
+    )
+
     return parser
 
 
@@ -101,15 +107,16 @@ def setup_harvester_logging(verbose: bool = False) -> None:
     setup_centralized_harvester_logging(verbose=verbose)
 
 
-def print_harvest_start(mode: str, limit: Optional[int] = None) -> None:
+def print_harvest_start(mode: str, limit: Optional[int] = None, source: str = "Truth Social") -> None:
     """Print harvester start message.
-    
+
     Args:
         mode: Harvesting mode
         limit: Harvest limit (optional)
+        source: Source name for display (default: Truth Social for backward compat)
     """
     limit_text = f" (limit: {limit})" if limit else ""
-    print_info(f"🚀 Starting Truth Social S3 harvesting in {mode} mode{limit_text}...")
+    print_info(f"Starting {source} S3 harvesting in {mode} mode{limit_text}...")
 
 
 def print_harvest_progress(harvested_count: int, limit: Optional[int] = None) -> None:
@@ -125,14 +132,15 @@ def print_harvest_progress(harvested_count: int, limit: Optional[int] = None) ->
         print_info(f"📊 Progress: {harvested_count} posts harvested")
 
 
-def print_harvest_complete(harvested_count: int, dry_run: bool = False) -> None:
+def print_harvest_complete(harvested_count: int, dry_run: bool = False, source: str = "S3") -> None:
     """Print harvester completion message.
-    
+
     Args:
         harvested_count: Total number of posts harvested
         dry_run: Whether this was a dry run
+        source: Source name for display (default: S3 for backward compat)
     """
-    print_success(f"S3 harvesting completed! Total posts: {harvested_count}")
+    print_success(f"{source} harvesting completed! Total posts: {harvested_count}")
     
     if dry_run:
         print_info("This was a dry run - no data was stored to S3")

--- a/shitposts/harvester_models.py
+++ b/shitposts/harvester_models.py
@@ -1,0 +1,71 @@
+"""
+Harvester Data Models
+Shared data structures for all signal harvesters.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Optional, Any
+
+
+class HarvesterMode(str, Enum):
+    """Supported harvesting modes."""
+    INCREMENTAL = "incremental"
+    BACKFILL = "backfill"
+    RANGE = "range"
+    FROM_DATE = "from_date"
+
+
+class HarvesterStatus(str, Enum):
+    """Harvester execution status."""
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class HarvestResult:
+    """Standardized result from any harvester.
+
+    Every harvester yields these through harvest(), regardless of source.
+    """
+    source_name: str          # e.g., "truth_social", "twitter", "sec_filings"
+    source_post_id: str       # Original ID from the source platform
+    s3_key: str               # Where the raw data was stored in S3
+    timestamp: str            # ISO format timestamp of the original post
+    content_preview: str      # First ~100 chars for logging
+    stored_at: str            # ISO format timestamp of when we stored it
+    metadata: Dict[str, Any] = field(default_factory=dict)  # Source-specific extras
+
+
+@dataclass
+class HarvestSummary:
+    """Summary of a single harvester execution run."""
+    source_name: str
+    mode: str
+    status: HarvesterStatus
+    total_harvested: int
+    total_api_calls: int
+    started_at: str           # ISO format
+    completed_at: str         # ISO format
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HarvesterConfig:
+    """Configuration for a harvester instance.
+
+    Each harvester reads its own source-specific settings but reports
+    them through this common structure for the registry.
+    """
+    source_name: str
+    enabled: bool = True
+    mode: HarvesterMode = HarvesterMode.INCREMENTAL
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    limit: Optional[int] = None
+    s3_prefix: Optional[str] = None  # Override for S3 path prefix
+    extra: Dict[str, Any] = field(default_factory=dict)  # Source-specific config

--- a/shitposts/harvester_registry.py
+++ b/shitposts/harvester_registry.py
@@ -1,0 +1,180 @@
+"""
+Harvester Registry
+Config-driven discovery and management of signal harvesters.
+"""
+
+from typing import Dict, List, Optional, Type
+
+from shit.logging import get_service_logger
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvesterConfig
+
+logger = get_service_logger("harvester_registry")
+
+
+class HarvesterRegistry:
+    """Registry for signal harvesters.
+
+    Usage:
+        registry = HarvesterRegistry()
+        registry.register("truth_social", TruthSocialS3Harvester)
+        registry.register("twitter", TwitterHarvester)
+
+        harvesters = registry.create_all_enabled(mode="incremental")
+        for harvester in harvesters:
+            await harvester.initialize()
+            async for result in harvester.harvest():
+                process(result)
+    """
+
+    def __init__(self):
+        self._registry: Dict[str, Type[SignalHarvester]] = {}
+        self._configs: Dict[str, HarvesterConfig] = {}
+
+    def register(
+        self,
+        source_name: str,
+        harvester_class: Type[SignalHarvester],
+        config: Optional[HarvesterConfig] = None,
+    ) -> None:
+        """Register a harvester class for a source.
+
+        Args:
+            source_name: Unique source identifier (e.g., "truth_social")
+            harvester_class: The harvester class (not an instance)
+            config: Optional configuration override
+        """
+        if not issubclass(harvester_class, SignalHarvester):
+            raise TypeError(
+                f"{harvester_class.__name__} must be a subclass of SignalHarvester"
+            )
+
+        self._registry[source_name] = harvester_class
+        if config:
+            self._configs[source_name] = config
+        else:
+            self._configs[source_name] = HarvesterConfig(source_name=source_name)
+
+        logger.info(f"Registered harvester: {source_name} -> {harvester_class.__name__}")
+
+    def unregister(self, source_name: str) -> None:
+        """Remove a harvester from the registry."""
+        self._registry.pop(source_name, None)
+        self._configs.pop(source_name, None)
+        logger.info(f"Unregistered harvester: {source_name}")
+
+    def get_class(self, source_name: str) -> Optional[Type[SignalHarvester]]:
+        """Get the harvester class for a source."""
+        return self._registry.get(source_name)
+
+    def get_config(self, source_name: str) -> Optional[HarvesterConfig]:
+        """Get the configuration for a source."""
+        return self._configs.get(source_name)
+
+    def list_sources(self) -> List[str]:
+        """List all registered source names."""
+        return list(self._registry.keys())
+
+    def list_enabled_sources(self) -> List[str]:
+        """List source names where the harvester is enabled."""
+        return [
+            name for name, config in self._configs.items()
+            if config.enabled
+        ]
+
+    def create_harvester(
+        self,
+        source_name: str,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> SignalHarvester:
+        """Create a harvester instance for a specific source.
+
+        Args:
+            source_name: Which source to create
+            mode: Harvesting mode
+            start_date: Start date (YYYY-MM-DD)
+            end_date: End date (YYYY-MM-DD)
+            limit: Maximum items to harvest
+            **kwargs: Source-specific arguments
+
+        Returns:
+            Configured harvester instance
+
+        Raises:
+            KeyError: If source_name is not registered
+        """
+        if source_name not in self._registry:
+            raise KeyError(
+                f"Unknown source: '{source_name}'. "
+                f"Registered sources: {self.list_sources()}"
+            )
+
+        cls = self._registry[source_name]
+        return cls(
+            mode=mode,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+            **kwargs,
+        )
+
+    def create_all_enabled(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[SignalHarvester]:
+        """Create harvester instances for all enabled sources.
+
+        Args:
+            mode: Harvesting mode (applied to all)
+            start_date: Start date (applied to all)
+            end_date: End date (applied to all)
+            limit: Limit (applied to all)
+
+        Returns:
+            List of configured harvester instances
+        """
+        harvesters = []
+        for source_name in self.list_enabled_sources():
+            config = self._configs[source_name]
+            extra_kwargs = config.extra if config.extra else {}
+
+            harvester = self.create_harvester(
+                source_name=source_name,
+                mode=mode,
+                start_date=start_date,
+                end_date=end_date,
+                limit=limit,
+                **extra_kwargs,
+            )
+            harvesters.append(harvester)
+
+        return harvesters
+
+
+def create_default_registry() -> HarvesterRegistry:
+    """Create the default registry with all known harvesters.
+
+    This is the single place that wires up which sources are available.
+    """
+    from shitposts.truth_social_s3_harvester import TruthSocialS3Harvester
+
+    registry = HarvesterRegistry()
+
+    # Register Truth Social (always enabled - it's the primary source)
+    registry.register(
+        "truth_social",
+        TruthSocialS3Harvester,
+        HarvesterConfig(source_name="truth_social", enabled=True),
+    )
+
+    # Future sources will be registered here:
+    # registry.register("twitter", TwitterHarvester, HarvesterConfig(..., enabled=False))
+
+    return registry

--- a/shitposts/truth_social_s3_harvester.py
+++ b/shitposts/truth_social_s3_harvester.py
@@ -4,15 +4,13 @@ Harvests raw Truth Social data and stores it directly in S3.
 """
 
 import asyncio
-import time
 from datetime import datetime
 from typing import AsyncGenerator, Dict, Optional, List
 import aiohttp
-import json
 
 from shit.config.shitpost_settings import settings
-from shit.utils.error_handling import handle_exceptions
-from shit.s3 import S3DataLake, S3Config
+from shitposts.base_harvester import SignalHarvester
+from shitposts.harvester_models import HarvestResult
 from shitposts.cli import (
     create_harvester_parser, validate_harvester_args, setup_harvester_logging,
     print_harvest_start, print_harvest_progress, print_harvest_complete,
@@ -24,12 +22,12 @@ from shit.logging import get_service_logger
 logger = get_service_logger("harvester")
 
 
-class TruthSocialS3Harvester:
-    """Harvester for Truth Social posts that stores raw data in S3."""
-    
+class TruthSocialS3Harvester(SignalHarvester):
+    """Harvester for Truth Social posts via ScrapeCreators API."""
+
     def __init__(self, mode="incremental", start_date=None, end_date=None, limit=None, max_id=None):
         """Initialize the Truth Social S3 harvester.
-        
+
         Args:
             mode: Harvesting mode - "incremental", "backfill", "range", "from_date"
             start_date: Start date for range/from_date modes (YYYY-MM-DD)
@@ -37,50 +35,33 @@ class TruthSocialS3Harvester:
             limit: Maximum number of posts to harvest (optional)
             max_id: Starting post ID for backfill mode (for resuming)
         """
+        super().__init__(mode=mode, start_date=start_date, end_date=end_date, limit=limit)
+
+        # Truth Social-specific config
         self.username = settings.TRUTH_SOCIAL_USERNAME
-        
-        # Harvesting mode configuration
-        self.mode = mode
-        self.start_date = start_date
-        self.end_date = end_date
-        self.limit = limit
         self.max_id = max_id
-        
-        # Parse dates if provided
-        if start_date:
-            self.start_datetime = datetime.fromisoformat(start_date).replace(tzinfo=None)
-        if end_date:
-            self.end_datetime = datetime.fromisoformat(end_date).replace(tzinfo=None)
-        else:
-            # Default end_date to today if not provided
-            self.end_datetime = datetime.now().replace(hour=23, minute=59, second=59, microsecond=999999)
-        
-        # API configuration
         self.api_key = settings.SCRAPECREATORS_API_KEY
         self.base_url = "https://api.scrapecreators.com/v1"
-        
-        # Trump's Truth Social user ID
-        self.user_id = "107780257626128497"
-        
-        # Session and state
+        self.user_id = "107780257626128497"  # Trump's Truth Social user ID
+
+        # HTTP session (created in _test_connection)
         self.session: Optional[aiohttp.ClientSession] = None
-        self.s3_data_lake: Optional[S3DataLake] = None
-        self.api_call_count = 0  # Track API calls per execution
-        
-    async def initialize(self, dry_run: bool = False):
-        """Initialize the Truth Social S3 harvester."""
-        logger.info("")
-        logger.info("═══════════════════════════════════════════════════════════")
-        logger.info(f"INITIALIZING HARVESTER: @{self.username}")
-        logger.info("═══════════════════════════════════════════════════════════")
-        logger.debug(f"🔧 Initialize method called with dry_run: {dry_run}")
-        
+
+    # ── Interface implementation ───────────────────────────────────────
+
+    def get_source_name(self) -> str:
+        return "truth_social"
+
+    def _get_s3_prefix(self) -> str:
+        """Use hyphenated form for backward compatibility with existing S3 data."""
+        return "truth-social"
+
+    async def _test_connection(self) -> None:
+        """Test the ScrapeCreators API connection."""
         if not self.api_key:
             raise ValueError("SCRAPECREATORS_API_KEY not configured. Please add it to your .env file.")
-        
-        try:
-            logger.debug("🌐 Creating aiohttp session...")
-            # Create aiohttp session
+
+        if not self.session:
             self.session = aiohttp.ClientSession(
                 headers={
                     'x-api-key': self.api_key,
@@ -88,306 +69,108 @@ class TruthSocialS3Harvester:
                     'User-Agent': 'Shitpost-Alpha-S3-Harvester/1.0'
                 }
             )
-            
-            # Test API connection
-            logger.info("Testing Truth Social API connection...")
-            await self._test_connection()
-            logger.info("✅ API connection successful")
-            logger.info("")
-            
-            # Initialize S3 Data Lake only if not in dry run mode
-            if not dry_run:
-                logger.info("Initializing S3 Data Lake...")
-                # Create S3 config from settings
-                s3_config = S3Config(
-                    bucket_name=settings.S3_BUCKET_NAME,
-                    prefix=settings.S3_PREFIX,
-                    region=settings.AWS_REGION,
-                    access_key_id=settings.AWS_ACCESS_KEY_ID,
-                    secret_access_key=settings.AWS_SECRET_ACCESS_KEY
-                )
-                self.s3_data_lake = S3DataLake(s3_config)
-                await self.s3_data_lake.initialize()
-                logger.info("✅ S3 Data Lake initialized successfully")
-            else:
-                logger.info("Dry run mode - skipping S3 initialization")
-            
-            logger.info("✅ Harvester initialized successfully")
-            logger.info("")
-            
-        except Exception as e:
-            logger.error(f"Failed to initialize Truth Social S3 harvester: {e}")
-            await self.cleanup()
-            raise
-    
-    async def _test_connection(self):
-        """Test the ScrapeCreators API connection."""
+
+        url = f"{self.base_url}/truthsocial/user/posts?user_id={self.user_id}&limit=1"
+        logger.debug(f"Testing API connection to: {url}")
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with self.session.get(url, timeout=timeout) as response:
+            logger.debug(f"API test response status: {response.status}")
+            if response.status != 200:
+                raise Exception(f"API connection test failed: {response.status}")
+            data = await response.json()
+            if not data.get('success'):
+                raise Exception(f"API returned error: {data}")
+        logger.debug("ScrapeCreators API connection test successful")
+
+    async def _fetch_batch(self, cursor: Optional[str] = None) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of posts from ScrapeCreators API.
+
+        Args:
+            cursor: The next_max_id for ScrapeCreators pagination.
+
+        Returns:
+            (list of raw post dicts, next cursor string or None)
+        """
         try:
-            # Test with a simple API call
-            url = f"{self.base_url}/truthsocial/user/posts?user_id={self.user_id}&limit=1"
-            logger.debug(f"Testing API connection to: {url}")
-            timeout = aiohttp.ClientTimeout(total=10)  # 10 second timeout for test
-            async with self.session.get(url, timeout=timeout) as response:
-                logger.debug(f"API test response status: {response.status}")
-                if response.status != 200:
-                    raise Exception(f"API connection test failed: {response.status}")
-                
-                data = await response.json()
-                logger.debug(f"API test response data: {data}")
-                if not data.get('success'):
-                    raise Exception(f"API returned error: {data}")
-                
-                logger.debug("ScrapeCreators API connection test successful")
-                        
-        except Exception as e:
-            logger.error(f"ScrapeCreators API connection test failed: {e}")
-            raise
-    
-    async def _fetch_recent_shitposts(self, next_max_id: Optional[str] = None) -> List[Dict]:
-        """Fetch recent shitposts using ScrapeCreators API."""
-        try:
-            # Build URL with pagination
             url = f"{self.base_url}/truthsocial/user/posts"
-            params = {
-                'user_id': self.user_id,
-                'limit': 20
-            }
-            
-            if next_max_id:
-                params['next_max_id'] = next_max_id
-            
+            params = {'user_id': self.user_id, 'limit': 20}
+
+            if cursor:
+                params['next_max_id'] = cursor
+
             self.api_call_count += 1
-            print(f"🌐 Making API call #{self.api_call_count} to: {url}")
             logger.info(f"Making API call #{self.api_call_count} to Truth Social API")
-            logger.debug(f"⏱️  Starting API call with 30 second timeout...")
-            timeout = aiohttp.ClientTimeout(total=30)  # 30 second timeout
+
+            timeout = aiohttp.ClientTimeout(total=30)
             async with self.session.get(url, params=params, timeout=timeout) as response:
-                logger.debug(f"📡 API response received, status: {response.status}")
+                logger.debug(f"API response received, status: {response.status}")
                 if response.status != 200:
                     logger.error(f"API request failed: {response.status}")
-                    return []
-                
+                    return [], None
+
                 data = await response.json()
-                logger.debug(f"API response data: {data}")
-                
                 if not data.get('success'):
                     logger.error(f"API returned error: {data}")
-                    return []
-                
-                shitposts = data.get('posts', [])  # API returns 'posts' not 'data'
-                logger.info(f"Fetched {len(shitposts)} posts from Truth Social API")
-                
-                return shitposts
-                
+                    return [], None
+
+                posts = data.get('posts', [])
+                logger.info(f"Fetched {len(posts)} posts from Truth Social API")
+
+                # Determine next cursor: use the last post's ID
+                next_cursor = posts[-1].get('id') if posts else None
+
+                return posts, next_cursor
+
         except Exception as e:
-            logger.error(f"Error fetching shitposts: {e}")
-            logger.error(f"Exception type: {type(e).__name__}")
+            logger.error(f"Error fetching posts: {e}")
             import traceback
             logger.error(f"Full traceback: {traceback.format_exc()}")
-            return []
-    
-    async def harvest_shitposts(self, dry_run: bool = False) -> AsyncGenerator[Dict, None]:
-        """Harvest shitposts based on configured mode."""
-        logger.debug(f"Starting shitpost harvest in {self.mode} mode...")
-        logger.debug(f"🔍 About to enter mode-specific harvest logic for: {self.mode}")
-        
-        if self.mode == "backfill":
-            logger.debug("🔄 Entering backfill mode")
-            async for result in self._harvest_backfill(dry_run):
-                yield result
-        elif self.mode == "range":
-            logger.debug("📅 Entering range mode")
-            async for result in self._harvest_backfill(dry_run, self.start_datetime, self.end_datetime):
-                yield result
-        elif self.mode == "from_date":
-            logger.debug("📆 Entering from_date mode (using range with end_date=today)")
-            async for result in self._harvest_backfill(dry_run, self.start_datetime, self.end_datetime):
-                yield result
-        else:  # incremental (default)
-            logger.debug("🔄 Entering incremental mode")
-            async for result in self._harvest_backfill(dry_run, incremental_mode=True):
-                yield result
-    
-    async def _harvest_backfill(self, dry_run: bool = False, start_date: Optional[datetime] = None, end_date: Optional[datetime] = None, incremental_mode: bool = False) -> AsyncGenerator[Dict, None]:
-        """Harvest historical Truth Social posts to S3.
-        
-        Args:
-            dry_run: If True, don't actually store to S3
-            start_date: Optional start date filter (inclusive)
-            end_date: Optional end date filter (inclusive)
-            incremental_mode: If True, stop when encountering existing posts in S3
-        """
-        logger.info("")
-        logger.info("═══════════════════════════════════════════════════════════")
-        logger.info("HARVESTING POSTS")
-        logger.info("═══════════════════════════════════════════════════════════")
-        
-        if incremental_mode:
-            logger.info("Mode: Incremental (will stop when encountering existing posts in S3)")
-            print("🔄 Incremental mode: Will stop when finding posts that already exist in S3")
-        elif start_date and end_date:
-            logger.info(f"Mode: Date Range ({start_date.date()} to {end_date.date()})")
-            logger.debug("🔄 Note: API doesn't support date filtering - crawling backwards through all posts")
-        else:
-            logger.info("Mode: Full Backfill")
-        
-        # Use provided max_id or start from most recent
-        max_id = self.max_id
-        total_harvested = 0
-        posts_processed = 0
-        
-        if max_id:
-            logger.debug(f"Resuming backfill from post ID: {max_id}")
-        else:
-            logger.debug("Starting backfill from most recent posts")
-        
-        while True:
-            try:
-                logger.debug(f"Fetching batch of posts with max_id: {max_id}")
-                # Fetch batch of posts from API (start with most recent, no max_id)
-                shitposts = await self._fetch_recent_shitposts(max_id)
-                
-                logger.debug(f"API returned {len(shitposts) if shitposts else 0} posts")
-                
-                if not shitposts:
-                    logger.debug("No more posts to harvest in backfill")
-                    break
-                
-                if incremental_mode:
-                    print(f"📡 Processing {len(shitposts)} posts from API (checking for existing posts in S3)...")
-                    logger.info(f"Processing {len(shitposts)} posts from API (checking for existing posts in S3)")
-                
-                # Check if we've reached the limit before processing
-                if self.limit and total_harvested >= self.limit:
-                    logger.debug(f"Reached harvest limit of {self.limit} posts")
-                    break
-                
-                # Process and store each shitpost to S3
-                for shitpost in shitposts:
-                    try:
-                        posts_processed += 1
-                        
-                        # Apply date filtering if specified
-                        if start_date or end_date:
-                            post_timestamp = datetime.fromisoformat(shitpost.get('created_at').replace('Z', '+00:00')).replace(tzinfo=None)
-                            
-                            # Check if post is before start date (stop crawling)
-                            if start_date and post_timestamp < start_date:
-                                logger.debug(f"📅 Reached posts before start date {start_date.date()}, stopping crawl")
-                                logger.debug(f"📈 Total posts processed: {posts_processed}, Found {total_harvested} in target range")
-                                return
-                            
-                            # Check if post is after end date (skip this post)
-                            if end_date and post_timestamp > end_date:
-                                max_id = shitpost.get('id')
-                                continue  # Skip this post, continue to next
-                        
-                        # Check for incremental mode - stop if post already exists in S3
-                        if incremental_mode and not dry_run:
-                            # Generate expected S3 key for this post
-                            post_timestamp = datetime.fromisoformat(shitpost.get('created_at').replace('Z', '+00:00')).replace(tzinfo=None)
-                            expected_s3_key = self.s3_data_lake._generate_s3_key(shitpost.get('id'), post_timestamp)
-                            
-                            print(f"🔍 Checking if post {shitpost.get('id')} already exists in S3...")
-                            print(f"🔍 S3 key: {expected_s3_key}")
-                            
-                            try:
-                                # Check if post already exists in S3 with timeout
-                                print(f"⏱️  Starting S3 existence check...")
-                                exists = await asyncio.wait_for(
-                                    self.s3_data_lake.check_object_exists(expected_s3_key),
-                                    timeout=15  # 15 second timeout
-                                )
-                                print(f"✅ S3 existence check completed: {exists}")
-                                
-                                if exists:
-                                    print(f"✅ Found existing post {shitpost.get('id')} in S3")
-                                    print(f"🔄 Incremental mode: Stopping harvest (no new posts to process)")
-                                    print(f"📈 Total new posts harvested: {total_harvested}")
-                                    logger.info(f"Incremental harvest completed - found existing post {shitpost.get('id')}, harvested {total_harvested} new posts")
-                                    return
-                                else:
-                                    print(f"📝 Post {shitpost.get('id')} is new - will process")
-                                    logger.debug(f"Post {shitpost.get('id')} is new, processing")
-                                    
-                            except asyncio.TimeoutError:
-                                print(f"⏰ S3 existence check timed out for post {shitpost.get('id')}")
-                                print(f"🔄 Assuming post is new and continuing...")
-                                # Continue processing as if it's a new post
-                            except Exception as e:
-                                print(f"❌ Error checking S3 existence: {e}")
-                                print(f"🔄 Assuming post is new and continuing...")
-                                # Continue processing as if it's a new post
-                        
-                        # Post passed date filtering and incremental checks - process it
-                        if dry_run:
-                            # In dry run mode, just create a mock result
-                            s3_key = f"truth-social/raw/2024/01/01/{shitpost.get('id')}.json"
-                            logger.debug(f"DRY RUN: Would store post {shitpost.get('id')}")
-                        else:
-                            # Store raw data to S3
-                            s3_key = await self.s3_data_lake.store_raw_data(shitpost)
-                            logger.info(f"Stored post {shitpost.get('id')} to S3: {s3_key}")
-                        
-                        # Create result object
-                        result = {
-                            'shitpost_id': shitpost.get('id'),
-                            's3_key': s3_key,
-                            'timestamp': shitpost.get('created_at'),
-                            'content_preview': shitpost.get('content', '')[:100] + '...' if shitpost.get('content') else 'No content',
-                            'stored_at': datetime.now().isoformat()
-                        }
-                        
-                        yield result
-                        total_harvested += 1
-                        
-                        # Check if we've reached the limit
-                        if self.limit and total_harvested >= self.limit:
-                            logger.debug(f"Reached harvest limit of {self.limit} posts")
-                            return
-                        
-                        # Update max_id for next batch (use the last post's ID for pagination)
-                        max_id = shitpost.get('id')
-                        
-                    except Exception as e:
-                        logger.error(f"Error processing shitpost {shitpost.get('id')}: {e}")
-                        continue
-                
-                logger.info(f"Progress: {total_harvested} posts harvested and stored to S3")
-                
-                # Small delay to be respectful to API
-                await asyncio.sleep(1)
-                
-            except Exception as e:
-                logger.error(f"Error in backfill harvest: {e}")
-                import traceback
-                logger.error(f"Full traceback: {traceback.format_exc()}")
-                await handle_exceptions(e)
-                break
-        
-        logger.info("")
-        logger.info("═══════════════════════════════════════════════════════════")
-        logger.info("HARVEST SUMMARY")
-        logger.info("═══════════════════════════════════════════════════════════")
-        logger.info(f"Total posts harvested: {total_harvested}")
-        logger.info(f"Total API calls made: {self.api_call_count}")
-        print(f"📊 API Call Summary: Made {self.api_call_count} API calls in this execution")
-    
-    
-    async def get_s3_stats(self) -> Dict[str, any]:
-        """Get statistics about S3 storage."""
-        if not self.s3_data_lake:
-            return {'error': 'S3 Data Lake not initialized'}
-        
-        return await self.s3_data_lake.get_data_stats()
-    
-    async def cleanup(self):
-        """Cleanup resources."""
+            return [], None
+
+    def _extract_item_id(self, item: Dict) -> str:
+        return item.get('id', '')
+
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        created_at = item.get('created_at', '')
+        if created_at.endswith('Z'):
+            created_at = created_at.replace('Z', '+00:00')
+        return datetime.fromisoformat(created_at).replace(tzinfo=None)
+
+    def _extract_content_preview(self, item: Dict) -> str:
+        content = item.get('content', '')
+        if content and len(content) > 100:
+            return content[:100] + '...'
+        return content or 'No content'
+
+    # ── Lifecycle overrides ────────────────────────────────────────────
+
+    async def cleanup(self) -> None:
+        """Cleanup aiohttp session and S3 resources."""
         if self.session:
             await self.session.close()
-        if self.s3_data_lake:
-            await self.s3_data_lake.cleanup()
-        logger.debug("Truth Social S3 harvester cleaned up")
+        await super().cleanup()
+
+    # ── Backward-compatible methods ────────────────────────────────────
+
+    async def _fetch_recent_shitposts(self, next_max_id: Optional[str] = None) -> List[Dict]:
+        """Fetch recent shitposts. Backward-compatible wrapper around _fetch_batch."""
+        posts, _ = await self._fetch_batch(cursor=next_max_id)
+        return posts
+
+    async def harvest_shitposts(self, dry_run: bool = False) -> AsyncGenerator[Dict, None]:
+        """Backward-compatible wrapper that delegates to harvest().
+
+        Existing callers expect Dict yields with 'shitpost_id' key.
+        This adapter translates HarvestResult to the legacy format.
+        """
+        async for result in self.harvest(dry_run=dry_run):
+            yield {
+                'shitpost_id': result.source_post_id,
+                's3_key': result.s3_key,
+                'timestamp': result.timestamp,
+                'content_preview': result.content_preview,
+                'stored_at': result.stored_at,
+            }
 
 
 async def main():
@@ -396,24 +179,24 @@ async def main():
         description="Truth Social S3 harvester - stores raw data in S3",
         epilog=HARVESTER_EXAMPLES
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validate arguments
     validate_harvester_args(args)
-    
+
     # Setup logging
     setup_harvester_logging(args.verbose)
-    
+
     # Test verbose logging
     if args.verbose:
-        print("🔍 VERBOSE MODE ENABLED - Debug logs will be shown")
-    
+        print("VERBOSE MODE ENABLED - Debug logs will be shown")
+
     # Print start message
     print_harvest_start(args.mode, args.limit)
     limit_text = f" (limit: {args.limit})" if args.limit else ""
     logger.info(f"Starting Truth Social S3 harvesting in {args.mode} mode{limit_text}")
-    
+
     # Create harvester with appropriate configuration
     harvester = TruthSocialS3Harvester(
         mode=args.mode,
@@ -422,47 +205,47 @@ async def main():
         limit=args.limit,
         max_id=args.max_id
     )
-    
+
     try:
         await harvester.initialize(dry_run=args.dry_run)
-        
+
         # Harvest shitposts
-        print("🔄 Starting harvest process...")
+        print("Starting harvest process...")
         logger.info("Starting harvest process")
         harvested_count = 0
-        
+
         async for result in harvester.harvest_shitposts(dry_run=args.dry_run):
             if args.dry_run:
-                print(f"📝 Would store: {result['shitpost_id']} - {result['content_preview']}")
+                print(f"Would store: {result['shitpost_id']} - {result['content_preview']}")
                 logger.info(f"Would store post: {result['shitpost_id']}")
             else:
-                print(f"✅ Stored: {result['shitpost_id']} - {result['content_preview']}")
+                print(f"Stored: {result['shitpost_id']} - {result['content_preview']}")
                 print(f"   S3 Key: {result['s3_key']}")
                 logger.info(f"Stored post: {result['shitpost_id']} to S3 key: {result['s3_key']}")
-            
+
             harvested_count += 1
-            
+
             # Apply limit if specified
             if args.limit and harvested_count >= args.limit:
-                print(f"🎯 Reached harvest limit of {args.limit} posts")
+                print(f"Reached harvest limit of {args.limit} posts")
                 logger.info(f"Reached harvest limit of {args.limit} posts")
                 break
-        
+
         # Print completion message
         print_harvest_complete(harvested_count, args.dry_run)
-        
+
         logger.info("")
-        logger.info("═══════════════════════════════════════════════════════════")
+        logger.info("=" * 59)
         logger.info("HARVEST COMPLETED")
-        logger.info("═══════════════════════════════════════════════════════════")
+        logger.info("=" * 59)
         logger.info(f"Total posts processed: {harvested_count}")
-        
+
         if not args.dry_run:
             # Show S3 statistics
             stats = await harvester.get_s3_stats()
             print_s3_stats(stats)
             logger.info(f"S3 storage stats: {stats}")
-        
+
     except KeyboardInterrupt:
         print_harvest_interrupted()
     except Exception as e:

--- a/shitposts/twitter_harvester.py
+++ b/shitposts/twitter_harvester.py
@@ -1,0 +1,124 @@
+"""
+Twitter/X Signal Harvester (Skeleton)
+
+This is a TEMPLATE for implementing a new signal source.
+It demonstrates the SignalHarvester interface pattern.
+
+To make this functional:
+    1. Set TWITTER_BEARER_TOKEN in .env
+    2. Implement _test_connection() with real Twitter API v2 calls
+    3. Implement _fetch_batch() with Twitter search/timeline endpoints
+    4. Register in harvester_registry.py with enabled=True
+    5. Add "twitter" to ENABLED_HARVESTERS in .env
+
+See TruthSocialS3Harvester for a complete working example.
+"""
+
+import aiohttp
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+from shitposts.base_harvester import SignalHarvester
+
+logger = get_service_logger("twitter_harvester")
+
+
+class TwitterHarvester(SignalHarvester):
+    """Skeleton harvester for Twitter/X posts.
+
+    NOT YET FUNCTIONAL. This class demonstrates the SignalHarvester
+    interface for future implementation.
+    """
+
+    def __init__(
+        self,
+        mode: str = "incremental",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: Optional[int] = None,
+        target_users: Optional[List[str]] = None,
+    ):
+        super().__init__(mode=mode, start_date=start_date, end_date=end_date, limit=limit)
+
+        # Twitter-specific config
+        self.bearer_token = getattr(settings, 'TWITTER_BEARER_TOKEN', None)
+        self.base_url = "https://api.twitter.com/2"
+        self.target_users = target_users or self._parse_target_users()
+
+        # HTTP session
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    def _parse_target_users(self) -> List[str]:
+        """Parse target users from settings."""
+        raw = getattr(settings, 'TWITTER_TARGET_USERS', '')
+        return [u.strip() for u in raw.split(",") if u.strip()]
+
+    # ── Interface implementation ───────────────────────────────────────
+
+    def get_source_name(self) -> str:
+        return "twitter"
+
+    async def _test_connection(self) -> None:
+        """Test Twitter API v2 connection.
+
+        TODO: Implement with real Twitter API call.
+        """
+        if not self.bearer_token:
+            raise ValueError(
+                "TWITTER_BEARER_TOKEN not configured. "
+                "Please add it to your .env file."
+            )
+
+        self.session = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bearer {self.bearer_token}",
+                "Content-Type": "application/json",
+                "User-Agent": "Shitpost-Alpha-Twitter-Harvester/1.0",
+            }
+        )
+
+        raise NotImplementedError(
+            "TwitterHarvester is a skeleton. "
+            "Implement _test_connection() with real API calls."
+        )
+
+    async def _fetch_batch(
+        self, cursor: Optional[str] = None
+    ) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of tweets.
+
+        TODO: Implement with Twitter API v2 search or user timeline.
+        """
+        raise NotImplementedError(
+            "TwitterHarvester is a skeleton. "
+            "Implement _fetch_batch() with real API calls."
+        )
+
+    def _extract_item_id(self, item: Dict) -> str:
+        """Extract tweet ID."""
+        return item.get("id", "")
+
+    def _extract_timestamp(self, item: Dict) -> datetime:
+        """Extract tweet creation timestamp.
+
+        Twitter API v2 uses ISO 8601 format: 2024-01-15T10:30:00.000Z
+        """
+        created_at = item.get("created_at", "")
+        if created_at.endswith("Z"):
+            created_at = created_at.replace("Z", "+00:00")
+        return datetime.fromisoformat(created_at).replace(tzinfo=None)
+
+    def _extract_content_preview(self, item: Dict) -> str:
+        """Extract tweet text preview."""
+        text = item.get("text", "")
+        if len(text) > 100:
+            return text[:100] + "..."
+        return text or "No content"
+
+    async def cleanup(self) -> None:
+        """Cleanup aiohttp session."""
+        if self.session:
+            await self.session.close()
+        await super().cleanup()


### PR DESCRIPTION
## Summary
- **SignalHarvester ABC** — universal base class with pagination, date filtering, incremental S3 checking, rate limiting, and cleanup lifecycle
- **HarvesterRegistry** — config-driven registry with `register()`, `create_harvester()`, `create_all_enabled()`, and `create_default_registry()` factory
- **TwitterHarvester skeleton** — ready for API implementation, with working extract methods
- **TruthSocialS3Harvester refactored** to inherit from SignalHarvester while maintaining full backward compatibility (`harvest_shitposts()` wrapper, hyphenated S3 prefix)
- **Multi-source orchestration** in `shitpost_alpha.py` via `--sources` flag and `ENABLED_HARVESTERS` env var
- **95 new/updated tests** across 4 test files (base_harvester: 32, registry: 22, twitter: 13, updated TS: 30+)

## New Files
- `shitposts/base_harvester.py` — SignalHarvester ABC
- `shitposts/harvester_models.py` — HarvestResult, HarvestSummary, HarvesterConfig dataclasses
- `shitposts/harvester_registry.py` — HarvesterRegistry + create_default_registry()
- `shitposts/twitter_harvester.py` — TwitterHarvester skeleton
- `shitposts/__init__.py` — Package exports
- `shit_tests/shitposts/test_base_harvester.py` — 32 tests
- `shit_tests/shitposts/test_harvester_registry.py` — 22 tests
- `shit_tests/shitposts/test_twitter_harvester.py` — 13 tests

## Modified Files
- `shitposts/truth_social_s3_harvester.py` — refactored to inherit from SignalHarvester
- `shitposts/cli.py` — added `--source` arg and source parameter to print functions
- `shitpost_alpha.py` — multi-source harvesting loop with `--sources` flag
- `shit/config/shitpost_settings.py` — ENABLED_HARVESTERS and Twitter config fields
- `shit_tests/shitposts/test_truth_social_s3_harvester.py` — updated for new inheritance
- `shit_tests/shitposts/test_shitposts_cli.py` — updated CLI test assertions
- `shit_tests/test_shitpost_alpha.py` — added sources fixture

## Test plan
- [x] All 150 harvester tests pass (`shit_tests/shitposts/`)
- [x] All 20 orchestrator tests pass (`shit_tests/test_shitpost_alpha.py`)
- [x] Full suite: 1611 passed, 10 pre-existing failures (config/prediction_operations)
- [x] No regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)