### PR TITLE
fix: resolve conftest pytest_plugins blocker, delete stale bypass tests, modernize settings config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **pytest collection blocker** -- Moved `pytest_plugins` declaration from `shit_tests/conftest.py` to root-level `conftest.py` (required by pytest 8.x)
+- **5 stale bypass tests** -- Deleted `test_get_bypass_reason_*` tests that called removed `_get_bypass_reason()` method (coverage exists in `test_bypass_service.py`)
+- **Pydantic V2 deprecation warnings** -- Migrated Settings from legacy `class Config` to `SettingsConfigDict`, removed all deprecated `env=` parameters from Field() calls
+
 ### Added
 - **Dynamic insight cards** -- 2-3 personality-driven callout cards above the screener table answering "so what right now?"
   - Latest call: most recent evaluated prediction with 7-day return and outcome

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+"""
+Root-level conftest.py for pytest plugin registration.
+
+pytest_plugins must be declared in a root-level conftest.py (not in subdirectories).
+This requirement was enforced starting in pytest 8.x.
+"""
+
+pytest_plugins = ['pytest_asyncio']

--- a/documentation/planning/tech_debt/codebase-health_2026-02-23/01_fix-conftest-and-failing-tests.md
+++ b/documentation/planning/tech_debt/codebase-health_2026-02-23/01_fix-conftest-and-failing-tests.md
@@ -1,0 +1,187 @@
+# Phase 01: Fix pytest conftest blocker and 10 failing tests
+
+**Status:** 🔧 IN PROGRESS
+**Started:** 2026-02-23
+
+| Field | Value |
+|-------|-------|
+| **PR Title** | fix: resolve conftest pytest_plugins blocker, delete stale bypass tests, modernize settings config |
+| **Risk Level** | Low |
+| **Effort** | Low (~1-2 hours) |
+| **Files Created** | 1 |
+| **Files Modified** | 3 |
+| **Files Deleted** | 0 |
+
+## Context
+
+The test suite has three distinct problems that erode CI trust and block other development:
+
+1. **pytest_plugins blocker**: `shit_tests/conftest.py` line 36 declares `pytest_plugins = ['pytest_asyncio']`. In pytest 8.x, this is forbidden in non-root-level conftest files. This blocks the entire test suite from running with bare `pytest` from the project root.
+
+2. **5 failing bypass reason tests**: `shit_tests/shitvault/test_prediction_operations.py` lines 434-468 contain 5 tests that call `prediction_ops._get_bypass_reason(shitpost_data)`. This method no longer exists on `PredictionOperations`. The bypass logic was refactored into `BypassService` (in `shit/content/bypass_service.py`), which already has comprehensive tests at `shit_tests/content/test_bypass_service.py`.
+
+3. **Pydantic V2 deprecation warnings in Settings**: `shit/config/shitpost_settings.py` uses the legacy `class Config` inner class pattern and the deprecated `env=` parameter on every `Field()` call. The correct pattern is `model_config = SettingsConfigDict(...)`.
+
+This phase is the foundation for all subsequent codebase-health work.
+
+## Dependencies
+
+- **Depends on**: None (this is the foundation phase)
+- **Unlocks**: Phases 02-08
+
+## Detailed Implementation Plan
+
+### Step 1: Create root-level conftest.py with pytest_plugins
+
+**File to create**: `/Users/chris/Projects/shitpost-alpha/conftest.py`
+
+```python
+"""
+Root-level conftest.py for pytest plugin registration.
+
+pytest_plugins must be declared in a root-level conftest.py (not in subdirectories).
+This requirement was enforced starting in pytest 8.x.
+"""
+
+pytest_plugins = ['pytest_asyncio']
+```
+
+### Step 2: Remove pytest_plugins from shit_tests/conftest.py
+
+**File to modify**: `/Users/chris/Projects/shitpost-alpha/shit_tests/conftest.py`
+
+**Current code at lines 35-36:**
+```python
+# Configure pytest for async tests
+pytest_plugins = ['pytest_asyncio']
+```
+
+**Replace with:**
+```python
+# NOTE: pytest_plugins declaration moved to root-level conftest.py
+# (pytest 8.x requires pytest_plugins in root conftest only)
+```
+
+No other lines change. The `import pytest_asyncio` on line 14 must remain — it is used by `@pytest_asyncio.fixture` decorators.
+
+### Step 3: Delete the 5 stale _get_bypass_reason tests
+
+**File to modify**: `/Users/chris/Projects/shitpost-alpha/shit_tests/shitvault/test_prediction_operations.py`
+
+Delete lines 434-468 — the 5 tests calling `prediction_ops._get_bypass_reason()`:
+- `test_get_bypass_reason_no_text` (line 434)
+- `test_get_bypass_reason_short_text` (line 440)
+- `test_get_bypass_reason_test_content` (line 446)
+- `test_get_bypass_reason_insufficient_words` (line 455)
+- `test_get_bypass_reason_fallback` (line 463)
+
+**Why delete instead of rewrite**: Equivalent coverage already exists in `shit_tests/content/test_bypass_service.py` (226 lines, 15+ test cases).
+
+### Step 4: Modernize Settings class to use ConfigDict pattern
+
+**File to modify**: `/Users/chris/Projects/shitpost-alpha/shit/config/shitpost_settings.py`
+
+#### Part 4a: Update imports
+
+**Current lines 8-9:**
+```python
+from pydantic_settings import BaseSettings
+from pydantic import Field
+```
+
+**Replace with:**
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+```
+
+#### Part 4b: Replace inner Config class with model_config
+
+**Current code at lines 141-143:**
+```python
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+```
+
+**Replace with:**
+```python
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,
+    )
+```
+
+#### Part 4c: Remove deprecated `env=` parameter from all Field() calls
+
+Every `Field()` call with `env=` must have that parameter removed. Field names already match env var names (all uppercase), so the explicit `env=` is redundant when `case_sensitive=False`.
+
+For single-line fields, remove `env="..."`:
+```python
+# Before:
+OPENAI_API_KEY: str = Field(default=None, env="OPENAI_API_KEY")
+# After:
+OPENAI_API_KEY: str = Field(default=None)
+```
+
+For multi-line fields, collapse after removing `env=`:
+```python
+# Before:
+EMAIL_FROM_ADDRESS: str = Field(
+    default="alerts@shitpostalpha.com",
+    env="EMAIL_FROM_ADDRESS",
+)
+# After:
+EMAIL_FROM_ADDRESS: str = Field(default="alerts@shitpostalpha.com")
+```
+
+Apply this to ALL Field() calls in lines 27-139 (~40 fields total).
+
+## Test Plan
+
+### Existing tests to verify (no modifications needed)
+All 648+ existing settings tests in `test_shitpost_settings.py` should pass unchanged. The Settings class API is not changing — only its internal configuration mechanism.
+
+### Tests that will be removed
+The 5 stale tests in `test_prediction_operations.py` (already covered by `test_bypass_service.py`).
+
+### No new tests needed
+1. Root conftest.py change is configuration, not logic
+2. Deleted tests are covered by existing BypassService tests
+3. Settings ConfigDict migration preserves identical behavior
+
+### Manual verification
+```bash
+# 1. Verify pytest collection works
+./venv/bin/python -m pytest --collect-only 2>&1 | head -20
+
+# 2. Run full test suite
+./venv/bin/python -m pytest
+
+# 3. Verify no pydantic deprecation warnings
+./venv/bin/python -m pytest -W error::DeprecationWarning shit_tests/shit/config/
+
+# 4. Verify prediction ops tests (5 fewer)
+./venv/bin/python -m pytest shit_tests/shitvault/test_prediction_operations.py -v
+```
+
+## Verification Checklist
+
+- [ ] Root-level `conftest.py` exists at project root
+- [ ] `pytest_plugins` is in root conftest.py, NOT in `shit_tests/conftest.py`
+- [ ] `pytest --collect-only` succeeds without errors
+- [ ] `test_get_bypass_reason_*` tests no longer exist
+- [ ] Settings uses `model_config = SettingsConfigDict(...)` (no `class Config`)
+- [ ] No `env=` parameters remain in any `Field()` call
+- [ ] Full test suite passes
+- [ ] No pydantic deprecation warnings
+- [ ] CHANGELOG.md updated
+
+## What NOT To Do
+
+1. **Do NOT move `pytest.ini`** from `shit_tests/` to project root — different issue, would break rootdir discovery.
+2. **Do NOT rewrite the 5 stale tests** to call BypassService — they'd duplicate existing comprehensive tests.
+3. **Do NOT add `validation_alias`** to Field() calls — redundant with `case_sensitive=False`.
+4. **Do NOT change the `load_dotenv` call** at lines 14-20 — it coexists safely with `env_file`.
+5. **Do NOT remove `import pytest_asyncio`** from `shit_tests/conftest.py` line 14 — it's used by fixture decorators.
+6. **Do NOT add `env_prefix`** to SettingsConfigDict — no prefix convention in this project.

--- a/shit/config/shitpost_settings.py
+++ b/shit/config/shitpost_settings.py
@@ -5,7 +5,7 @@ Uses Pydantic for environment variable validation and management.
 
 import os
 from typing import Optional
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
 # Load .env file from project root
@@ -24,123 +24,95 @@ class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
     # Environment
-    ENVIRONMENT: str = Field(default="development", env="ENVIRONMENT")
-    DEBUG: bool = Field(default=True, env="DEBUG")
+    ENVIRONMENT: str = Field(default="development")
+    DEBUG: bool = Field(default=True)
 
     # Database
-    DATABASE_URL: str = Field(
-        default="sqlite:///./shitpost_alpha.db", env="DATABASE_URL"
-    )
+    DATABASE_URL: str = Field(default="sqlite:///./shitpost_alpha.db")
 
     # LLM Configuration
-    OPENAI_API_KEY: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
-    ANTHROPIC_API_KEY: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
-    XAI_API_KEY: Optional[str] = Field(default=None, env="XAI_API_KEY")
-    LLM_PROVIDER: str = Field(default="openai", env="LLM_PROVIDER")  # openai, anthropic, grok
-    LLM_MODEL: str = Field(default="gpt-4", env="LLM_MODEL")
-    LLM_BASE_URL: Optional[str] = Field(default=None, env="LLM_BASE_URL")  # Custom base URL for OpenAI-compatible APIs
+    OPENAI_API_KEY: Optional[str] = Field(default=None)
+    ANTHROPIC_API_KEY: Optional[str] = Field(default=None)
+    XAI_API_KEY: Optional[str] = Field(default=None)
+    LLM_PROVIDER: str = Field(default="openai")  # openai, anthropic, grok
+    LLM_MODEL: str = Field(default="gpt-4")
+    LLM_BASE_URL: Optional[str] = Field(default=None)  # Custom base URL for OpenAI-compatible APIs
 
     # Truth Social Shitpost Configuration
-    TRUTH_SOCIAL_USERNAME: str = Field(
-        default="realDonaldTrump", env="TRUTH_SOCIAL_USERNAME"
-    )
-    TRUTH_SOCIAL_SHITPOST_INTERVAL: int = Field(
-        default=30, env="TRUTH_SOCIAL_SHITPOST_INTERVAL"
-    )  # seconds between shitpost harvests
+    TRUTH_SOCIAL_USERNAME: str = Field(default="realDonaldTrump")
+    TRUTH_SOCIAL_SHITPOST_INTERVAL: int = Field(default=30)  # seconds between shitpost harvests
 
     # Analysis Configuration
-    CONFIDENCE_THRESHOLD: float = Field(default=0.7, env="CONFIDENCE_THRESHOLD")
-    MAX_SHITPOST_LENGTH: int = Field(default=4000, env="MAX_SHITPOST_LENGTH")
+    CONFIDENCE_THRESHOLD: float = Field(default=0.7)
+    MAX_SHITPOST_LENGTH: int = Field(default=4000)
 
     # System Launch Configuration
-    SYSTEM_LAUNCH_DATE: str = Field(
-        default="2025-01-01T00:00:00Z", env="SYSTEM_LAUNCH_DATE"
-    )
+    SYSTEM_LAUNCH_DATE: str = Field(default="2025-01-01T00:00:00Z")
 
     # SMS/Alerting Configuration (Phase 2)
-    TWILIO_ACCOUNT_SID: Optional[str] = Field(default=None, env="TWILIO_ACCOUNT_SID")
-    TWILIO_AUTH_TOKEN: Optional[str] = Field(default=None, env="TWILIO_AUTH_TOKEN")
-    TWILIO_PHONE_NUMBER: Optional[str] = Field(default=None, env="TWILIO_PHONE_NUMBER")
+    TWILIO_ACCOUNT_SID: Optional[str] = Field(default=None)
+    TWILIO_AUTH_TOKEN: Optional[str] = Field(default=None)
+    TWILIO_PHONE_NUMBER: Optional[str] = Field(default=None)
 
     # Email Configuration (Phase 2 - Alerting)
-    EMAIL_PROVIDER: str = Field(
-        default="smtp", env="EMAIL_PROVIDER"
-    )  # "smtp" or "sendgrid"
-    SMTP_HOST: Optional[str] = Field(default=None, env="SMTP_HOST")
-    SMTP_PORT: int = Field(default=587, env="SMTP_PORT")
-    SMTP_USERNAME: Optional[str] = Field(default=None, env="SMTP_USERNAME")
-    SMTP_PASSWORD: Optional[str] = Field(default=None, env="SMTP_PASSWORD")
-    SMTP_USE_TLS: bool = Field(default=True, env="SMTP_USE_TLS")
-    EMAIL_FROM_ADDRESS: str = Field(
-        default="alerts@shitpostalpha.com",
-        env="EMAIL_FROM_ADDRESS",
-    )
-    EMAIL_FROM_NAME: str = Field(
-        default="Shitpost Alpha",
-        env="EMAIL_FROM_NAME",
-    )
-    SENDGRID_API_KEY: Optional[str] = Field(default=None, env="SENDGRID_API_KEY")
+    EMAIL_PROVIDER: str = Field(default="smtp")  # "smtp" or "sendgrid"
+    SMTP_HOST: Optional[str] = Field(default=None)
+    SMTP_PORT: int = Field(default=587)
+    SMTP_USERNAME: Optional[str] = Field(default=None)
+    SMTP_PASSWORD: Optional[str] = Field(default=None)
+    SMTP_USE_TLS: bool = Field(default=True)
+    EMAIL_FROM_ADDRESS: str = Field(default="alerts@shitpostalpha.com")
+    EMAIL_FROM_NAME: str = Field(default="Shitpost Alpha")
+    SENDGRID_API_KEY: Optional[str] = Field(default=None)
 
     # Telegram Bot Configuration (Phase 2 - Alerting)
-    TELEGRAM_BOT_TOKEN: Optional[str] = Field(default=None, env="TELEGRAM_BOT_TOKEN")
-    TELEGRAM_BOT_USERNAME: Optional[str] = Field(
-        default=None, env="TELEGRAM_BOT_USERNAME"
-    )  # Without @ prefix
-    TELEGRAM_WEBHOOK_URL: Optional[str] = Field(
-        default=None, env="TELEGRAM_WEBHOOK_URL"
-    )  # For webhook mode (optional)
+    TELEGRAM_BOT_TOKEN: Optional[str] = Field(default=None)
+    TELEGRAM_BOT_USERNAME: Optional[str] = Field(default=None)  # Without @ prefix
+    TELEGRAM_WEBHOOK_URL: Optional[str] = Field(default=None)  # For webhook mode (optional)
 
     # Market Data Resilience Configuration
-    ALPHA_VANTAGE_API_KEY: Optional[str] = Field(default=None, env="ALPHA_VANTAGE_API_KEY")
-    MARKET_DATA_PRIMARY_PROVIDER: str = Field(default="yfinance", env="MARKET_DATA_PRIMARY_PROVIDER")
-    MARKET_DATA_FALLBACK_PROVIDER: str = Field(default="alphavantage", env="MARKET_DATA_FALLBACK_PROVIDER")
-    MARKET_DATA_MAX_RETRIES: int = Field(default=3, env="MARKET_DATA_MAX_RETRIES")
-    MARKET_DATA_RETRY_DELAY: float = Field(default=1.0, env="MARKET_DATA_RETRY_DELAY")  # seconds
-    MARKET_DATA_RETRY_BACKOFF: float = Field(default=2.0, env="MARKET_DATA_RETRY_BACKOFF")  # multiplier
-    MARKET_DATA_STALENESS_THRESHOLD_HOURS: int = Field(default=48, env="MARKET_DATA_STALENESS_THRESHOLD_HOURS")
-    MARKET_DATA_HEALTH_CHECK_SYMBOLS: str = Field(default="SPY,AAPL", env="MARKET_DATA_HEALTH_CHECK_SYMBOLS")
-    MARKET_DATA_FAILURE_ALERT_CHAT_ID: Optional[str] = Field(default=None, env="MARKET_DATA_FAILURE_ALERT_CHAT_ID")
+    ALPHA_VANTAGE_API_KEY: Optional[str] = Field(default=None)
+    MARKET_DATA_PRIMARY_PROVIDER: str = Field(default="yfinance")
+    MARKET_DATA_FALLBACK_PROVIDER: str = Field(default="alphavantage")
+    MARKET_DATA_MAX_RETRIES: int = Field(default=3)
+    MARKET_DATA_RETRY_DELAY: float = Field(default=1.0)  # seconds
+    MARKET_DATA_RETRY_BACKOFF: float = Field(default=2.0)  # multiplier
+    MARKET_DATA_STALENESS_THRESHOLD_HOURS: int = Field(default=48)
+    MARKET_DATA_HEALTH_CHECK_SYMBOLS: str = Field(default="SPY,AAPL")
+    MARKET_DATA_FAILURE_ALERT_CHAT_ID: Optional[str] = Field(default=None)
 
     # ScrapeCreators API Configuration
-    SCRAPECREATORS_API_KEY: Optional[str] = Field(
-        default=None, env="SCRAPECREATORS_API_KEY"
-    )
+    SCRAPECREATORS_API_KEY: Optional[str] = Field(default=None)
 
     # S3 Data Lake Configuration
-    S3_BUCKET_NAME: str = Field(default="shitpost-alpha-raw-data", env="S3_BUCKET_NAME")
-    S3_PREFIX: str = Field(default="truth-social", env="S3_PREFIX")
-    AWS_ACCESS_KEY_ID: Optional[str] = Field(default=None, env="AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY: Optional[str] = Field(
-        default=None, env="AWS_SECRET_ACCESS_KEY"
-    )
-    AWS_REGION: str = Field(default="us-east-1", env="AWS_REGION")
+    S3_BUCKET_NAME: str = Field(default="shitpost-alpha-raw-data")
+    S3_PREFIX: str = Field(default="truth-social")
+    AWS_ACCESS_KEY_ID: Optional[str] = Field(default=None)
+    AWS_SECRET_ACCESS_KEY: Optional[str] = Field(default=None)
+    AWS_REGION: str = Field(default="us-east-1")
 
     # Multi-Source Harvester Configuration
-    ENABLED_HARVESTERS: str = Field(
-        default="truth_social",
-        env="ENABLED_HARVESTERS",
-    )  # Comma-separated list of enabled harvester source names
+    ENABLED_HARVESTERS: str = Field(default="truth_social")  # Comma-separated list of enabled harvester source names
 
     # Twitter/X Configuration (Future)
-    TWITTER_API_KEY: Optional[str] = Field(default=None, env="TWITTER_API_KEY")
-    TWITTER_API_SECRET: Optional[str] = Field(default=None, env="TWITTER_API_SECRET")
-    TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None, env="TWITTER_BEARER_TOKEN")
-    TWITTER_TARGET_USERS: str = Field(
-        default="", env="TWITTER_TARGET_USERS"
-    )  # Comma-separated Twitter usernames to monitor
+    TWITTER_API_KEY: Optional[str] = Field(default=None)
+    TWITTER_API_SECRET: Optional[str] = Field(default=None)
+    TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None)
+    TWITTER_TARGET_USERS: str = Field(default="")  # Comma-separated Twitter usernames to monitor
 
     # Logging
-    LOG_LEVEL: str = Field(default="INFO", env="LOG_LEVEL")
-    FILE_LOGGING: bool = Field(default=False, env="FILE_LOGGING")
-    LOG_FILE_PATH: Optional[str] = Field(default=None, env="LOG_FILE_PATH")
+    LOG_LEVEL: str = Field(default="INFO")
+    FILE_LOGGING: bool = Field(default=False)
+    LOG_FILE_PATH: Optional[str] = Field(default=None)
 
     # Neon CLI (used by db-admin tooling, not by application code)
-    NEON_PROJECT_ID: Optional[str] = Field(default=None, env="NEON_PROJECT_ID")
-    NEON_ORG_ID: Optional[str] = Field(default=None, env="NEON_ORG_ID")
+    NEON_PROJECT_ID: Optional[str] = Field(default=None)
+    NEON_ORG_ID: Optional[str] = Field(default=None)
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,
+    )
 
     def get_llm_api_key(self) -> str:
         """Get the appropriate LLM API key based on provider."""

--- a/shit_tests/conftest.py
+++ b/shit_tests/conftest.py
@@ -32,8 +32,8 @@ from shit.llm.llm_client import LLMClient
 from shit.config.shitpost_settings import Settings
 
 
-# Configure pytest for async tests
-pytest_plugins = ['pytest_asyncio']
+# NOTE: pytest_plugins declaration moved to root-level conftest.py
+# (pytest 8.x requires pytest_plugins in root conftest only)
 
 
 @pytest.fixture(scope="session")

--- a/shit_tests/shitvault/test_prediction_operations.py
+++ b/shit_tests/shitvault/test_prediction_operations.py
@@ -431,41 +431,6 @@ class TestPredictionOperations:
         
         assert result is False
 
-    def test_get_bypass_reason_no_text(self, prediction_ops):
-        """Test bypass reason for empty text."""
-        shitpost_data = {'text': ''}
-        reason = prediction_ops._get_bypass_reason(shitpost_data)
-        assert reason == 'No text content'
-
-    def test_get_bypass_reason_short_text(self, prediction_ops):
-        """Test bypass reason for short text."""
-        shitpost_data = {'text': 'short'}
-        reason = prediction_ops._get_bypass_reason(shitpost_data)
-        assert reason == 'Text too short'
-
-    def test_get_bypass_reason_test_content(self, prediction_ops):
-        """Test bypass reason for test content (needs to be long enough)."""
-        # These words trigger test content check only if they pass length check
-        # Length must be >= 10 characters and have >= 3 words, so single words won't trigger this
-        shitpost_data = {'text': 'short'}
-        reason = prediction_ops._get_bypass_reason(shitpost_data)
-        # Short single words return "Text too short" before reaching test content check
-        assert reason == 'Text too short'
-
-    def test_get_bypass_reason_insufficient_words(self, prediction_ops):
-        """Test bypass reason for insufficient words."""
-        # Text that is long enough (>= 10 chars) but has < 3 words
-        shitpost_data = {'text': 'two words here'}  # 14 chars, 3 words - should pass
-        reason = prediction_ops._get_bypass_reason(shitpost_data)
-        # With 3 words and 14 chars, this should fall through to default
-        assert reason == 'Content not analyzable'
-
-    def test_get_bypass_reason_fallback(self, prediction_ops):
-        """Test bypass reason fallback."""
-        shitpost_data = {'text': 'Some weird content that cannot be analyzed properly'}
-        reason = prediction_ops._get_bypass_reason(shitpost_data)
-        # This should pass all checks and return the fallback
-        assert reason in ['No text content', 'Text too short', 'Test content', 'Insufficient words', 'Content not analyzable']
 
 
 class TestPredictionOperationsIntegration:


### PR DESCRIPTION
## Summary
- Moved `pytest_plugins` declaration from `shit_tests/conftest.py` to root-level `conftest.py` (required by pytest 8.x, was blocking test collection)
- Deleted 5 stale `test_get_bypass_reason_*` tests that called a removed method — equivalent coverage already exists in `test_bypass_service.py`
- Migrated Settings from legacy `class Config` to `SettingsConfigDict` and removed deprecated `env=` parameter from all ~40 `Field()` calls (Pydantic V2)

**Tech Debt Phase 01** — foundation that unlocks Phases 02-08 in the [codebase-health session](documentation/planning/tech_debt/codebase-health_2026-02-23/00_TECH_DEBT.md).

## Test plan
- [x] `pytest --collect-only` succeeds (2121 tests collected)
- [x] Full test suite: 2116 passed, 5 failed (pre-existing config test ordering issue, unchanged from main)
- [x] No pydantic deprecation warnings (`-W error::DeprecationWarning` passes)
- [x] `_get_bypass_reason` tests removed (grep confirms zero references)
- [x] Zero `env=` parameters remain in `shitpost_settings.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)