### PR TITLE
fix: replace deprecated asyncio.get_event_loop() and remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Asyncio deprecation warnings** — Replaced 8 instances of deprecated `asyncio.get_event_loop()` with modern alternatives (`asyncio.to_thread()` and `asyncio.get_running_loop()`) for Python 3.13 compatibility
+
+### Removed
+- **Dead code cleanup** — Removed unused `validate_prompt_version()` function from prompt module and unused `Decimal` import from market data models
+
 ### Changed
 - **Event worker CLI** — Extracted shared `run_worker_main()` helper, eliminating ~100 lines of duplicated boilerplate across 4 event consumer modules
 - **cards.py split** - Reorganized 1,930-line `shitty_ui/components/cards.py` into 8 focused modules under `shitty_ui/components/cards/` package. All existing imports work unchanged via `__init__.py` re-exports.

--- a/shit/llm/prompts.py
+++ b/shit/llm/prompts.py
@@ -377,17 +377,6 @@ def get_system_message(analysis_type: str = 'financial_analyst') -> str:
     return SYSTEM_MESSAGES.get(analysis_type, SYSTEM_MESSAGES['general'])
 
 
-def validate_prompt_version(version: str) -> bool:
-    """Validate prompt version for consistency.
-    
-    Args:
-        version: Version string to validate
-        
-    Returns:
-        True if version is valid
-    """
-    return version == PROMPT_VERSION
-
 
 def get_prompt_metadata() -> Dict[str, Any]:
     """Get metadata about prompt system.

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -7,7 +7,6 @@ from datetime import datetime, date
 from typing import Optional
 from sqlalchemy import Column, String, Date, DateTime, Float, BigInteger, ForeignKey, Integer, Boolean, Text
 from sqlalchemy.orm import relationship
-from decimal import Decimal
 
 from shit.db.data_models import Base, TimestampMixin, IDMixin
 

--- a/shit/s3/s3_data_lake.py
+++ b/shit/s3/s3_data_lake.py
@@ -107,8 +107,7 @@ class S3DataLake:
             logger.info(f"Uploading data to S3: {s3_key}")
             try:
                 await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(
-                        None,
+                    asyncio.to_thread(
                         lambda: self.s3_client.client.put_object(
                             Bucket=self.config.bucket_name,
                             Key=s3_key,
@@ -148,8 +147,7 @@ class S3DataLake:
             True if object exists, False otherwise
         """
         try:
-            await asyncio.get_event_loop().run_in_executor(
-                None,
+            await asyncio.to_thread(
                 lambda: self.s3_client.client.head_object(Bucket=self.config.bucket_name, Key=s3_key)
             )
             logger.debug(f"Object exists in S3: {s3_key}")
@@ -177,8 +175,7 @@ class S3DataLake:
             Raw data dictionary or None if not found
         """
         try:
-            response = await asyncio.get_event_loop().run_in_executor(
-                None,
+            response = await asyncio.to_thread(
                 lambda: self.s3_client.client.get_object(Bucket=self.config.bucket_name, Key=s3_key)
             )
             

--- a/shit/utils/error_handling.py
+++ b/shit/utils/error_handling.py
@@ -141,7 +141,7 @@ class CircuitBreaker:
     def _on_failure(self):
         """Handle failed execution."""
         self.failure_count += 1
-        self.last_failure_time = asyncio.get_event_loop().time()
+        self.last_failure_time = asyncio.get_running_loop().time()
         
         if self.failure_count >= self.failure_threshold:
             self.state = "OPEN"
@@ -152,7 +152,7 @@ class CircuitBreaker:
         if not self.last_failure_time:
             return True
         
-        return (asyncio.get_event_loop().time() - self.last_failure_time) >= self.recovery_timeout
+        return (asyncio.get_running_loop().time() - self.last_failure_time) >= self.recovery_timeout
 
 
 class RateLimiter:
@@ -165,7 +165,7 @@ class RateLimiter:
     
     async def acquire(self) -> bool:
         """Try to acquire a rate limit slot."""
-        now = asyncio.get_event_loop().time()
+        now = asyncio.get_running_loop().time()
         
         # Remove old calls outside the time window
         self.calls = [call_time for call_time in self.calls if now - call_time < self.time_window]

--- a/shit_tests/shit/llm/test_prompts.py
+++ b/shit_tests/shit/llm/test_prompts.py
@@ -14,7 +14,6 @@ from shit.llm.prompts import (
     get_alert_prompt,
     get_custom_prompt,
     get_system_message,
-    validate_prompt_version,
     get_prompt_metadata,
     SYSTEM_MESSAGES,
     PROMPT_VERSION
@@ -274,18 +273,6 @@ class TestPromptFunctions:
         message = get_system_message()  # No parameter
         assert isinstance(message, str)
         assert message == SYSTEM_MESSAGES['financial_analyst']  # Default type
-
-    def test_validate_prompt_version_valid(self):
-        """Test prompt version validation with valid version."""
-        assert validate_prompt_version("1.0") is True
-        assert validate_prompt_version(PROMPT_VERSION) is True
-
-    def test_validate_prompt_version_invalid(self):
-        """Test prompt version validation with invalid version."""
-        assert validate_prompt_version("2.0") is False
-        assert validate_prompt_version("1.1") is False
-        assert validate_prompt_version("") is False
-        assert validate_prompt_version(None) is False
 
     def test_get_prompt_metadata(self):
         """Test prompt metadata generation."""

--- a/shit_tests/shit/s3/test_s3_data_lake.py
+++ b/shit_tests/shit/s3/test_s3_data_lake.py
@@ -128,23 +128,20 @@ class TestS3DataLake:
         # Mock the S3 client methods
         mock_s3_client.client.put_object = MagicMock()
         
-        # Mock asyncio.wait_for and run_in_executor
+        # Mock asyncio.wait_for and to_thread
         with patch('asyncio.wait_for') as mock_wait_for, \
-             patch('asyncio.get_event_loop') as mock_get_loop:
-            
+             patch('asyncio.to_thread') as mock_to_thread:
+
             mock_wait_for.return_value = None
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.return_value = None
-            
+            mock_to_thread.return_value = None
+
             s3_key = await data_lake.store_raw_data(sample_raw_data)
-            
+
             # Verify the S3 key was generated correctly
             assert s3_key == "test-prefix/raw/2024/01/15/123456789.json"
-            
+
             # Verify put_object was called
             mock_wait_for.assert_called_once()
-            mock_loop.run_in_executor.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_store_raw_data_missing_id(self, data_lake, mock_s3_client):
@@ -174,15 +171,13 @@ class TestS3DataLake:
         # Mock the S3 client methods
         mock_s3_client.client.put_object = MagicMock()
         
-        # Mock asyncio.wait_for and run_in_executor
+        # Mock asyncio.wait_for and to_thread
         with patch('asyncio.wait_for') as mock_wait_for, \
-             patch('asyncio.get_event_loop') as mock_get_loop:
-            
+             patch('asyncio.to_thread') as mock_to_thread:
+
             mock_wait_for.return_value = None
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.return_value = None
-            
+            mock_to_thread.return_value = None
+
             # Test with invalid timestamp
             sample_raw_data["created_at"] = "invalid-timestamp"
             
@@ -200,12 +195,10 @@ class TestS3DataLake:
         
         # Mock asyncio.wait_for to raise TimeoutError
         with patch('asyncio.wait_for') as mock_wait_for, \
-             patch('asyncio.get_event_loop') as mock_get_loop:
-            
+             patch('asyncio.to_thread') as mock_to_thread:
+
             mock_wait_for.side_effect = asyncio.TimeoutError()
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.return_value = None
+            mock_to_thread.return_value = None
             
             with pytest.raises(asyncio.TimeoutError):
                 await data_lake.store_raw_data(sample_raw_data)
@@ -215,14 +208,12 @@ class TestS3DataLake:
         """Test raw data storage with upload error."""
         await data_lake.initialize()
         
-        # Mock asyncio.wait_for and run_in_executor
+        # Mock asyncio.wait_for and to_thread
         with patch('asyncio.wait_for') as mock_wait_for, \
-             patch('asyncio.get_event_loop') as mock_get_loop:
-            
+             patch('asyncio.to_thread') as mock_to_thread:
+
             mock_wait_for.side_effect = Exception("Upload failed")
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.return_value = None
+            mock_to_thread.return_value = None
             
             with pytest.raises(Exception, match="Upload failed"):
                 await data_lake.store_raw_data(sample_raw_data)
@@ -232,37 +223,26 @@ class TestS3DataLake:
         """Test checking object existence when object exists."""
         await data_lake.initialize()
         
-        # Mock asyncio.get_event_loop and run_in_executor
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            # run_in_executor returns a coroutine, so we need to mock it properly
-            mock_loop.run_in_executor = AsyncMock(return_value=None)
-            
+        # Mock asyncio.to_thread
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=None) as mock_to_thread:
             result = await data_lake.check_object_exists("test-key")
-            
+
             assert result == True
-            mock_loop.run_in_executor.assert_called_once()
+            mock_to_thread.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_check_object_exists_false(self, data_lake, mock_s3_client):
         """Test checking object existence when object doesn't exist."""
         await data_lake.initialize()
         
-        # Mock asyncio.get_event_loop and run_in_executor to raise ClientError
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            
-            # Create a mock ClientError with NoSuchKey
-            mock_error = ClientError(
-                error_response={'Error': {'Code': 'NoSuchKey'}},
-                operation_name='HeadObject'
-            )
-            mock_loop.run_in_executor = AsyncMock(side_effect=mock_error)
-            
+        # Mock asyncio.to_thread to raise ClientError
+        mock_error = ClientError(
+            error_response={'Error': {'Code': 'NoSuchKey'}},
+            operation_name='HeadObject'
+        )
+        with patch('asyncio.to_thread', new_callable=AsyncMock, side_effect=mock_error):
             result = await data_lake.check_object_exists("test-key")
-            
+
             assert result == False
 
     @pytest.mark.asyncio
@@ -270,12 +250,8 @@ class TestS3DataLake:
         """Test checking object existence with other error."""
         await data_lake.initialize()
         
-        # Mock asyncio.get_event_loop and run_in_executor to raise other error
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Network error"))
-            
+        # Mock asyncio.to_thread to raise other error
+        with patch('asyncio.to_thread', new_callable=AsyncMock, side_effect=Exception("Network error")):
             with pytest.raises(Exception, match="Network error"):
                 await data_lake.check_object_exists("test-key")
 
@@ -290,15 +266,10 @@ class TestS3DataLake:
         }
         mock_response['Body'].read.return_value = json.dumps(sample_raw_data).encode('utf-8')
         
-        # Mock asyncio.get_event_loop and run_in_executor
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            # run_in_executor returns a coroutine, so we need to mock it properly
-            mock_loop.run_in_executor = AsyncMock(return_value=mock_response)
-            
+        # Mock asyncio.to_thread
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=mock_response):
             result = await data_lake.get_raw_data("test-key")
-            
+
             assert result == sample_raw_data
 
     @pytest.mark.asyncio
@@ -306,20 +277,14 @@ class TestS3DataLake:
         """Test raw data retrieval when object not found."""
         await data_lake.initialize()
         
-        # Mock asyncio.get_event_loop and run_in_executor to raise ClientError
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            
-            # Create a mock ClientError with NoSuchKey
-            mock_error = ClientError(
-                error_response={'Error': {'Code': 'NoSuchKey'}},
-                operation_name='GetObject'
-            )
-            mock_loop.run_in_executor = AsyncMock(side_effect=mock_error)
-            
+        # Mock asyncio.to_thread to raise ClientError
+        mock_error = ClientError(
+            error_response={'Error': {'Code': 'NoSuchKey'}},
+            operation_name='GetObject'
+        )
+        with patch('asyncio.to_thread', new_callable=AsyncMock, side_effect=mock_error):
             result = await data_lake.get_raw_data("test-key")
-            
+
             assert result is None
 
     @pytest.mark.asyncio
@@ -327,12 +292,8 @@ class TestS3DataLake:
         """Test raw data retrieval with other error."""
         await data_lake.initialize()
         
-        # Mock asyncio.get_event_loop and run_in_executor to raise other error
-        with patch('asyncio.get_event_loop') as mock_get_loop:
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Network error"))
-            
+        # Mock asyncio.to_thread to raise other error
+        with patch('asyncio.to_thread', new_callable=AsyncMock, side_effect=Exception("Network error")):
             with pytest.raises(Exception, match="Network error"):
                 await data_lake.get_raw_data("test-key")
 
@@ -534,15 +495,13 @@ class TestS3DataLake:
         # Mock the S3 client methods
         mock_s3_client.client.put_object = MagicMock()
         
-        # Mock asyncio.wait_for and run_in_executor
+        # Mock asyncio.wait_for and to_thread
         with patch('asyncio.wait_for') as mock_wait_for, \
-             patch('asyncio.get_event_loop') as mock_get_loop:
-            
+             patch('asyncio.to_thread') as mock_to_thread:
+
             mock_wait_for.return_value = None
-            mock_loop = MagicMock()
-            mock_get_loop.return_value = mock_loop
-            mock_loop.run_in_executor.return_value = None
-            
+            mock_to_thread.return_value = None
+
             raw_data = {
                 "id": "123456789",
                 "content": "test post",

--- a/shit_tests/shit/utils/test_error_handling.py
+++ b/shit_tests/shit/utils/test_error_handling.py
@@ -528,14 +528,14 @@ class TestCircuitBreaker:
     async def test_should_attempt_reset_within_timeout(self):
         """Test should_attempt_reset within timeout period."""
         cb = CircuitBreaker(failure_threshold=1, recovery_timeout=1.0)
-        cb.last_failure_time = asyncio.get_event_loop().time()
+        cb.last_failure_time = asyncio.get_running_loop().time()
         assert cb._should_attempt_reset() is False
 
     @pytest.mark.asyncio
     async def test_should_attempt_reset_after_timeout(self):
         """Test should_attempt_reset after timeout period."""
         cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.1)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         cb.last_failure_time = loop.time() - 0.2  # 0.2 seconds ago
         assert cb._should_attempt_reset() is True
 

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -4,7 +4,6 @@ Business logic orchestrator for analyzing shitposts with enhanced context.
 """
 
 import asyncio
-import concurrent.futures
 from typing import Dict, List, Optional
 from datetime import datetime
 
@@ -525,13 +524,10 @@ class ShitpostAnalyzer:
             assets: List of ticker symbols from the prediction
         """
         try:
-            loop = asyncio.get_event_loop()
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                result = await loop.run_in_executor(
-                    executor,
-                    auto_backfill_prediction,
-                    prediction_id,
-                )
+            result = await asyncio.to_thread(
+                auto_backfill_prediction,
+                prediction_id,
+            )
 
             if result:
                 logger.info(


### PR DESCRIPTION
## Summary
- Replaced 8 instances of deprecated `asyncio.get_event_loop()` with modern alternatives (`asyncio.to_thread()` and `asyncio.get_running_loop()`) for Python 3.13 compatibility
- Removed unused `validate_prompt_version()` function and unused `Decimal` import
- Updated 14 test mocks to match new async patterns

## Test plan
- [x] All 130 affected tests pass (`test_s3_data_lake.py`, `test_error_handling.py`, `test_prompts.py`)
- [x] No remaining `get_event_loop` calls in source files (verified via grep)
- [x] No remaining `concurrent.futures` import in `shitpost_analyzer.py`
- [x] No remaining `validate_prompt_version` references in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Phase 01 of [codebase-health tech debt remediation](documentation/planning/tech_debt/codebase-health_2026-02-25/00_TECH_DEBT.md)