### PR TITLE
feat(ui): add sentiment background fills and left-border accents to all card types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Sentiment visual differentiation for all card types** - Added colored background fills to sentiment badges and 3px left-border accents to card wrappers across signal cards, post cards, prediction timeline cards, and feed signal cards. Users can now scan the dashboard and instantly identify bullish (green), bearish (red), and neutral (gray) signals without reading text.
+- **`SENTIMENT_BG_COLORS` constant** - Centralized sentiment background color definitions in `constants.py`
+- **`get_sentiment_style()` helper** - Centralized sentiment color/icon/background lookup in `cards.py`, eliminating duplicated inline dictionaries
+
 ### Fixed
 - **Inconsistent confidence display across card types** - Standardized confidence format to bare percentage (e.g., `75%`) across hero signal cards, post cards, and prediction timeline cards. Previously used three different formats: `Conf: 75%`, `75%`, and `Confidence: 75%`.
 - **Duplicate hero signal cards on dashboard** - Posts mentioning multiple tickers (e.g., RTX, LMT, NOC, GD) no longer produce duplicate identical cards in the Active Signals hero section

--- a/shitty_ui/constants.py
+++ b/shitty_ui/constants.py
@@ -21,6 +21,14 @@ SENTIMENT_COLORS = {
     "neutral": "#94a3b8",   # Slate 400 (same as COLORS["text_muted"])
 }
 
+# Pre-computed sentiment badge background colors (hex + alpha suffix)
+# Used by card components for consistent badge and border styling
+SENTIMENT_BG_COLORS = {
+    "bullish": "#10b98126",   # Emerald 500 at ~15% opacity
+    "bearish": "#ef444426",   # Red 500 at ~15% opacity
+    "neutral": "#94a3b826",   # Slate 400 at ~15% opacity
+}
+
 # Marker configuration for signal overlays
 MARKER_CONFIG = {
     "min_size": 8,          # Minimum marker size (pixels)


### PR DESCRIPTION
## Summary
- Add colored background fills to sentiment badges across all 5 card types (3 cards were missing them)
- Add 3px left-border accent to 4 card wrappers (only hero card had it before)
- Add `SENTIMENT_BG_COLORS` constant and `get_sentiment_style()` helper to centralize duplicated sentiment color/icon lookups
- Users can now visually scan the dashboard and instantly identify bullish (green), bearish (red), and neutral (gray) signals without reading text

## Test plan
- [x] 6 tests for `get_sentiment_style()` helper (bullish, bearish, neutral, None, case-insensitive, unknown)
- [x] 12 tests for left-border presence on all card types (bullish + bearish for each, neutral for bypassed post cards, 3px format check)
- [x] 6 tests for sentiment badge background fill presence across all card types
- [x] All 24 new tests passing
- [x] All 364 shitty_ui tests passing (3 pre-existing telegram failures excluded)
- [x] Full test suite: 1676 passed (pre-existing failures in config/analyzer/telegram unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)