### PR TITLE
enhance(ui): replace empty chart boxes with compact informative empty states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Smart Empty States** - Dashboard chart sections that have no data now display compact (80px) informative messages instead of tall (250px) blank chart boxes
+  - Accuracy Over Time, Accuracy by Confidence, and Performance by Asset on the main dashboard
+  - Accuracy by Confidence and Sentiment Breakdown on the Performance page
+  - Each empty state explains why data is missing and when to expect it
+  - Recovers ~500px of wasted vertical space, keeping real content above the fold
+
 ### Added
 - **Sentiment visual differentiation for all card types** - Added colored background fills to sentiment badges and 3px left-border accents to card wrappers across signal cards, post cards, prediction timeline cards, and feed signal cards. Users can now scan the dashboard and instantly identify bullish (green), bearish (red), and neutral (gray) signals without reading text.
 - **`SENTIMENT_BG_COLORS` constant** - Centralized sentiment background color definitions in `constants.py`

--- a/shit_tests/shitty_ui/test_layout.py
+++ b/shit_tests/shitty_ui/test_layout.py
@@ -527,6 +527,100 @@ class TestEmptyChart:
         assert fig.layout is not None
 
 
+class TestEmptyStateChart:
+    """Tests for create_empty_state_chart function."""
+
+    def test_returns_figure(self):
+        """Test that function returns a Plotly Figure."""
+        from components.cards import create_empty_state_chart
+        import plotly.graph_objects as go
+
+        fig = create_empty_state_chart("No data available")
+        assert isinstance(fig, go.Figure)
+
+    def test_default_height_is_compact(self):
+        """Test that the default height is 80px, not 250px like create_empty_chart."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("No data")
+        assert fig.layout.height == 80
+
+    def test_custom_height(self):
+        """Test that custom height is respected."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("No data", height=120)
+        assert fig.layout.height == 120
+
+    def test_includes_message_in_annotation(self):
+        """Test that the primary message appears in the annotation."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Custom empty message")
+        annotations = fig.layout.annotations
+        assert len(annotations) == 1
+        assert "Custom empty message" in annotations[0].text
+
+    def test_includes_hint_in_annotation(self):
+        """Test that the hint text appears in the annotation when provided."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main message", hint="This is the hint")
+        annotation_text = fig.layout.annotations[0].text
+        assert "This is the hint" in annotation_text
+
+    def test_no_hint_when_omitted(self):
+        """Test that no hint span is added when hint is empty."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main message")
+        annotation_text = fig.layout.annotations[0].text
+        assert "<br>" not in annotation_text
+
+    def test_icon_is_included(self):
+        """Test that the default info icon is in the annotation."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Test")
+        annotation_text = fig.layout.annotations[0].text
+        # Default icon is the info emoji
+        assert "\u2139" in annotation_text
+
+    def test_custom_icon(self):
+        """Test that a custom icon replaces the default."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Test", icon="\u23f3")
+        annotation_text = fig.layout.annotations[0].text
+        assert "\u23f3" in annotation_text
+
+    def test_no_grid_or_tick_labels(self):
+        """Test that axes have no grid, ticks, or labels."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Test")
+        assert fig.layout.xaxis.showgrid is False
+        assert fig.layout.yaxis.showgrid is False
+        assert fig.layout.xaxis.showticklabels is False
+        assert fig.layout.yaxis.showticklabels is False
+
+    def test_transparent_background(self):
+        """Test that the figure has a transparent background."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Test")
+        assert fig.layout.plot_bgcolor == "rgba(0,0,0,0)"
+        assert fig.layout.paper_bgcolor == "rgba(0,0,0,0)"
+
+    def test_accessible_via_layout_import(self):
+        """Test that the function can be imported from the layout re-export hub."""
+        from layout import create_empty_state_chart
+        import plotly.graph_objects as go
+
+        fig = create_empty_state_chart("Test")
+        assert isinstance(fig, go.Figure)
+
+
 class TestPeriodButtonStyles:
     """Tests for get_period_button_styles function."""
 

--- a/shitty_ui/components/cards.py
+++ b/shitty_ui/components/cards.py
@@ -119,6 +119,54 @@ def create_empty_chart(message: str = "No data available"):
     return fig
 
 
+def create_empty_state_chart(
+    message: str = "No data available",
+    hint: str = "",
+    icon: str = "\u2139\ufe0f",
+    height: int = 80,
+) -> go.Figure:
+    """Create a compact empty-state chart for sections with no data.
+
+    Unlike create_empty_chart(), this produces a shorter, visually subtle
+    figure designed to minimize wasted vertical space while informing the
+    user why data is missing and when to expect it.
+
+    Args:
+        message: Primary message (e.g., "No accuracy data yet").
+        hint: Secondary hint explaining what needs to happen
+              (e.g., "Predictions need 7+ days to mature").
+        icon: Unicode icon prefix for the message. Default info icon.
+        height: Figure height in pixels. Default 80.
+
+    Returns:
+        A Plotly go.Figure with centered annotation text and minimal chrome.
+    """
+    display_text = f"{icon}  {message}"
+    if hint:
+        display_text += f"<br><span style='font-size:11px; color:{COLORS['border']}'>{hint}</span>"
+
+    fig = go.Figure()
+    fig.add_annotation(
+        text=display_text,
+        showarrow=False,
+        font=dict(color=COLORS["text_muted"], size=13),
+        xref="paper",
+        yref="paper",
+        x=0.5,
+        y=0.5,
+    )
+    fig.update_layout(
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        font_color=COLORS["text_muted"],
+        height=height,
+        margin=dict(l=0, r=0, t=10, b=10),
+        xaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+        yaxis=dict(showgrid=False, showticklabels=False, zeroline=False),
+    )
+    return fig
+
+
 def create_hero_signal_card(row) -> html.Div:
     """Create a hero signal card for a high-confidence prediction."""
     timestamp = row.get("timestamp")

--- a/shitty_ui/layout.py
+++ b/shitty_ui/layout.py
@@ -16,6 +16,7 @@ from constants import COLORS
 from components.cards import (
     create_error_card,
     create_empty_chart,
+    create_empty_state_chart,
     create_feed_signal_card,
     create_hero_signal_card,
     create_metric_card,

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -12,6 +12,7 @@ from constants import COLORS
 from components.cards import (
     create_error_card,
     create_empty_chart,
+    create_empty_state_chart,
     create_hero_signal_card,
     create_metric_card,
     create_signal_card,
@@ -807,7 +808,10 @@ def register_dashboard_callbacks(app: Dash):
                     showlegend=False,
                 )
             else:
-                acc_fig = create_empty_chart("Not enough data to show accuracy trend")
+                acc_fig = create_empty_state_chart(
+                    message="Not enough weekly data to chart accuracy trend",
+                    hint="Requires 2+ weeks of evaluated predictions",
+                )
         except Exception as e:
             errors.append(f"Accuracy over time: {e}")
             print(f"Error loading accuracy over time: {traceback.format_exc()}")
@@ -845,8 +849,9 @@ def register_dashboard_callbacks(app: Dash):
                     height=250,
                 )
             else:
-                conf_fig = create_empty_chart(
-                    "No outcome data available for this period"
+                conf_fig = create_empty_state_chart(
+                    message="No accuracy data for this period",
+                    hint="Predictions need 7+ trading days to mature before accuracy is measured",
                 )
         except Exception as e:
             errors.append(f"Confidence chart: {e}")
@@ -888,8 +893,9 @@ def register_dashboard_callbacks(app: Dash):
                     hovermode="x unified",
                 )
             else:
-                asset_fig = create_empty_chart(
-                    "No outcome data available for this period"
+                asset_fig = create_empty_state_chart(
+                    message="No asset performance data for this period",
+                    hint="Asset accuracy appears after prediction outcomes are evaluated",
                 )
         except Exception as e:
             errors.append(f"Asset chart: {e}")
@@ -1506,7 +1512,10 @@ def register_dashboard_callbacks(app: Dash):
                     height=300,
                 )
             else:
-                conf_fig = create_empty_chart("No confidence data available")
+                conf_fig = create_empty_state_chart(
+                    message="No confidence breakdown available yet",
+                    hint="Appears after predictions have evaluated outcomes",
+                )
         except Exception as e:
             errors.append(f"Confidence chart: {e}")
             conf_fig = create_empty_chart(f"Error: {str(e)[:50]}")
@@ -1568,7 +1577,10 @@ def register_dashboard_callbacks(app: Dash):
                     ),
                 )
             else:
-                sent_fig = create_empty_chart("No sentiment data available")
+                sent_fig = create_empty_state_chart(
+                    message="No sentiment breakdown available yet",
+                    hint="Appears after predictions with sentiment labels are evaluated",
+                )
         except Exception as e:
             errors.append(f"Sentiment chart: {e}")
             sent_fig = create_empty_chart(f"Error: {str(e)[:50]}")


### PR DESCRIPTION
## Summary
- Add `create_empty_state_chart()` function to `cards.py` that renders a compact 80px chart with informative message and hint text, replacing the 250px blank boxes
- Replace 5 `create_empty_chart()` calls in `dashboard.py` with `create_empty_state_chart()` for "no data" branches on main dashboard (3 charts) and Performance page (2 charts)
- Error states (`except` blocks) remain using the original `create_empty_chart()` at full height for visibility
- Re-export `create_empty_state_chart` from `layout.py` for test accessibility
- Add 11 tests in `TestEmptyStateChart` class covering: return type, default/custom height, message/hint/icon rendering, axis config, transparent background, and layout import

## Test plan
- [x] 11 new tests pass: `pytest shit_tests/shitty_ui/test_layout.py -v -k "TestEmptyStateChart"` (all pass)
- [x] Full UI test suite passes: `pytest shit_tests/shitty_ui/ -v` (383 passed, 3 pre-existing failures in Telegram tests)
- [x] Full test suite: 1736 passed (13 failed + 38 errors are all pre-existing, unrelated to this change)
- [x] `create_empty_chart()` function NOT modified (still used in 12+ locations)
- [x] Error-state `except` blocks still use `create_empty_chart()` for full-height error display

🤖 Generated with [Claude Code](https://claude.com/claude-code)