### PR TITLE
fix: smart time fallback & surface evaluated outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dashboard KPIs show zeros** -- Added smart fallback to all-time data when selected time period has no evaluated predictions, with visual indicator
+- **Signal feed buries evaluated outcomes** -- Changed sort order to show Correct/Incorrect signals before Pending ones; added "Evaluated" filter option
+- **Accuracy chart requires 2+ weeks** -- Lowered threshold to 1 week; added all-time fallback when period has no data
+- **Hero signals often empty** -- Added progressive time window fallback (72h -> 7d -> 30d -> lower confidence) with dynamic labels
+
 ### Changed
 - **Monolith → Microservices cutover** - Replaced `shitpost-alpha` orchestrator with standalone `harvester` cron service
   - New `harvester` service runs `python -m shitposts --mode incremental` every 5 minutes

--- a/shitty_ui/components/cards.py
+++ b/shitty_ui/components/cards.py
@@ -8,7 +8,7 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 import plotly.graph_objects as go
 
-from constants import COLORS, SENTIMENT_COLORS, SENTIMENT_BG_COLORS
+from constants import COLORS, FONT_SIZES, SENTIMENT_COLORS, SENTIMENT_BG_COLORS
 
 
 def strip_urls(text: str) -> str:
@@ -347,6 +347,7 @@ def create_metric_card(
     subtitle: str = "",
     icon: str = "chart-line",
     color: str = None,
+    note: str = "",
 ):
     """Create a metric card component with responsive styling."""
     color = color or COLORS["accent"]
@@ -376,6 +377,16 @@ def create_metric_card(
                     ),
                     html.Small(subtitle, style={"color": COLORS["text_muted"]})
                     if subtitle
+                    else None,
+                    html.Div(
+                        note,
+                        style={
+                            "color": COLORS["warning"],
+                            "fontSize": FONT_SIZES["small"],
+                            "marginTop": "4px",
+                        },
+                    )
+                    if note
                     else None,
                 ],
                 style={"textAlign": "center", "padding": "15px"},

--- a/shitty_ui/pages/signals.py
+++ b/shitty_ui/pages/signals.py
@@ -196,6 +196,10 @@ def create_signal_feed_page() -> html.Div:
                                                         "value": "all",
                                                     },
                                                     {
+                                                        "label": "Evaluated (has outcome)",
+                                                        "value": "evaluated",
+                                                    },
+                                                    {
                                                         "label": "Correct",
                                                         "value": "correct",
                                                     },


### PR DESCRIPTION
## Summary
- **KPI Cards**: Smart fallback to all-time data when selected period has no evaluated predictions, with "All-time" indicator note
- **Signal Feed**: Sort evaluated outcomes (Correct/Incorrect) above pending; add "Evaluated (has outcome)" filter option
- **Accuracy Chart**: Lowered threshold from 2 weeks to 1 week; added all-time fallback with warning annotation when period is empty
- **Hero Signals**: Progressive fallback through 4 strategies (72h → 7d → 30d → lower confidence) with dynamic labels

## Test plan
- [x] 12 new unit tests (4 KPI fallback + 5 hero fallback + 3 sort/filter)
- [x] All 424 existing UI tests pass (3 pre-existing Telegram failures unrelated)
- [ ] Visual: set period to "7D" — confirm KPIs show all-time data with "All-time" note
- [ ] Visual: set period to "All" — confirm charts load normally
- [ ] Visual: check /signals "Evaluated" dropdown filter works

**Phase**: `01_fix-data-visibility` from `dashboard-redesign_2026-02-16`
**Plan doc**: `documentation/planning/phases/dashboard-redesign_2026-02-16/01_fix-data-visibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)