### PR TITLE
Fix prediction outcome date anchor to use source timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **7d return calculation anchored to wrong date** - OutcomeCalculator was using `prediction.created_at` (when LLM analysis ran) instead of the original post's publication timestamp to anchor return calculations. All same-batch predictions got identical entry prices and returns regardless of when the actual posts were published. Now uses `shitpost.timestamp` / `signal.published_at` as the anchor date, with `created_at` as fallback.
 - **Market data pipeline runtime errors** - Fix critical bugs preventing market data CLI from working
   - Add `Signal` model imports to resolve SQLAlchemy mapper errors in backfill_prices, auto_backfill_service, outcome_calculator, and cli modules
   - Add `session.rollback()` in `update-all-prices` JSON/JSONB fallback path to prevent transaction poisoning


### PR DESCRIPTION
## Summary
Fixed a critical bug in `OutcomeCalculator` where prediction outcome calculations were anchored to the wrong date. The calculator was using `prediction.created_at` (when LLM analysis was performed) instead of the original post/signal publication timestamp, causing incorrect 7-day return calculations and outcome accuracy metrics.

## Key Changes
- **New `_get_source_date()` method**: Implements proper date precedence:
  1. Uses `prediction.shitpost.timestamp` (Truth Social post publication time)
  2. Falls back to `prediction.signal.published_at` (signal publication time)
  3. Falls back to `prediction.created_at` (analysis time) only as last resort
  4. Returns `None` if no timestamps available

- **Updated `calculate_outcome_for_prediction()`**: Now calls `_get_source_date()` instead of directly using `prediction.created_at`, with improved error messaging

- **Comprehensive test coverage**: Added `TestGetSourceDate` class with 6 test cases covering:
  - Shitpost timestamp preference
  - Signal fallback when no shitpost
  - Created_at fallback when no source timestamps
  - Proper precedence ordering
  - Edge cases (None values, missing attributes)

- **Code formatting**: Applied consistent formatting throughout (line wrapping, quote style, trailing commas) for improved readability

## Implementation Details
The fix ensures that outcome calculations (price returns, P&L, accuracy metrics) are measured from the correct anchor date—when the prediction was actually made public—rather than when the analysis was performed days or weeks later. This is critical for accurate backtesting and performance evaluation.

https://claude.ai/code/session_01MTuurx1Vp9M1yzNjjBe4Bw