### PR TITLE
feat: contextual empty states with guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Smart empty states** -- Dashboard sections now show contextual guidance when empty, including data counts, why the section is empty, and suggestions to expand the time period or visit other pages
+  - New `create_empty_state_html()` component for HTML-based empty states with navigation links
+  - Enhanced `create_empty_state_chart()` with `context_line` and `action_text` parameters
+  - New `get_empty_state_context()` cached query for aggregate counts
 - **Expandable thesis cards** -- Signal feed and post feed cards now show a "Show full thesis" toggle when the LLM investment reasoning exceeds the preview length, allowing users to read the full analysis without navigating away
   - Feed signal cards expand at 120 characters, post cards at 200 characters
   - Click-to-expand uses clientside callbacks for zero-latency toggling

--- a/documentation/planning/phases/dashboard-redesign_2026-02-16/03_smart-empty-states.md
+++ b/documentation/planning/phases/dashboard-redesign_2026-02-16/03_smart-empty-states.md
@@ -1,7 +1,9 @@
 # Phase 03: Smart Empty States
 
-**Status**: 🔧 IN PROGRESS
+**Status**: ✅ COMPLETE
 **Started**: 2026-02-16
+**Completed**: 2026-02-16
+**PR**: #76
 
 **PR Title**: feat: contextual empty states with guidance
 **Risk Level**: Low

--- a/documentation/planning/phases/dashboard-redesign_2026-02-16/03_smart-empty-states.md
+++ b/documentation/planning/phases/dashboard-redesign_2026-02-16/03_smart-empty-states.md
@@ -1,0 +1,291 @@
+# Phase 03: Smart Empty States
+
+**Status**: 🔧 IN PROGRESS
+**Started**: 2026-02-16
+
+**PR Title**: feat: contextual empty states with guidance
+**Risk Level**: Low
+**Estimated Effort**: Small-Medium (~2-3 hours)
+**Dependencies**: Phase 01 (soft — uses similar fallback pattern)
+**Unlocks**: Phase 10 (Brand Identity)
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `shitty_ui/components/cards.py` | Enhance `create_empty_state_chart()` with `context_line`/`action_text` params; add new `create_empty_state_html()` |
+| `shitty_ui/data.py` | Add `get_empty_state_context()` cached query function |
+| `shitty_ui/pages/dashboard.py` | Update 7 empty state locations across 2 callbacks |
+| `shitty_ui/pages/dashboard.py` | Add `create_empty_state_html` and `get_empty_state_context` imports |
+| `shit_tests/shitty_ui/test_cards.py` | Add `TestEmptyStateHtml` class (8 tests) |
+| `shit_tests/shitty_ui/test_layout.py` | Extend `TestEmptyStateChart` (7 tests for new params) |
+| `shit_tests/shitty_ui/test_data.py` | Add `TestGetEmptyStateContext` class (5 tests) |
+| `CHANGELOG.md` | Add entry |
+
+## Context
+
+The dashboard currently shows six distinct empty state messages that are dead ends: a gray icon, a static message, and no path forward. Users see these when:
+- The selected time period (7D, 30D) has no evaluated data, even though a wider window does
+- Predictions are too young to have outcomes (7-day maturation window)
+- The system is new and very little data exists yet
+
+**Goal**: Replace each dead end with a contextual message that tells the user (a) why it's empty, (b) what timeframe has data, and (c) where to look next.
+
+**Screenshot**: See `/tmp/design-review/dashboard-desktop.png` — all KPI zeros, empty charts with static messages.
+
+## Detailed Implementation
+
+### Step A: Add `get_empty_state_context()` to data.py
+
+**File**: `shitty_ui/data.py`
+**Location**: Around line 1475, after `get_high_confidence_metrics`
+
+One lightweight query that gathers counts all empty states need:
+
+```python
+@ttl_cache(ttl_seconds=300)
+def get_empty_state_context() -> Dict[str, Any]:
+    """Get contextual counts for smart empty state messages.
+
+    Returns lightweight aggregate counts used by empty-state components
+    to guide users toward timeframes and pages that have data.
+
+    Returns:
+        Dict with keys:
+            total_evaluated: int -- all-time evaluated prediction outcomes
+            total_pending: int -- outcomes awaiting maturation
+            total_high_confidence: int -- all-time high-confidence signals (>=0.75)
+    """
+    query = text("""
+        SELECT
+            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS total_evaluated,
+            COUNT(CASE WHEN correct_t7 IS NULL THEN 1 END) AS total_pending,
+            COUNT(CASE WHEN prediction_confidence >= 0.75 AND correct_t7 IS NOT NULL THEN 1 END) AS total_high_confidence
+        FROM prediction_outcomes
+    """)
+
+    try:
+        rows, columns = execute_query(query)
+        if rows and rows[0]:
+            total_evaluated = rows[0][0] or 0
+            total_pending = rows[0][1] or 0
+            total_high_confidence = rows[0][2] or 0
+
+            return {
+                "total_evaluated": total_evaluated,
+                "total_pending": total_pending,
+                "total_high_confidence": total_high_confidence,
+            }
+    except Exception as e:
+        logger.error(f"Error loading empty state context: {e}")
+
+    return {
+        "total_evaluated": 0,
+        "total_pending": 0,
+        "total_high_confidence": 0,
+    }
+```
+
+Also add to `clear_all_caches()` (~line 1095):
+```python
+get_empty_state_context.clear_cache()  # type: ignore
+```
+
+### Step B: Enhance `create_empty_state_chart()` in cards.py
+
+**File**: `shitty_ui/components/cards.py`
+**Current signature** (line ~130):
+
+```python
+def create_empty_state_chart(
+    message: str = "No data available",
+    hint: str = "",
+    icon: str = "ℹ️",
+    height: int = 80,
+) -> go.Figure:
+```
+
+**New signature** (backward-compatible):
+
+```python
+def create_empty_state_chart(
+    message: str = "No data available",
+    hint: str = "",
+    icon: str = "ℹ️",
+    height: int = 80,
+    context_line: str = "",
+    action_text: str = "",
+) -> go.Figure:
+```
+
+- `context_line`: Secondary data-driven line (e.g., "74 evaluated trades all-time"). Rendered in `COLORS["text_muted"]`.
+- `action_text`: Navigation hint (e.g., "Try expanding to All"). Rendered in `COLORS["accent"]`.
+
+Update the annotation text assembly (lines ~144-146):
+```python
+display_text = f"{icon}  {message}"
+if hint:
+    display_text += f"<br><span style='font-size:11px; color:{COLORS['border']}'>{hint}</span>"
+if context_line:
+    display_text += f"<br><span style='font-size:11px; color:{COLORS['text_muted']}'>{context_line}</span>"
+if action_text:
+    display_text += f"<br><span style='font-size:11px; color:{COLORS['accent']}'>{action_text}</span>"
+```
+
+Auto-adjust height when extra lines present:
+```python
+extra_lines = sum(1 for x in [context_line, action_text] if x)
+if extra_lines > 0 and height == 80:
+    height = 80 + (extra_lines * 18)
+```
+
+### Step C: Add `create_empty_state_html()` to cards.py
+
+**File**: `shitty_ui/components/cards.py`
+**Location**: Near `create_empty_state_chart` (around line 167)
+
+For sections that render Dash components (hero section, signal lists) rather than Plotly figures:
+
+```python
+def create_empty_state_html(
+    message: str,
+    hint: str = "",
+    context_line: str = "",
+    action_text: str = "",
+    action_href: str = "",
+    icon_class: str = "fas fa-moon",
+) -> html.Div:
+    """Create an HTML empty-state card with contextual guidance."""
+    children = [
+        html.I(className=f"{icon_class} me-2", style={"color": COLORS["text_muted"]}),
+        html.Span(message, style={"color": COLORS["text_muted"], "fontSize": "0.9rem"}),
+    ]
+
+    sub_children = []
+    if hint:
+        sub_children.append(html.Div(hint, style={
+            "color": COLORS["border"], "fontSize": "0.8rem", "marginTop": "6px",
+        }))
+    if context_line:
+        sub_children.append(html.Div(context_line, style={
+            "color": COLORS["text_muted"], "fontSize": "0.8rem", "marginTop": "4px",
+        }))
+    if action_text:
+        action_content = (
+            dcc.Link(action_text, href=action_href, style={
+                "color": COLORS["accent"], "fontSize": "0.8rem", "textDecoration": "none",
+            })
+            if action_href
+            else html.Span(action_text, style={
+                "color": COLORS["accent"], "fontSize": "0.8rem",
+            })
+        )
+        sub_children.append(html.Div(action_content, style={"marginTop": "4px"}))
+
+    return html.Div(
+        [html.Div(children), *sub_children],
+        style={
+            "padding": "24px", "textAlign": "center",
+            "backgroundColor": COLORS["secondary"], "borderRadius": "12px",
+            "border": f"1px solid {COLORS['border']}",
+        },
+    )
+```
+
+### Step D: Update Empty States in dashboard.py
+
+Update 7 locations where empty states appear. Each follows the same pattern:
+
+```python
+try:
+    ctx = get_empty_state_context()
+    total_eval = ctx["total_evaluated"]
+    context_line = f"{total_eval} evaluated trade{'s' if total_eval != 1 else ''} all-time" if total_eval > 0 else ""
+    action_text = "Try expanding to All" if total_eval > 0 and days is not None else ""
+except Exception:
+    context_line = ""
+    action_text = ""
+```
+
+Then pass `context_line` and `action_text` to `create_empty_state_chart()` or `create_empty_state_html()`.
+
+**Locations to update:**
+
+| Location | Lines | Type | Context Message |
+|----------|-------|------|-----------------|
+| Hero signals empty | ~599-625 | HTML | "N high-confidence signals all-time" + link to /performance |
+| Accuracy over time | ~750-753 | Chart | "N evaluated trades all-time" + "Try expanding to All" |
+| Confidence chart | ~791-794 | Chart | "N evaluated trades all-time" + "Try expanding to All" |
+| Asset chart | ~835-838 | Chart | "N evaluated trades all-time" + "Try expanding to All" |
+| Recent signals | ~851-861 | HTML | "N signals all-time" + link to /signals |
+| Performance confidence | ~1250-1253 | Chart | "N predictions awaiting evaluation" |
+| Performance sentiment | ~1315-1318 | Chart | "N predictions awaiting evaluation" |
+
+### Step E: Update dashboard.py imports
+
+Add `create_empty_state_html` to the existing cards import in `dashboard.py`, and add `get_empty_state_context` to the data import.
+
+### Key Design Decisions
+
+- **Single query for all context**: `get_empty_state_context()` runs one query cached for 5 minutes. Multiple empty states in the same render hit the cache.
+- **Graceful degradation**: Every `get_empty_state_context()` call is wrapped in `try/except`. If the query fails, empty states fall back to the original behavior (message + hint, no context).
+- **No buttons in charts**: Plotly annotations are SVG text — they can't contain clickable HTML. Only the HTML empty states (`create_empty_state_html`) get `dcc.Link` components.
+
+---
+
+## Test Plan
+
+### `TestEmptyStateChart` extensions (test_layout.py)
+1. `test_context_line_appears_in_annotation`
+2. `test_action_text_appears_in_annotation`
+3. `test_context_and_action_combined`
+4. `test_empty_context_line_omitted`
+5. `test_auto_height_adjustment_with_context`
+6. `test_explicit_height_no_crash`
+7. `test_backward_compatibility_no_new_params`
+
+### `TestEmptyStateHtml` (test_cards.py)
+1. `test_returns_html_div`
+2. `test_message_appears_in_text`
+3. `test_hint_appears_when_provided`
+4. `test_context_line_appears_when_provided`
+5. `test_action_text_with_href_creates_link`
+6. `test_action_text_without_href_creates_span`
+7. `test_icon_class_applied`
+8. `test_minimal_call_only_message`
+
+### `TestGetEmptyStateContext` (test_data.py)
+1. `test_returns_expected_keys`
+2. `test_handles_all_zeros`
+3. `test_handles_null_values`
+4. `test_handles_query_error`
+
+---
+
+## Verification Checklist
+
+- [ ] `source venv/bin/activate && pytest shit_tests/shitty_ui/ -v` — full UI suite passes
+- [ ] All existing callers of `create_empty_state_chart()` work without modification (no new required params)
+- [ ] Visual: set period to "7D" — confirm context messages render with counts and action text
+- [ ] Visual: set period to "All" — confirm charts load normally (no empty states shown)
+- [ ] CHANGELOG.md updated
+
+## What NOT To Do
+
+1. **Do NOT add navigation buttons to chart empty states.** Plotly annotations are SVG text, not clickable HTML.
+2. **Do NOT make `get_empty_state_context()` a required dependency.** Every call is wrapped in try/except with fallbacks.
+3. **Do NOT change the default height unconditionally.** Auto-adjust only when new content lines are present.
+4. **Do NOT query full prediction_outcomes per empty state.** Use the single cached function.
+5. **Do NOT modify `build_empty_signal_chart()` in charts.py.** That serves trends/asset pages (different scope).
+6. **Do NOT duplicate the `dcc` import in cards.py.** It already exists on line 7.
+7. **Do NOT break existing test assertions.** The new params are all optional with empty-string defaults.
+
+## CHANGELOG Entry
+
+```markdown
+### Added
+- **Smart empty states** -- Dashboard sections now show contextual guidance when empty, including data counts, why the section is empty, and suggestions to expand the time period or visit other pages
+  - New `create_empty_state_html()` component for HTML-based empty states with navigation links
+  - Enhanced `create_empty_state_chart()` with `context_line` and `action_text` parameters
+  - New `get_empty_state_context()` cached query for aggregate counts
+```

--- a/shit_tests/shitty_ui/test_layout.py
+++ b/shit_tests/shitty_ui/test_layout.py
@@ -662,6 +662,68 @@ class TestEmptyStateChart:
         assert fig.layout.xaxis.showticklabels is False
         assert fig.layout.yaxis.showticklabels is False
 
+    def test_context_line_appears_in_annotation(self):
+        """Test that context_line text appears in the annotation."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main", context_line="74 evaluated trades all-time")
+        text = fig.layout.annotations[0].text
+        assert "74 evaluated trades all-time" in text
+
+    def test_action_text_appears_in_annotation(self):
+        """Test that action_text appears in the annotation with accent color."""
+        from components.cards import create_empty_state_chart
+        from constants import COLORS
+
+        fig = create_empty_state_chart("Main", action_text="Try expanding to All")
+        text = fig.layout.annotations[0].text
+        assert "Try expanding to All" in text
+        assert COLORS["accent"] in text
+
+    def test_context_and_action_combined(self):
+        """Test that both context_line and action_text appear together."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart(
+            "Main", context_line="10 trades", action_text="Try All"
+        )
+        text = fig.layout.annotations[0].text
+        assert "10 trades" in text
+        assert "Try All" in text
+
+    def test_empty_context_line_omitted(self):
+        """Test that empty context_line doesn't add extra markup."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main only")
+        text = fig.layout.annotations[0].text
+        # Only one line — no extra <br> tags beyond message
+        assert text.count("<br>") == 0
+
+    def test_auto_height_adjustment_with_context(self):
+        """Test that height auto-adjusts when context lines are added."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main", context_line="ctx", action_text="act")
+        assert fig.layout.height == 80 + (2 * 18)  # 116
+
+    def test_explicit_height_no_auto_adjust(self):
+        """Test that explicit height is not auto-adjusted."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("Main", context_line="ctx", height=120)
+        assert fig.layout.height == 120
+
+    def test_backward_compatibility_no_new_params(self):
+        """Test that calling without new params works identically to before."""
+        from components.cards import create_empty_state_chart
+
+        fig = create_empty_state_chart("No data", hint="Check back later")
+        assert fig.layout.height == 80
+        text = fig.layout.annotations[0].text
+        assert "No data" in text
+        assert "Check back later" in text
+
     def test_transparent_background(self):
         """Test that the figure has a transparent background."""
         from components.cards import create_empty_state_chart

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -13,6 +13,7 @@ from components.cards import (
     create_error_card,
     create_empty_chart,
     create_empty_state_chart,
+    create_empty_state_html,
     create_hero_signal_card,
     create_metric_card,
     create_signal_card,
@@ -38,6 +39,7 @@ from data import (
     get_sentiment_accuracy,
     get_dashboard_kpis,
     get_dashboard_kpis_with_fallback,
+    get_empty_state_context,
 )
 
 
@@ -590,29 +592,19 @@ def register_dashboard_callbacks(app: Dash):
                     ]
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    hc = ctx["total_high_confidence"]
+                    hc_line = f"{hc} high-confidence signal{'s' if hc != 1 else ''} all-time" if hc > 0 else ""
+                except Exception:
+                    hc_line = ""
                 hero_section = html.Div(
                     [
-                        html.Div(
-                            [
-                                html.I(
-                                    className="fas fa-moon me-2",
-                                    style={"color": COLORS["text_muted"]},
-                                ),
-                                html.Span(
-                                    "No signals with confidence >= 60% in the last 30 days",
-                                    style={
-                                        "color": COLORS["text_muted"],
-                                        "fontSize": "0.9rem",
-                                    },
-                                ),
-                            ],
-                            style={
-                                "padding": "24px",
-                                "textAlign": "center",
-                                "backgroundColor": COLORS["secondary"],
-                                "borderRadius": "12px",
-                                "border": f"1px solid {COLORS['border']}",
-                            },
+                        create_empty_state_html(
+                            message="No signals with confidence \u2265 60% in the last 30 days",
+                            context_line=hc_line,
+                            action_text="View all on Performance page",
+                            action_href="/performance",
                         )
                     ]
                 )
@@ -763,9 +755,19 @@ def register_dashboard_callbacks(app: Dash):
                     yaxis={"range": [0, 105], "title": "Accuracy %"},
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    total_eval = ctx["total_evaluated"]
+                    ctx_line = f"{total_eval} evaluated trade{'s' if total_eval != 1 else ''} all-time" if total_eval > 0 else ""
+                    act_text = "Try expanding to All" if total_eval > 0 and days is not None else ""
+                except Exception:
+                    ctx_line = ""
+                    act_text = ""
                 acc_fig = create_empty_state_chart(
                     message="No evaluated predictions yet",
                     hint="Predictions need 7+ trading days to mature before accuracy is measured",
+                    context_line=ctx_line,
+                    action_text=act_text,
                 )
         except Exception as e:
             errors.append(f"Accuracy over time: {e}")
@@ -812,9 +814,19 @@ def register_dashboard_callbacks(app: Dash):
                     bargap=0.35,
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    total_eval = ctx["total_evaluated"]
+                    ctx_line = f"{total_eval} evaluated trade{'s' if total_eval != 1 else ''} all-time" if total_eval > 0 else ""
+                    act_text = "Try expanding to All" if total_eval > 0 and days is not None else ""
+                except Exception:
+                    ctx_line = ""
+                    act_text = ""
                 conf_fig = create_empty_state_chart(
                     message="No accuracy data for this period",
                     hint="Predictions need 7+ trading days to mature before accuracy is measured",
+                    context_line=ctx_line,
+                    action_text=act_text,
                 )
         except Exception as e:
             errors.append(f"Confidence chart: {e}")
@@ -866,9 +878,19 @@ def register_dashboard_callbacks(app: Dash):
                     bargap=0.3,
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    total_eval = ctx["total_evaluated"]
+                    ctx_line = f"{total_eval} evaluated trade{'s' if total_eval != 1 else ''} all-time" if total_eval > 0 else ""
+                    act_text = "Try expanding to All" if total_eval > 0 and days is not None else ""
+                except Exception:
+                    ctx_line = ""
+                    act_text = ""
                 asset_fig = create_empty_state_chart(
                     message="No asset performance data for this period",
                     hint="Asset accuracy appears after prediction outcomes are evaluated",
+                    context_line=ctx_line,
+                    action_text=act_text,
                 )
         except Exception as e:
             errors.append(f"Asset chart: {e}")
@@ -883,14 +905,19 @@ def register_dashboard_callbacks(app: Dash):
                     create_signal_card(row) for _, row in signals_df.iterrows()
                 ]
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    total_eval = ctx["total_evaluated"]
+                    ctx_line = f"{total_eval} signal{'s' if total_eval != 1 else ''} all-time" if total_eval > 0 else ""
+                except Exception:
+                    ctx_line = ""
                 signal_cards = [
-                    html.P(
-                        "No recent signals for this period",
-                        style={
-                            "color": COLORS["text_muted"],
-                            "textAlign": "center",
-                            "padding": "20px",
-                        },
+                    create_empty_state_html(
+                        message="No recent signals for this period",
+                        context_line=ctx_line,
+                        action_text="View all signals",
+                        action_href="/signals",
+                        icon_class="fas fa-satellite-dish",
                     )
                 ]
         except Exception as e:
@@ -1285,9 +1312,16 @@ def register_dashboard_callbacks(app: Dash):
                     bargap=0.35,
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    pending = ctx["total_pending"]
+                    ctx_line = f"{pending} prediction{'s' if pending != 1 else ''} awaiting evaluation" if pending > 0 else ""
+                except Exception:
+                    ctx_line = ""
                 conf_fig = create_empty_state_chart(
                     message="No confidence breakdown available yet",
                     hint="Appears after predictions have evaluated outcomes",
+                    context_line=ctx_line,
                 )
         except Exception as e:
             errors.append(f"Confidence chart: {e}")
@@ -1349,9 +1383,16 @@ def register_dashboard_callbacks(app: Dash):
                     ),
                 )
             else:
+                try:
+                    ctx = get_empty_state_context()
+                    pending = ctx["total_pending"]
+                    ctx_line = f"{pending} prediction{'s' if pending != 1 else ''} awaiting evaluation" if pending > 0 else ""
+                except Exception:
+                    ctx_line = ""
                 sent_fig = create_empty_state_chart(
                     message="No sentiment breakdown available yet",
                     hint="Appears after predictions with sentiment labels are evaluated",
+                    context_line=ctx_line,
                 )
         except Exception as e:
             errors.append(f"Sentiment chart: {e}")


### PR DESCRIPTION
## Summary
- Dashboard empty states now show data-driven context instead of dead-end messages
- Each empty section shows aggregate counts (e.g., "74 evaluated trades all-time"), why the view is empty, and navigation hints ("Try expanding to All", links to /performance)
- All 7 empty state locations updated: hero signals, accuracy chart, confidence chart, asset chart, recent signals, performance confidence, performance sentiment

## Changes
- **`data.py`**: New `get_empty_state_context()` cached query (5-min TTL) — single lightweight COUNT query for all empty states
- **`cards.py`**: Enhanced `create_empty_state_chart()` with `context_line`/`action_text` params; new `create_empty_state_html()` for HTML empty states with `dcc.Link` navigation
- **`dashboard.py`**: Updated 7 empty state locations with contextual messages + imports
- **Tests**: 19 new tests (8 HTML component, 7 chart extensions, 4 data layer)

## Test plan
- [x] `pytest shit_tests/shitty_ui/ -v` — 491 passed (3 pre-existing telegram failures)
- [x] All existing callers of `create_empty_state_chart()` work without modification (backward compatible)
- [x] "What NOT To Do" items from plan reviewed — none violated

🤖 Generated with [Claude Code](https://claude.com/claude-code)