### PR TITLE
feat(dashboard): dynamic insight cards that answer 'so what right now?'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dynamic insight cards** -- 2-3 personality-driven callout cards above the screener table answering "so what right now?"
+  - Latest call: most recent evaluated prediction with 7-day return and outcome
+  - Best & worst: top and bottom performing predictions in the selected period
+  - System pulse: accuracy percentage vs coin flip baseline with self-deprecating commentary
+  - Hot asset: most-predicted ticker with average return
+  - High-confidence signal: recent high-confidence call with outcome status
+  - Each card links to the relevant asset detail page
+  - Cards update with time period filter (7D/30D/90D/All)
+  - Graceful degradation: each insight query has independent error handling
+  - Cleaned up dead Signals/Trends/Performance brand copy from Phase 05
+
 ### Changed
 - **2-view information architecture** -- Consolidated 4 pages (Dashboard, Signals, Trends, Performance) into 2 views: Home (Screener) and Asset Detail
   - Removed nav links from header — logo-only navigation

--- a/documentation/planning/phases/dashboard-rethink_2026-02-22/06_actionable-insight-cards.md
+++ b/documentation/planning/phases/dashboard-rethink_2026-02-22/06_actionable-insight-cards.md
@@ -1,5 +1,9 @@
 # Phase 06: Actionable Insight Cards
 
+**Status:** ✅ COMPLETE
+**Started:** 2026-02-23
+**Completed:** 2026-02-23
+
 **PR Title:** feat(dashboard): dynamic insight cards that answer "so what right now?"
 
 **Risk Level:** Medium
@@ -440,6 +444,12 @@ Also add `get_dynamic_insights` to the `clear_all_caches()` function:
     "chart_empty_accuracy": "Not enough data to chart accuracy yet",
 ```
 
+### Step 2b: Clean up dead brand copy from Phase 05
+
+**File:** `shitty_ui/brand_copy.py`
+
+Remove copy keys for Signals Page (lines 59-65), Trends Page (lines 67-76), and Performance Page (lines 87-100) — all pages were deleted in Phase 05. Keep only active copy.
+
 ### Step 3: Create the insight cards component
 
 **File:** `shitty_ui/components/insights.py` (NEW FILE)
@@ -694,67 +704,14 @@ def create_insight_cards(insights: List[Dict[str, Any]], max_cards: int = 3) -> 
 
 #### 4a. Add imports
 
-**Existing imports (lines 12-20):**
-```python
-from components.cards import (
-    create_error_card,
-    create_empty_chart,
-    create_empty_state_chart,
-    create_empty_state_html,
-    create_metric_card,
-    create_post_card,
-    create_unified_signal_card,
-)
-```
-
-**Add after this import block:**
+**Add to existing imports:**
 ```python
 from components.insights import create_insight_cards
 ```
 
-**Existing data imports (lines 25-42):**
+**Add `get_dynamic_insights` to the existing `from data import (...)` block:**
 ```python
-from data import (
-    get_unified_feed,
-    get_sparkline_prices,
-    get_performance_metrics,
-    get_accuracy_by_confidence,
-    get_accuracy_by_asset,
-    get_predictions_with_outcomes,
-    load_recent_posts,
-    get_weekly_signal_count,
-    get_high_confidence_metrics,
-    get_best_performing_asset,
-    get_accuracy_over_time,
-    get_backtest_simulation,
-    get_sentiment_accuracy,
-    get_dashboard_kpis,
-    get_dashboard_kpis_with_fallback,
-    get_empty_state_context,
-)
-```
-
-**Replace with (add `get_dynamic_insights`):**
-```python
-from data import (
-    get_unified_feed,
-    get_sparkline_prices,
-    get_performance_metrics,
-    get_accuracy_by_confidence,
-    get_accuracy_by_asset,
-    get_predictions_with_outcomes,
-    load_recent_posts,
-    get_weekly_signal_count,
-    get_high_confidence_metrics,
-    get_best_performing_asset,
-    get_accuracy_over_time,
-    get_backtest_simulation,
-    get_sentiment_accuracy,
-    get_dashboard_kpis,
-    get_dashboard_kpis_with_fallback,
-    get_empty_state_context,
     get_dynamic_insights,
-)
 ```
 
 #### 4b. Add insight cards container to the layout
@@ -803,34 +760,28 @@ In the `create_dashboard_page()` function, add a loading container for insight c
 
 #### 4c. Update the main dashboard callback to include insight cards
 
-**Existing callback outputs (lines 514-523):**
+**Existing callback outputs (3 outputs, post-Phase 05):**
 ```python
     @app.callback(
         [
-            Output("unified-feed-container", "children"),
+            Output("screener-table-container", "children"),
             Output("performance-metrics", "children"),
-            Output("accuracy-over-time-chart", "figure"),
-            Output("confidence-accuracy-chart", "figure"),
-            Output("asset-accuracy-chart", "figure"),
             Output("last-update-timestamp", "data"),
         ],
 ```
 
-**Replace with (add insight-cards-container output):**
+**Replace with (add insight-cards-container as first output, 3→4):**
 ```python
     @app.callback(
         [
             Output("insight-cards-container", "children"),
-            Output("unified-feed-container", "children"),
+            Output("screener-table-container", "children"),
             Output("performance-metrics", "children"),
-            Output("accuracy-over-time-chart", "figure"),
-            Output("confidence-accuracy-chart", "figure"),
-            Output("asset-accuracy-chart", "figure"),
             Output("last-update-timestamp", "data"),
         ],
 ```
 
-**In the `update_dashboard` function body, add insight card generation at the TOP of the function, right after the `days` and `current_time` setup (after line 538):**
+**In the `update_dashboard` function body, add insight card generation after `current_time`:**
 
 After:
 ```python
@@ -850,16 +801,13 @@ Add:
             insight_cards = html.Div()  # Silent failure -- insights are not critical
 ```
 
-**Update the return statement (existing line ~884):**
+**Update the return statement (3→4 values):**
 
 **Existing:**
 ```python
         return (
-            feed_cards,
+            screener_table,
             metrics_row,
-            acc_fig,
-            conf_fig,
-            asset_fig,
             current_time,
         )
 ```
@@ -868,11 +816,8 @@ Add:
 ```python
         return (
             insight_cards,
-            feed_cards,
+            screener_table,
             metrics_row,
-            acc_fig,
-            conf_fig,
-            asset_fig,
             current_time,
         )
 ```
@@ -1079,7 +1024,7 @@ Run the full dashboard test suite to ensure no regressions:
 source venv/bin/activate && pytest shit_tests/shitty_ui/ -v
 ```
 
-The callback output count change (6 -> 7 outputs) will break existing callback tests that mock the `update_dashboard` return value. These tests need the return tuple updated to include the `insight_cards` element as the first item.
+The callback output count change (3 -> 4 outputs) may affect existing callback tests that mock the `update_dashboard` return value. These tests need the return tuple updated to include the `insight_cards` element as the first item.
 
 ### Manual Verification Steps
 
@@ -1129,7 +1074,7 @@ The callback output count change (6 -> 7 outputs) will break existing callback t
 - [ ] `shitty_ui/components/insights.py` exists with `create_insight_cards()` and `_create_single_insight_card()`
 - [ ] `shitty_ui/pages/dashboard.py` imports `create_insight_cards` and `get_dynamic_insights`
 - [ ] `create_dashboard_page()` includes `insight-cards-container` div above `performance-metrics`
-- [ ] `update_dashboard` callback has 7 outputs (insight cards + original 6)
+- [ ] `update_dashboard` callback has 4 outputs (insight cards + original 3)
 - [ ] `update_dashboard` return tuple starts with `insight_cards`
 - [ ] `pytest shit_tests/shitty_ui/ -v` passes (including new insight tests)
 - [ ] `ruff check shitty_ui/components/insights.py` passes

--- a/documentation/planning/phases/dashboard-rethink_2026-02-22/06_actionable-insight-cards.md
+++ b/documentation/planning/phases/dashboard-rethink_2026-02-22/06_actionable-insight-cards.md
@@ -3,6 +3,7 @@
 **Status:** ✅ COMPLETE
 **Started:** 2026-02-23
 **Completed:** 2026-02-23
+**PR:** #87
 
 **PR Title:** feat(dashboard): dynamic insight cards that answer "so what right now?"
 

--- a/shit_tests/shitty_ui/test_copy.py
+++ b/shit_tests/shitty_ui/test_copy.py
@@ -50,20 +50,14 @@ class TestCopyDictStructure:
             "chart_empty_confidence_hint",
             "chart_empty_asset",
             "chart_empty_asset_hint",
-            # Signals page
-            "signals_page_title",
-            "signals_page_subtitle",
-            "signals_empty_filters",
-            "signals_error",
-            "signals_load_more",
-            "signals_export",
-            # Trends page
-            "trends_page_title",
-            "trends_page_subtitle",
-            "trends_chart_default",
-            "trends_no_asset_data",
-            "trends_no_asset_hint",
-            "trends_no_signals_for_asset",
+            # Insight cards
+            "insight_latest_call_label",
+            "insight_best_worst_label",
+            "insight_system_pulse_label",
+            "insight_hot_asset_label",
+            "insight_hot_signal_label",
+            "insight_empty",
+            "insight_section_aria",
             # Assets page
             "asset_page_subtitle",
             "asset_no_predictions",
@@ -72,17 +66,6 @@ class TestCopyDictStructure:
             "asset_performance_header",
             "asset_related_header",
             "asset_timeline_header",
-            # Performance page
-            "backtest_title",
-            "backtest_subtitle",
-            "perf_confidence_header",
-            "perf_sentiment_header",
-            "perf_asset_header",
-            "perf_empty_confidence",
-            "perf_empty_confidence_hint",
-            "perf_empty_sentiment",
-            "perf_empty_sentiment_hint",
-            "perf_empty_asset_table",
             # Cards
             "card_pending_analysis",
             "card_bypassed",
@@ -105,7 +88,6 @@ class TestCopyDictStructure:
 
     def test_format_placeholders_are_valid(self):
         format_keys = [
-            "trends_no_signals_for_asset",
             "asset_page_subtitle",
             "asset_no_predictions",
             "asset_timeline_header",
@@ -141,7 +123,11 @@ class TestCopyToneGuard:
             assert "???" not in value, f"COPY['{key}'] contains '???' -- too try-hard"
 
     def test_no_all_caps_words(self):
-        allowed_caps = {"AI", "LLM", "P&L", "CSV", "ACTIVE", "SIGNALS", "NOT", "THAT"}
+        allowed_caps = {
+            "AI", "LLM", "P&L", "CSV", "ACTIVE", "SIGNALS", "NOT", "THAT",
+            "LATEST", "CALL", "BEST", "WORST", "SYSTEM", "PULSE",
+            "ASSET", "HIGH-CONFIDENCE", "SIGNAL",
+        }
         for key, value in COPY.items():
             words = value.split()
             for word in words:

--- a/shit_tests/shitty_ui/test_copy.py
+++ b/shit_tests/shitty_ui/test_copy.py
@@ -79,7 +79,9 @@ class TestCopyDictStructure:
 
     def test_all_values_are_strings(self):
         for key, value in COPY.items():
-            assert isinstance(value, str), f"COPY['{key}'] should be str, got {type(value)}"
+            assert isinstance(value, str), (
+                f"COPY['{key}'] should be str, got {type(value)}"
+            )
             assert len(value) > 0, f"COPY['{key}'] should not be empty"
 
     def test_no_double_spaces(self):
@@ -94,7 +96,9 @@ class TestCopyDictStructure:
         ]
         for key in format_keys:
             result = COPY[key].format(symbol="AAPL")
-            assert "AAPL" in result, f"COPY['{key}'].format(symbol='AAPL') should contain 'AAPL'"
+            assert "AAPL" in result, (
+                f"COPY['{key}'].format(symbol='AAPL') should contain 'AAPL'"
+            )
 
 
 class TestCopyToneGuard:
@@ -124,9 +128,23 @@ class TestCopyToneGuard:
 
     def test_no_all_caps_words(self):
         allowed_caps = {
-            "AI", "LLM", "P&L", "CSV", "ACTIVE", "SIGNALS", "NOT", "THAT",
-            "LATEST", "CALL", "BEST", "WORST", "SYSTEM", "PULSE",
-            "ASSET", "HIGH-CONFIDENCE", "SIGNAL",
+            "AI",
+            "LLM",
+            "P&L",
+            "CSV",
+            "ACTIVE",
+            "SIGNALS",
+            "NOT",
+            "THAT",
+            "LATEST",
+            "CALL",
+            "BEST",
+            "WORST",
+            "SYSTEM",
+            "PULSE",
+            "ASSET",
+            "HIGH-CONFIDENCE",
+            "SIGNAL",
         }
         for key, value in COPY.items():
             words = value.split()

--- a/shit_tests/shitty_ui/test_insights.py
+++ b/shit_tests/shitty_ui/test_insights.py
@@ -186,9 +186,7 @@ class TestGetDynamicInsights:
         result = get_dynamic_insights(days=30)
         required_keys = {"type", "headline", "body", "assets", "sentiment", "priority"}
         for insight in result:
-            assert required_keys.issubset(
-                insight.keys()
-            ), f"Missing keys in {insight}"
+            assert required_keys.issubset(insight.keys()), f"Missing keys in {insight}"
 
     def test_insight_survives_db_error_gracefully(self):
         """If all queries fail, should return empty list without raising."""

--- a/shit_tests/shitty_ui/test_insights.py
+++ b/shit_tests/shitty_ui/test_insights.py
@@ -1,0 +1,440 @@
+"""Tests for dynamic insight cards component and data function."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+
+class TestGetDynamicInsights:
+    """Tests for data.get_dynamic_insights()."""
+
+    @patch("data.execute_query")
+    def test_returns_empty_list_when_no_data(self, mock_query):
+        """Should return [] when all queries return empty results."""
+        mock_query.return_value = ([], [])
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=7)
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @patch("data.execute_query")
+    def test_returns_latest_call_insight(self, mock_query):
+        """Should include a latest_call insight when recent outcomes exist."""
+        mock_query.side_effect = [
+            # latest_call
+            (
+                [
+                    (
+                        "AAPL",
+                        "bullish",
+                        5.04,
+                        True,
+                        50.40,
+                        datetime.now().date(),
+                        0.8,
+                        datetime.now() - timedelta(hours=6),
+                    )
+                ],
+                [
+                    "symbol",
+                    "sentiment",
+                    "return_t7",
+                    "correct_t7",
+                    "pnl_t7",
+                    "prediction_date",
+                    "confidence",
+                    "post_timestamp",
+                ],
+            ),
+            # best_worst
+            ([], []),
+            # system_pulse
+            ([], []),
+            # hot_asset
+            ([], []),
+            # hot_signal
+            ([], []),
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=7)
+        latest = [i for i in result if i["type"] == "latest_call"]
+        assert len(latest) == 1
+        assert "AAPL" in latest[0]["assets"]
+        assert latest[0]["sentiment"] == "positive"
+
+    @patch("data.execute_query")
+    def test_latest_call_negative_sentiment(self, mock_query):
+        """Should mark incorrect prediction as negative sentiment."""
+        mock_query.side_effect = [
+            (
+                [
+                    (
+                        "TSLA",
+                        "bullish",
+                        -3.5,
+                        False,
+                        -35.0,
+                        datetime.now().date(),
+                        0.7,
+                        datetime.now() - timedelta(hours=2),
+                    )
+                ],
+                [
+                    "symbol",
+                    "sentiment",
+                    "return_t7",
+                    "correct_t7",
+                    "pnl_t7",
+                    "prediction_date",
+                    "confidence",
+                    "post_timestamp",
+                ],
+            ),
+            ([], []),
+            ([], []),
+            ([], []),
+            ([], []),
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=7)
+        latest = [i for i in result if i["type"] == "latest_call"]
+        assert len(latest) == 1
+        assert latest[0]["sentiment"] == "negative"
+        assert "Ouch" in latest[0]["body"]
+
+    @patch("data.execute_query")
+    def test_system_pulse_requires_minimum_predictions(self, mock_query):
+        """System pulse insight should not appear with fewer than 5 predictions."""
+        mock_query.side_effect = [
+            ([], []),  # latest_call
+            ([], []),  # best_worst
+            ([(3, 2)], ["total", "correct"]),  # system_pulse -- only 3 predictions
+            ([], []),  # hot_asset
+            ([], []),  # hot_signal
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=30)
+        pulse = [i for i in result if i["type"] == "system_pulse"]
+        assert len(pulse) == 0
+
+    @patch("data.execute_query")
+    def test_system_pulse_appears_with_enough_predictions(self, mock_query):
+        """System pulse should appear when at least 5 predictions exist."""
+        mock_query.side_effect = [
+            ([], []),  # latest_call
+            ([], []),  # best_worst
+            ([(10, 6)], ["total", "correct"]),  # system_pulse -- 10 predictions
+            ([], []),  # hot_asset
+            ([], []),  # hot_signal
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=30)
+        pulse = [i for i in result if i["type"] == "system_pulse"]
+        assert len(pulse) == 1
+        assert "60%" in pulse[0]["headline"]
+
+    @patch("data.execute_query")
+    def test_each_insight_has_required_keys(self, mock_query):
+        """Every insight dict must have type, headline, body, assets, sentiment, priority."""
+        mock_query.side_effect = [
+            (
+                [
+                    (
+                        "XOM",
+                        "bullish",
+                        3.2,
+                        True,
+                        32.0,
+                        datetime.now().date(),
+                        0.82,
+                        datetime.now(),
+                    )
+                ],
+                [
+                    "symbol",
+                    "sentiment",
+                    "return_t7",
+                    "correct_t7",
+                    "pnl_t7",
+                    "prediction_date",
+                    "confidence",
+                    "post_timestamp",
+                ],
+            ),
+            ([], []),
+            ([(10, 6)], ["total", "correct"]),
+            ([], []),
+            ([], []),
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=30)
+        required_keys = {"type", "headline", "body", "assets", "sentiment", "priority"}
+        for insight in result:
+            assert required_keys.issubset(
+                insight.keys()
+            ), f"Missing keys in {insight}"
+
+    def test_insight_survives_db_error_gracefully(self):
+        """If all queries fail, should return empty list without raising."""
+        with patch("data.execute_query") as mock_query:
+            mock_query.side_effect = Exception("connection lost")
+            from data import get_dynamic_insights
+
+            get_dynamic_insights.clear_cache()
+            result = get_dynamic_insights(days=7)
+            assert isinstance(result, list)
+
+    @patch("data.execute_query")
+    def test_best_worst_insight(self, mock_query):
+        """Should generate best/worst insight when both rows exist."""
+        mock_query.side_effect = [
+            ([], []),  # latest_call
+            (
+                [
+                    ("XOM", 5.04, True, datetime.now().date(), "best"),
+                    ("AMZN", -2.06, False, datetime.now().date(), "worst"),
+                ],
+                ["symbol", "return_t7", "correct_t7", "prediction_date", "rank_type"],
+            ),  # best_worst
+            ([], []),  # system_pulse
+            ([], []),  # hot_asset
+            ([], []),  # hot_signal
+        ]
+        from data import get_dynamic_insights
+
+        get_dynamic_insights.clear_cache()
+        result = get_dynamic_insights(days=7)
+        bw = [i for i in result if i["type"] == "best_worst"]
+        assert len(bw) == 1
+        assert "XOM" in bw[0]["assets"]
+        assert "AMZN" in bw[0]["assets"]
+
+
+class TestCreateInsightCards:
+    """Tests for components.insights.create_insight_cards()."""
+
+    def test_empty_insights_returns_empty_state(self):
+        """Should show empty state message when no insights available."""
+        from components.insights import create_insight_cards
+
+        result = create_insight_cards([])
+        assert result is not None
+        # Should contain the empty message (a P element)
+        assert hasattr(result, "children")
+
+    def test_renders_correct_number_of_cards(self):
+        """Should render at most max_cards cards."""
+        from components.insights import create_insight_cards
+
+        insights = [
+            {
+                "type": "latest_call",
+                "headline": "Test 1",
+                "body": "Body 1",
+                "assets": ["AAPL"],
+                "sentiment": "positive",
+                "timestamp": None,
+                "priority": 1,
+            },
+            {
+                "type": "best_worst",
+                "headline": "Test 2",
+                "body": "Body 2",
+                "assets": ["XOM"],
+                "sentiment": "neutral",
+                "timestamp": None,
+                "priority": 2,
+            },
+            {
+                "type": "system_pulse",
+                "headline": "Test 3",
+                "body": "Body 3",
+                "assets": [],
+                "sentiment": "neutral",
+                "timestamp": None,
+                "priority": 3,
+            },
+            {
+                "type": "hot_asset",
+                "headline": "Test 4",
+                "body": "Body 4",
+                "assets": ["LMT"],
+                "sentiment": "positive",
+                "timestamp": None,
+                "priority": 4,
+            },
+        ]
+        result = create_insight_cards(insights, max_cards=2)
+        card_children = [
+            c
+            for c in result.children
+            if hasattr(c, "className") and c.className == "insight-card"
+        ]
+        assert len(card_children) == 2
+
+    def test_sorts_by_priority(self):
+        """Lower priority number should appear first."""
+        from components.insights import create_insight_cards
+
+        insights = [
+            {
+                "type": "hot_asset",
+                "headline": "Low priority",
+                "body": "",
+                "assets": [],
+                "sentiment": "neutral",
+                "timestamp": None,
+                "priority": 5,
+            },
+            {
+                "type": "latest_call",
+                "headline": "High priority",
+                "body": "",
+                "assets": [],
+                "sentiment": "positive",
+                "timestamp": None,
+                "priority": 1,
+            },
+        ]
+        result = create_insight_cards(insights, max_cards=2)
+        cards = [
+            c
+            for c in result.children
+            if hasattr(c, "className") and c.className == "insight-card"
+        ]
+        # First card's headline (second child, index 1) should be "High priority"
+        first_card_headline = cards[0].children[1].children
+        assert "High priority" in str(first_card_headline)
+
+    def test_asset_links_are_dcc_links(self):
+        """Asset symbols should render as clickable dcc.Link elements."""
+        from components.insights import _create_single_insight_card
+
+        insight = {
+            "type": "latest_call",
+            "headline": "Test",
+            "body": "Body",
+            "assets": ["AAPL", "TSLA"],
+            "sentiment": "positive",
+            "timestamp": None,
+            "priority": 1,
+        }
+        card = _create_single_insight_card(insight)
+        # Find the asset links div (last non-None child)
+        link_divs = [c for c in card.children if c is not None]
+        last_child = link_divs[-1]
+        links = [c for c in last_child.children if hasattr(c, "href")]
+        assert len(links) == 2
+        assert links[0].href == "/assets/AAPL"
+        assert links[1].href == "/assets/TSLA"
+
+    def test_container_has_aria_label(self):
+        """Insight cards container should have an aria-label for accessibility."""
+        from components.insights import create_insight_cards
+
+        insights = [
+            {
+                "type": "system_pulse",
+                "headline": "Test",
+                "body": "Body",
+                "assets": [],
+                "sentiment": "neutral",
+                "timestamp": None,
+                "priority": 1,
+            },
+        ]
+        result = create_insight_cards(insights)
+        assert result.role == "region"
+
+    def test_positive_sentiment_gets_success_border(self):
+        """Positive sentiment should use the success color for the left border."""
+        from components.insights import _create_single_insight_card
+        from constants import COLORS
+
+        insight = {
+            "type": "latest_call",
+            "headline": "Test",
+            "body": "Body",
+            "assets": [],
+            "sentiment": "positive",
+            "timestamp": None,
+            "priority": 1,
+        }
+        card = _create_single_insight_card(insight)
+        assert COLORS["success"] in card.style["borderLeft"]
+
+    def test_negative_sentiment_gets_danger_border(self):
+        """Negative sentiment should use the danger color for the left border."""
+        from components.insights import _create_single_insight_card
+        from constants import COLORS
+
+        insight = {
+            "type": "latest_call",
+            "headline": "Test",
+            "body": "Body",
+            "assets": [],
+            "sentiment": "negative",
+            "timestamp": None,
+            "priority": 1,
+        }
+        card = _create_single_insight_card(insight)
+        assert COLORS["danger"] in card.style["borderLeft"]
+
+
+class TestFormatInsightTimestamp:
+    """Tests for _format_insight_timestamp()."""
+
+    def test_none_returns_empty_string(self):
+        from components.insights import _format_insight_timestamp
+
+        assert _format_insight_timestamp(None) == ""
+
+    def test_recent_datetime_returns_relative(self):
+        from components.insights import _format_insight_timestamp
+
+        ts = datetime.now() - timedelta(hours=3)
+        result = _format_insight_timestamp(ts)
+        assert "3h ago" == result
+
+    def test_days_ago(self):
+        from components.insights import _format_insight_timestamp
+
+        ts = datetime.now() - timedelta(days=2)
+        result = _format_insight_timestamp(ts)
+        assert "2d ago" == result
+
+    def test_weeks_ago(self):
+        from components.insights import _format_insight_timestamp
+
+        ts = datetime.now() - timedelta(days=15)
+        result = _format_insight_timestamp(ts)
+        assert "2w ago" == result
+
+    def test_just_now(self):
+        from components.insights import _format_insight_timestamp
+
+        ts = datetime.now() - timedelta(seconds=10)
+        result = _format_insight_timestamp(ts)
+        assert result == "just now"
+
+    def test_non_datetime_returns_truncated_string(self):
+        from components.insights import _format_insight_timestamp
+
+        result = _format_insight_timestamp("2026-02-23 12:00:00")
+        assert result == "2026-02-23"

--- a/shitty_ui/brand_copy.py
+++ b/shitty_ui/brand_copy.py
@@ -19,7 +19,6 @@ COPY = {
         "Please do not bet your rent money on this."
     ),
     "footer_source_link": "View Source (yes, this is real and it's spectacular)",
-
     # ===== Dashboard: KPI Section =====
     "kpi_total_signals_title": "Total Signals",
     "kpi_total_signals_subtitle": "predictions we actually checked",
@@ -29,25 +28,20 @@ COPY = {
     "kpi_avg_return_subtitle": "mean return per signal (not great, not terrible)",
     "kpi_pnl_title": "Total P&L",
     "kpi_pnl_subtitle": "simulated $1k trades (Monopoly money, for now)",
-
     # ===== Dashboard: Analytics Section =====
     "analytics_header": "Show Me The Money",
     "tab_accuracy": "Accuracy Over Time",
     "tab_confidence": "By Confidence Level",
     "tab_asset": "By Asset (click to drill down)",
-
     # ===== Dashboard: Posts + Feed Columns =====
     "latest_posts_header": "Latest Shitposts",
     "latest_posts_subtitle": "fresh off Truth Social, with our AI's hot take on your portfolio",
-
     # ===== Dashboard: Data Table =====
     "data_table_header": "Full Prediction Ledger",
-
     # ===== Dashboard: Empty States =====
     "empty_feed_period": "No predictions for this period. The money printer is paused.",
     "empty_posts": "No posts to show. Even shitposters sleep sometimes.",
     "empty_predictions_table": "No predictions match these filters. We're not THAT prolific.",
-
     # ===== Dashboard: Insight Cards =====
     "insight_latest_call_label": "LATEST CALL",
     "insight_best_worst_label": "BEST & WORST",
@@ -56,7 +50,6 @@ COPY = {
     "insight_hot_signal_label": "HIGH-CONFIDENCE SIGNAL",
     "insight_empty": "Nothing interesting to report. Check back in 5 minutes.",
     "insight_section_aria": "Dynamic insight cards summarizing recent prediction performance",
-
     # ===== Dashboard: Chart Empty States =====
     "chart_empty_accuracy": "Not enough data to chart accuracy yet",
     "chart_empty_accuracy_hint": "Predictions need 7+ trading days to mature. Patience, money isn't made overnight.",
@@ -64,7 +57,6 @@ COPY = {
     "chart_empty_confidence_hint": "Takes 7+ days per prediction. We'll get there.",
     "chart_empty_asset": "No asset performance data yet",
     "chart_empty_asset_hint": "Asset accuracy appears after the market proves us wrong (or makes us rich)",
-
     # ===== Assets Page =====
     "asset_page_subtitle": "The Full Damage Report for {symbol}",
     "asset_no_predictions": "No predictions found for {symbol}. We kept our mouth shut for once.",
@@ -73,12 +65,10 @@ COPY = {
     "asset_performance_header": "Performance Summary",
     "asset_related_header": "Related Assets",
     "asset_timeline_header": "Prediction Timeline for {symbol}",
-
     # ===== Cards: Analysis Status Labels =====
     "card_pending_analysis": "Pending Analysis",
     "card_bypassed": "Bypassed",
     "card_error_title": "Error Loading Data",
-
     # ===== Refresh Indicator =====
     "refresh_last_updated": "Last updated ",
     "refresh_next": "Next refresh ",

--- a/shitty_ui/brand_copy.py
+++ b/shitty_ui/brand_copy.py
@@ -48,6 +48,15 @@ COPY = {
     "empty_posts": "No posts to show. Even shitposters sleep sometimes.",
     "empty_predictions_table": "No predictions match these filters. We're not THAT prolific.",
 
+    # ===== Dashboard: Insight Cards =====
+    "insight_latest_call_label": "LATEST CALL",
+    "insight_best_worst_label": "BEST & WORST",
+    "insight_system_pulse_label": "SYSTEM PULSE",
+    "insight_hot_asset_label": "HOT ASSET",
+    "insight_hot_signal_label": "HIGH-CONFIDENCE SIGNAL",
+    "insight_empty": "Nothing interesting to report. Check back in 5 minutes.",
+    "insight_section_aria": "Dynamic insight cards summarizing recent prediction performance",
+
     # ===== Dashboard: Chart Empty States =====
     "chart_empty_accuracy": "Not enough data to chart accuracy yet",
     "chart_empty_accuracy_hint": "Predictions need 7+ trading days to mature. Patience, money isn't made overnight.",
@@ -55,25 +64,6 @@ COPY = {
     "chart_empty_confidence_hint": "Takes 7+ days per prediction. We'll get there.",
     "chart_empty_asset": "No asset performance data yet",
     "chart_empty_asset_hint": "Asset accuracy appears after the market proves us wrong (or makes us rich)",
-
-    # ===== Signals Page =====
-    "signals_page_title": "Signal Feed",
-    "signals_page_subtitle": "Every prediction, including the ones we wish we could delete",
-    "signals_empty_filters": "No signals match your filters. Maybe lower your standards?",
-    "signals_error": "Failed to load signals. The irony of our own system failing is not lost on us.",
-    "signals_load_more": "Load More Signals",
-    "signals_export": "Export CSV",
-
-    # ===== Trends Page =====
-    "trends_page_title": "Signal Over Trend",
-    "trends_page_subtitle": "Our predictions vs. what the market actually did (spoiler: the market usually wins)",
-    "trends_chart_default": "Pick an asset to see how wrong we are",
-    "trends_no_asset_data": "No Asset Data Available",
-    "trends_no_asset_hint": (
-        "Predictions need to be analyzed and validated before "
-        "we can show you how wrong we were. Check back later."
-    ),
-    "trends_no_signals_for_asset": "No prediction signals for {symbol} in this period. We had nothing to say.",
 
     # ===== Assets Page =====
     "asset_page_subtitle": "The Full Damage Report for {symbol}",
@@ -83,21 +73,6 @@ COPY = {
     "asset_performance_header": "Performance Summary",
     "asset_related_header": "Related Assets",
     "asset_timeline_header": "Prediction Timeline for {symbol}",
-
-    # ===== Performance Page =====
-    "backtest_title": "Backtest Results",
-    "backtest_subtitle": (
-        "Simulated P&L following high-confidence signals with $10,000 of American dream money. "
-        "In hindsight, everything is obvious."
-    ),
-    "perf_confidence_header": "Accuracy by Confidence Level",
-    "perf_sentiment_header": "Sentiment Breakdown",
-    "perf_asset_header": "Performance by Asset",
-    "perf_empty_confidence": "No confidence breakdown yet",
-    "perf_empty_confidence_hint": "We need more predictions to evaluate. Patience is a virtue we can't afford.",
-    "perf_empty_sentiment": "No sentiment breakdown yet",
-    "perf_empty_sentiment_hint": "We need evaluated predictions to know if our vibes were right.",
-    "perf_empty_asset_table": "No asset data yet. The market hasn't had time to take our money.",
 
     # ===== Cards: Analysis Status Labels =====
     "card_pending_analysis": "Pending Analysis",

--- a/shitty_ui/components/insights.py
+++ b/shitty_ui/components/insights.py
@@ -1,0 +1,241 @@
+"""Dynamic insight cards for the dashboard.
+
+Generates 2-3 time-aware, context-rich callout cards that answer
+"why should I care RIGHT NOW?" -- placed above the screener table.
+
+Each insight is a structured dict produced by data.get_dynamic_insights(),
+rendered here into Dash HTML components with personality-driven copy,
+asset links, and color-coded sentiment borders.
+"""
+
+from datetime import datetime
+from typing import List, Dict, Any
+
+from dash import html, dcc
+
+from constants import COLORS
+from brand_copy import COPY
+
+
+# Map insight type -> COPY key for the category label
+_LABEL_MAP = {
+    "latest_call": "insight_latest_call_label",
+    "best_worst": "insight_best_worst_label",
+    "system_pulse": "insight_system_pulse_label",
+    "hot_asset": "insight_hot_asset_label",
+    "hot_signal": "insight_hot_signal_label",
+}
+
+# Map insight sentiment -> left border color
+_BORDER_COLOR_MAP = {
+    "positive": COLORS["success"],
+    "negative": COLORS["danger"],
+    "neutral": COLORS["text_muted"],
+}
+
+
+def _format_insight_timestamp(ts) -> str:
+    """Format a timestamp into a human-readable relative string.
+
+    Args:
+        ts: datetime object or None.
+
+    Returns:
+        String like "2d ago", "5h ago", or "" if None.
+    """
+    if ts is None:
+        return ""
+    if not isinstance(ts, datetime):
+        return str(ts)[:10]
+
+    delta = datetime.now() - ts
+    if delta.days > 7:
+        return f"{delta.days // 7}w ago"
+    elif delta.days > 0:
+        return f"{delta.days}d ago"
+    elif delta.seconds >= 3600:
+        return f"{delta.seconds // 3600}h ago"
+    elif delta.seconds >= 60:
+        return f"{delta.seconds // 60}m ago"
+    else:
+        return "just now"
+
+
+def _create_single_insight_card(insight: Dict[str, Any]) -> html.Div:
+    """Render a single insight dict into a Dash html.Div card.
+
+    Args:
+        insight: Dict with keys: type, headline, body, assets, sentiment,
+                 timestamp, priority.
+
+    Returns:
+        html.Div containing the rendered insight card.
+    """
+    insight_type = insight.get("type", "system_pulse")
+    headline = insight.get("headline", "")
+    body = insight.get("body", "")
+    assets = insight.get("assets", [])
+    sentiment = insight.get("sentiment", "neutral")
+    timestamp = insight.get("timestamp")
+
+    # Category label
+    label_key = _LABEL_MAP.get(insight_type, "insight_system_pulse_label")
+    category_label = COPY.get(label_key, insight_type.upper().replace("_", " "))
+
+    # Left border color
+    border_color = _BORDER_COLOR_MAP.get(sentiment, COLORS["text_muted"])
+
+    # Timestamp display
+    time_str = _format_insight_timestamp(timestamp)
+
+    # Build asset links
+    asset_links = []
+    for symbol in assets[:3]:  # Max 3 links per card
+        asset_links.append(
+            dcc.Link(
+                symbol,
+                href=f"/assets/{symbol}",
+                style={
+                    "color": COLORS["accent"],
+                    "fontSize": "0.8rem",
+                    "fontWeight": "600",
+                    "textDecoration": "none",
+                    "marginRight": "12px",
+                },
+            )
+        )
+
+    # Card children
+    children = [
+        # Category label row
+        html.Div(
+            [
+                html.Span(
+                    category_label,
+                    style={
+                        "fontSize": "0.7rem",
+                        "fontWeight": "600",
+                        "textTransform": "uppercase",
+                        "letterSpacing": "0.05em",
+                        "color": COLORS["text_muted"],
+                    },
+                ),
+                html.Span(
+                    time_str,
+                    style={
+                        "fontSize": "0.75rem",
+                        "color": COLORS["text_muted"],
+                    },
+                ) if time_str else None,
+            ],
+            style={
+                "display": "flex",
+                "justifyContent": "space-between",
+                "alignItems": "center",
+                "marginBottom": "8px",
+            },
+        ),
+        # Headline
+        html.Div(
+            headline,
+            style={
+                "fontSize": "0.95rem",
+                "fontWeight": "600",
+                "color": COLORS["text"],
+                "lineHeight": "1.4",
+                "marginBottom": "6px",
+            },
+        ),
+        # Body / commentary
+        html.Div(
+            body,
+            style={
+                "fontSize": "0.85rem",
+                "color": COLORS["text_muted"],
+                "lineHeight": "1.4",
+                "marginBottom": "8px",
+            },
+        ) if body else None,
+        # Asset links row
+        html.Div(
+            asset_links,
+            style={
+                "display": "flex",
+                "alignItems": "center",
+                "flexWrap": "wrap",
+                "gap": "4px",
+            },
+        ) if asset_links else None,
+    ]
+
+    # Filter out None children
+    children = [c for c in children if c is not None]
+
+    return html.Div(
+        children,
+        className="insight-card",
+        style={
+            "padding": "16px",
+            "backgroundColor": COLORS["secondary"],
+            "border": f"1px solid {COLORS['border']}",
+            "borderLeft": f"3px solid {border_color}",
+            "borderRadius": "8px",
+            "flex": "1 1 0",
+            "minWidth": "280px",
+        },
+    )
+
+
+def create_insight_cards(insights: List[Dict[str, Any]], max_cards: int = 3) -> html.Div:
+    """Create the insight cards container from a pool of insight dicts.
+
+    Sorts insights by priority (lower = more important), then picks
+    the top `max_cards` insights. If no insights are available, returns
+    an empty-state message.
+
+    Args:
+        insights: List of insight dicts from get_dynamic_insights().
+        max_cards: Maximum number of cards to display (default 3).
+
+    Returns:
+        html.Div containing the insight card row, or empty state.
+    """
+    if not insights:
+        return html.Div(
+            html.P(
+                COPY["insight_empty"],
+                style={
+                    "color": COLORS["text_muted"],
+                    "fontSize": "0.85rem",
+                    "textAlign": "center",
+                    "padding": "16px",
+                },
+            ),
+            style={"marginBottom": "24px"},
+        )
+
+    # Sort by priority (lower = more important), then by timestamp (newer first)
+    def sort_key(ins):
+        priority = ins.get("priority", 99)
+        ts = ins.get("timestamp")
+        # Newer timestamps should sort first (higher epoch = lower sort value)
+        ts_epoch = -ts.timestamp() if isinstance(ts, datetime) else 0
+        return (priority, ts_epoch)
+
+    sorted_insights = sorted(insights, key=sort_key)
+    selected = sorted_insights[:max_cards]
+
+    cards = [_create_single_insight_card(ins) for ins in selected]
+
+    return html.Div(
+        cards,
+        role="region",
+        **{"aria-label": COPY["insight_section_aria"]},
+        className="insight-cards-container",
+        style={
+            "display": "flex",
+            "flexWrap": "wrap",
+            "gap": "16px",
+            "marginBottom": "24px",
+        },
+    )

--- a/shitty_ui/components/insights.py
+++ b/shitty_ui/components/insights.py
@@ -126,7 +126,9 @@ def _create_single_insight_card(insight: Dict[str, Any]) -> html.Div:
                         "fontSize": "0.75rem",
                         "color": COLORS["text_muted"],
                     },
-                ) if time_str else None,
+                )
+                if time_str
+                else None,
             ],
             style={
                 "display": "flex",
@@ -155,7 +157,9 @@ def _create_single_insight_card(insight: Dict[str, Any]) -> html.Div:
                 "lineHeight": "1.4",
                 "marginBottom": "8px",
             },
-        ) if body else None,
+        )
+        if body
+        else None,
         # Asset links row
         html.Div(
             asset_links,
@@ -165,7 +169,9 @@ def _create_single_insight_card(insight: Dict[str, Any]) -> html.Div:
                 "flexWrap": "wrap",
                 "gap": "4px",
             },
-        ) if asset_links else None,
+        )
+        if asset_links
+        else None,
     ]
 
     # Filter out None children
@@ -186,7 +192,9 @@ def _create_single_insight_card(insight: Dict[str, Any]) -> html.Div:
     )
 
 
-def create_insight_cards(insights: List[Dict[str, Any]], max_cards: int = 3) -> html.Div:
+def create_insight_cards(
+    insights: List[Dict[str, Any]], max_cards: int = 3
+) -> html.Div:
     """Create the insight cards container from a pool of insight dicts.
 
     Sorts insights by priority (lower = more important), then picks

--- a/shitty_ui/data.py
+++ b/shitty_ui/data.py
@@ -1258,6 +1258,7 @@ def clear_all_caches() -> None:
     get_dashboard_kpis.clear_cache()  # type: ignore
     get_top_predicted_asset.clear_cache()  # type: ignore
     get_empty_state_context.clear_cache()  # type: ignore
+    get_dynamic_insights.clear_cache()  # type: ignore
 
 
 # =============================================================================
@@ -2557,3 +2558,282 @@ def get_multi_asset_signals(
     except Exception as e:
         logger.error(f"Error loading multi-asset signals: {e}")
         return pd.DataFrame()
+
+
+# =============================================================================
+# Dynamic Insight Cards
+# =============================================================================
+
+
+@ttl_cache(ttl_seconds=300)
+def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
+    """Generate a pool of dynamic insight candidates for the dashboard.
+
+    Queries for multiple insight types and returns them as structured dicts.
+    The UI layer picks the top 2-3 most interesting/recent from this pool.
+
+    Each insight dict has:
+        type: str -- "latest_call", "best_worst", "system_pulse", "hot_asset", "hot_signal"
+        headline: str -- Primary text (personality-driven)
+        body: str -- Secondary commentary
+        assets: List[str] -- Tickers mentioned (for linking)
+        sentiment: str -- "positive", "negative", "neutral" (for border color)
+        timestamp: datetime or None -- When this insight became relevant
+        priority: int -- Lower = more important (for ranking)
+
+    Args:
+        days: Number of days to look back (None = all time).
+
+    Returns:
+        List of insight dicts, unranked (caller sorts by priority + recency).
+        Returns empty list if no data available.
+    """
+    insights: List[Dict[str, Any]] = []
+
+    date_filter = ""
+    params: Dict[str, Any] = {}
+    if days is not None:
+        date_filter = "AND po.prediction_date >= :start_date"
+        params["start_date"] = (datetime.now() - timedelta(days=days)).date()
+
+    # ---- Insight 1: Most recent prediction with an outcome ----
+    try:
+        latest_query = text(f"""
+            SELECT
+                po.symbol,
+                po.prediction_sentiment,
+                po.return_t7,
+                po.correct_t7,
+                po.pnl_t7,
+                po.prediction_date,
+                po.prediction_confidence,
+                tss.timestamp AS post_timestamp
+            FROM prediction_outcomes po
+            INNER JOIN predictions p ON po.prediction_id = p.id
+            INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
+            WHERE po.correct_t7 IS NOT NULL
+                {date_filter}
+            ORDER BY po.prediction_date DESC
+            LIMIT 1
+        """)
+        rows, columns = execute_query(latest_query, params)
+        if rows and rows[0]:
+            r = rows[0]
+            symbol = r[0]
+            return_t7 = float(r[2]) if r[2] is not None else None
+            correct = r[3]
+            post_ts = r[7]
+
+            if return_t7 is not None:
+                ret_str = f"{return_t7:+.2f}%"
+                if correct:
+                    headline = f"Trump mentioned {symbol} -- it's {ret_str} in 7 days."
+                    body = "Cha-ching." if return_t7 > 2 else "Not bad."
+                    ins_sentiment = "positive"
+                else:
+                    headline = f"Trump mentioned {symbol} -- it went {ret_str} in 7 days."
+                    body = "Ouch." if return_t7 < -2 else "Close, but no cigar."
+                    ins_sentiment = "negative"
+
+                insights.append({
+                    "type": "latest_call",
+                    "headline": headline,
+                    "body": body,
+                    "assets": [symbol],
+                    "sentiment": ins_sentiment,
+                    "timestamp": post_ts,
+                    "priority": 1,
+                })
+    except Exception as e:
+        logger.error(f"Error generating latest_call insight: {e}")
+
+    # ---- Insight 2: Best and worst performing prediction in period ----
+    try:
+        date_filter_bare = ""
+        if days is not None:
+            date_filter_bare = "AND prediction_date >= :start_date"
+
+        best_worst_query = text(f"""
+            (
+                SELECT symbol, return_t7, correct_t7, prediction_date, 'best' AS rank_type
+                FROM prediction_outcomes
+                WHERE correct_t7 IS NOT NULL AND return_t7 IS NOT NULL
+                    {date_filter_bare}
+                ORDER BY return_t7 DESC
+                LIMIT 1
+            )
+            UNION ALL
+            (
+                SELECT symbol, return_t7, correct_t7, prediction_date, 'worst' AS rank_type
+                FROM prediction_outcomes
+                WHERE correct_t7 IS NOT NULL AND return_t7 IS NOT NULL
+                    {date_filter_bare}
+                ORDER BY return_t7 ASC
+                LIMIT 1
+            )
+        """)
+        rows, columns = execute_query(best_worst_query, params)
+        if rows and len(rows) == 2:
+            best_row = rows[0] if rows[0][4] == "best" else rows[1]
+            worst_row = rows[1] if rows[1][4] == "worst" else rows[0]
+            best_sym = best_row[0]
+            best_ret = float(best_row[1])
+            worst_sym = worst_row[0]
+            worst_ret = float(worst_row[1])
+
+            headline = f"Best: {best_sym} {best_ret:+.2f}%. Worst: {worst_sym} {worst_ret:+.2f}%."
+            body = "Can't win 'em all."
+
+            insights.append({
+                "type": "best_worst",
+                "headline": headline,
+                "body": body,
+                "assets": [best_sym, worst_sym],
+                "sentiment": "neutral",
+                "timestamp": None,
+                "priority": 2,
+            })
+    except Exception as e:
+        logger.error(f"Error generating best_worst insight: {e}")
+
+    # ---- Insight 3: System accuracy vs coin flip ----
+    try:
+        date_filter_bare = ""
+        if days is not None:
+            date_filter_bare = "AND prediction_date >= :start_date"
+
+        accuracy_query = text(f"""
+            SELECT
+                COUNT(*) AS total,
+                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS correct
+            FROM prediction_outcomes
+            WHERE correct_t7 IS NOT NULL
+                {date_filter_bare}
+        """)
+        rows, columns = execute_query(accuracy_query, params)
+        if rows and rows[0] and rows[0][0] and rows[0][0] >= 5:
+            total = rows[0][0]
+            correct = rows[0][1] or 0
+            accuracy = round(correct / total * 100, 1)
+
+            if accuracy > 55:
+                body = "Not bad for a shitpost-powered AI."
+                ins_sentiment = "positive"
+            elif accuracy > 45:
+                body = f"Coin flip is 50%. We're {'barely beating' if accuracy > 50 else 'losing to'} random."
+                ins_sentiment = "neutral"
+            else:
+                body = "Maybe we should just flip a coin."
+                ins_sentiment = "negative"
+
+            period_label = f"last {days} days" if days else "all time"
+            headline = f"{accuracy:.0f}% accuracy ({total} predictions, {period_label})."
+
+            insights.append({
+                "type": "system_pulse",
+                "headline": headline,
+                "body": body,
+                "assets": [],
+                "sentiment": ins_sentiment,
+                "timestamp": None,
+                "priority": 3,
+            })
+    except Exception as e:
+        logger.error(f"Error generating system_pulse insight: {e}")
+
+    # ---- Insight 4: Most active asset (most predictions recently) ----
+    try:
+        date_filter_bare = ""
+        if days is not None:
+            date_filter_bare = "AND prediction_date >= :start_date"
+
+        active_query = text(f"""
+            SELECT
+                symbol,
+                COUNT(*) AS pred_count,
+                ROUND(AVG(return_t7)::numeric, 2) AS avg_return
+            FROM prediction_outcomes
+            WHERE correct_t7 IS NOT NULL
+                {date_filter_bare}
+            GROUP BY symbol
+            HAVING COUNT(*) >= 3
+            ORDER BY COUNT(*) DESC
+            LIMIT 1
+        """)
+        rows, columns = execute_query(active_query, params)
+        if rows and rows[0]:
+            symbol = rows[0][0]
+            count = rows[0][1]
+            avg_ret = float(rows[0][2]) if rows[0][2] is not None else 0.0
+
+            ret_comment = f"averaging {avg_ret:+.2f}% per call" if avg_ret != 0 else "averaging flat returns"
+            headline = f"{symbol} is our most-called asset ({count} predictions), {ret_comment}."
+            body = "Trump can't stop talking about it." if count > 10 else "Keeps showing up."
+
+            insights.append({
+                "type": "hot_asset",
+                "headline": headline,
+                "body": body,
+                "assets": [symbol],
+                "sentiment": "positive" if avg_ret > 0 else "negative" if avg_ret < 0 else "neutral",
+                "timestamp": None,
+                "priority": 4,
+            })
+    except Exception as e:
+        logger.error(f"Error generating hot_asset insight: {e}")
+
+    # ---- Insight 5: Recent high-confidence signal ----
+    try:
+        hot_signal_query = text("""
+            SELECT
+                po.symbol,
+                po.prediction_sentiment,
+                po.prediction_confidence,
+                po.correct_t7,
+                po.return_t7,
+                tss.timestamp AS post_timestamp
+            FROM prediction_outcomes po
+            INNER JOIN predictions p ON po.prediction_id = p.id
+            INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
+            WHERE po.prediction_confidence >= 0.75
+            ORDER BY tss.timestamp DESC
+            LIMIT 1
+        """)
+        rows, columns = execute_query(hot_signal_query)
+        if rows and rows[0]:
+            symbol = rows[0][0]
+            sentiment = (rows[0][1] or "neutral").lower()
+            confidence = float(rows[0][2]) if rows[0][2] is not None else 0.0
+            correct = rows[0][3]
+            return_t7 = float(rows[0][4]) if rows[0][4] is not None else None
+            post_ts = rows[0][5]
+
+            conf_pct = f"{confidence:.0%}"
+            if correct is None:
+                headline = f"High-confidence call: {sentiment.upper()} on {symbol} ({conf_pct}). Awaiting results."
+                body = "The suspense is killing us."
+                ins_sentiment = "neutral"
+            elif correct:
+                ret_str = f"{return_t7:+.2f}%" if return_t7 is not None else "N/A"
+                headline = f"High-confidence call on {symbol} ({conf_pct}) was RIGHT. {ret_str} in 7d."
+                body = "Even a broken AI is right twice a day."
+                ins_sentiment = "positive"
+            else:
+                ret_str = f"{return_t7:+.2f}%" if return_t7 is not None else "N/A"
+                headline = f"High-confidence call on {symbol} ({conf_pct}) was WRONG. {ret_str} in 7d."
+                body = "Confidence != competence."
+                ins_sentiment = "negative"
+
+            insights.append({
+                "type": "hot_signal",
+                "headline": headline,
+                "body": body,
+                "assets": [symbol],
+                "sentiment": ins_sentiment,
+                "timestamp": post_ts,
+                "priority": 5,
+            })
+    except Exception as e:
+        logger.error(f"Error generating hot_signal insight: {e}")
+
+    return insights

--- a/shitty_ui/data.py
+++ b/shitty_ui/data.py
@@ -2631,19 +2631,23 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
                     body = "Cha-ching." if return_t7 > 2 else "Not bad."
                     ins_sentiment = "positive"
                 else:
-                    headline = f"Trump mentioned {symbol} -- it went {ret_str} in 7 days."
+                    headline = (
+                        f"Trump mentioned {symbol} -- it went {ret_str} in 7 days."
+                    )
                     body = "Ouch." if return_t7 < -2 else "Close, but no cigar."
                     ins_sentiment = "negative"
 
-                insights.append({
-                    "type": "latest_call",
-                    "headline": headline,
-                    "body": body,
-                    "assets": [symbol],
-                    "sentiment": ins_sentiment,
-                    "timestamp": post_ts,
-                    "priority": 1,
-                })
+                insights.append(
+                    {
+                        "type": "latest_call",
+                        "headline": headline,
+                        "body": body,
+                        "assets": [symbol],
+                        "sentiment": ins_sentiment,
+                        "timestamp": post_ts,
+                        "priority": 1,
+                    }
+                )
     except Exception as e:
         logger.error(f"Error generating latest_call insight: {e}")
 
@@ -2684,15 +2688,17 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
             headline = f"Best: {best_sym} {best_ret:+.2f}%. Worst: {worst_sym} {worst_ret:+.2f}%."
             body = "Can't win 'em all."
 
-            insights.append({
-                "type": "best_worst",
-                "headline": headline,
-                "body": body,
-                "assets": [best_sym, worst_sym],
-                "sentiment": "neutral",
-                "timestamp": None,
-                "priority": 2,
-            })
+            insights.append(
+                {
+                    "type": "best_worst",
+                    "headline": headline,
+                    "body": body,
+                    "assets": [best_sym, worst_sym],
+                    "sentiment": "neutral",
+                    "timestamp": None,
+                    "priority": 2,
+                }
+            )
     except Exception as e:
         logger.error(f"Error generating best_worst insight: {e}")
 
@@ -2727,17 +2733,21 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
                 ins_sentiment = "negative"
 
             period_label = f"last {days} days" if days else "all time"
-            headline = f"{accuracy:.0f}% accuracy ({total} predictions, {period_label})."
+            headline = (
+                f"{accuracy:.0f}% accuracy ({total} predictions, {period_label})."
+            )
 
-            insights.append({
-                "type": "system_pulse",
-                "headline": headline,
-                "body": body,
-                "assets": [],
-                "sentiment": ins_sentiment,
-                "timestamp": None,
-                "priority": 3,
-            })
+            insights.append(
+                {
+                    "type": "system_pulse",
+                    "headline": headline,
+                    "body": body,
+                    "assets": [],
+                    "sentiment": ins_sentiment,
+                    "timestamp": None,
+                    "priority": 3,
+                }
+            )
     except Exception as e:
         logger.error(f"Error generating system_pulse insight: {e}")
 
@@ -2766,19 +2776,33 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
             count = rows[0][1]
             avg_ret = float(rows[0][2]) if rows[0][2] is not None else 0.0
 
-            ret_comment = f"averaging {avg_ret:+.2f}% per call" if avg_ret != 0 else "averaging flat returns"
+            ret_comment = (
+                f"averaging {avg_ret:+.2f}% per call"
+                if avg_ret != 0
+                else "averaging flat returns"
+            )
             headline = f"{symbol} is our most-called asset ({count} predictions), {ret_comment}."
-            body = "Trump can't stop talking about it." if count > 10 else "Keeps showing up."
+            body = (
+                "Trump can't stop talking about it."
+                if count > 10
+                else "Keeps showing up."
+            )
 
-            insights.append({
-                "type": "hot_asset",
-                "headline": headline,
-                "body": body,
-                "assets": [symbol],
-                "sentiment": "positive" if avg_ret > 0 else "negative" if avg_ret < 0 else "neutral",
-                "timestamp": None,
-                "priority": 4,
-            })
+            insights.append(
+                {
+                    "type": "hot_asset",
+                    "headline": headline,
+                    "body": body,
+                    "assets": [symbol],
+                    "sentiment": "positive"
+                    if avg_ret > 0
+                    else "negative"
+                    if avg_ret < 0
+                    else "neutral",
+                    "timestamp": None,
+                    "priority": 4,
+                }
+            )
     except Exception as e:
         logger.error(f"Error generating hot_asset insight: {e}")
 
@@ -2824,15 +2848,17 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
                 body = "Confidence != competence."
                 ins_sentiment = "negative"
 
-            insights.append({
-                "type": "hot_signal",
-                "headline": headline,
-                "body": body,
-                "assets": [symbol],
-                "sentiment": ins_sentiment,
-                "timestamp": post_ts,
-                "priority": 5,
-            })
+            insights.append(
+                {
+                    "type": "hot_signal",
+                    "headline": headline,
+                    "body": body,
+                    "assets": [symbol],
+                    "sentiment": ins_sentiment,
+                    "timestamp": post_ts,
+                    "priority": 5,
+                }
+            )
     except Exception as e:
         logger.error(f"Error generating hot_signal insight: {e}")
 

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -264,7 +264,6 @@ def create_dashboard_page() -> html.Div:
     )
 
 
-
 def register_dashboard_callbacks(app: Dash):
     """Register all dashboard-specific callbacks."""
 

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -33,8 +33,10 @@ from data import (
     get_predictions_with_outcomes,
     load_recent_posts,
     get_dashboard_kpis_with_fallback,
+    get_dynamic_insights,
 )
 from components.screener import build_screener_table
+from components.insights import create_insight_cards
 
 
 def create_dashboard_page() -> html.Div:
@@ -97,6 +99,16 @@ def create_dashboard_page() -> html.Div:
                             "alignItems": "center",
                             "justifyContent": "flex-end",
                         },
+                    ),
+                    # Dynamic Insight Cards (above KPIs, answer "so what right now?")
+                    dcc.Loading(
+                        id="insight-cards-loading",
+                        type="default",
+                        color=COLORS["accent"],
+                        children=html.Div(
+                            id="insight-cards-container",
+                            style={"marginBottom": "16px"},
+                        ),
                     ),
                     # Key Metrics Row (Primary tier - hero treatment)
                     dcc.Loading(
@@ -324,6 +336,7 @@ def register_dashboard_callbacks(app: Dash):
     # ========== Main Dashboard Update Callback ==========
     @app.callback(
         [
+            Output("insight-cards-container", "children"),
             Output("screener-table-container", "children"),
             Output("performance-metrics", "children"),
             Output("last-update-timestamp", "data"),
@@ -343,6 +356,15 @@ def register_dashboard_callbacks(app: Dash):
 
         # Current timestamp for refresh indicator
         current_time = datetime.now().isoformat()
+
+        # ===== Dynamic Insight Cards =====
+        try:
+            insight_pool = get_dynamic_insights(days=days)
+            insight_cards = create_insight_cards(insight_pool, max_cards=3)
+        except Exception as e:
+            errors.append(f"Insight cards: {e}")
+            print(f"Error loading insight cards: {traceback.format_exc()}")
+            insight_cards = html.Div()  # Silent failure -- insights are not critical
 
         # ===== Asset Screener Table =====
         try:
@@ -448,6 +470,7 @@ def register_dashboard_callbacks(app: Dash):
             print(f"Dashboard update completed with errors: {errors}")
 
         return (
+            insight_cards,
             screener_table,
             metrics_row,
             current_time,


### PR DESCRIPTION
## Summary

- Add 2-3 dynamic insight cards above the screener table that provide personality-driven, time-aware callouts answering "why should I care right now?"
- 5 insight types: latest call outcome, best/worst predictions, system accuracy pulse, hot asset, high-confidence signal
- Each card links to the relevant asset detail page, updates with period filter, and has independent error handling
- Cleaned up dead Signals/Trends/Performance brand copy from Phase 05

**Plan:** `documentation/planning/phases/dashboard-rethink_2026-02-22/06_actionable-insight-cards.md`

## Files Changed

| File | Change |
|------|--------|
| `shitty_ui/data.py` | Add `get_dynamic_insights()` with 5 SQL insight queries |
| `shitty_ui/components/insights.py` | NEW — `create_insight_cards()` rendering component |
| `shitty_ui/pages/dashboard.py` | Integrate insight cards into layout and callback (3→4 outputs) |
| `shitty_ui/brand_copy.py` | Add insight labels; remove dead Signals/Trends/Performance copy |
| `shit_tests/shitty_ui/test_insights.py` | NEW — 21 tests (data, component, timestamp) |
| `shit_tests/shitty_ui/test_copy.py` | Update for new/removed copy keys |

## Verification

```
✓  681/684 tests pass (3 pre-existing telegram failures)
✓  21 new tests written and passing
✓  ruff check clean on all modified files
✓  ruff format produces no changes
✓  All plan deliverables complete
✓  "What NOT To Do" items reviewed — none violated
```

## Test plan

- [x] `get_dynamic_insights()` returns empty list with no data
- [x] Each insight type generates correctly from mocked queries
- [x] System pulse requires minimum 5 predictions
- [x] All insight dicts have required keys
- [x] Database errors are swallowed gracefully (partial failure)
- [x] `create_insight_cards()` renders correct number of cards
- [x] Cards sort by priority
- [x] Asset links are proper `dcc.Link` elements
- [x] Container has `role="region"` and `aria-label`
- [x] Positive/negative sentiment gets correct border color
- [x] Timestamp formatting covers all time ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)