### PR TITLE
chore: bump 9 dependencies to current stable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead code cleanup** — Removed unused `validate_prompt_version()` function from prompt module and unused `Decimal` import from market data models
 
 ### Changed
+- **Dependency upgrades** — Bumped 9 dependencies to current stable versions: certifi 2026.1.4, urllib3 2.6.3, anthropic 0.83.0, boto3 1.42.0, SQLAlchemy 2.0.47, pytest 8.4.0, pytest-asyncio 0.25.0, pytest-cov 6.2.0, vcrpy 7.0.0. Updated pytest minversion to 8.4.
 - **Event worker CLI** — Extracted shared `run_worker_main()` helper, eliminating ~100 lines of duplicated boilerplate across 4 event consumer modules
 - **cards.py split** - Reorganized 1,930-line `shitty_ui/components/cards.py` into 8 focused modules under `shitty_ui/components/cards/` package. All existing imports work unchanged via `__init__.py` re-exports.
 - **Alerts panel refactor** - Split `create_alert_config_panel()` into 8 sub-component builder functions in new `alert_components.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,21 @@
 # Core dependencies
 pydantic>=2.0.0
-sqlalchemy[asyncio]>=2.0.0
+sqlalchemy[asyncio]>=2.0.47
 aiosqlite>=0.19.0
 asyncio-mqtt>=0.16.0
 
 # HTTP and web scraping
 aiohttp>=3.8.0
 requests>=2.31.0
+certifi>=2026.1.4
+urllib3>=2.6.3
 
 # AWS S3
-boto3>=1.26.0
+boto3>=1.42.0
 
 # LLM providers
 openai>=1.0.0
-anthropic>=0.40.0
+anthropic>=0.83.0
 
 # Database
 psycopg[binary]>=3.2.0  # For PostgreSQL async support
@@ -21,10 +23,10 @@ psycopg2-binary>=2.9.0  # For PostgreSQL sync support (dashboard)
 asyncpg>=0.29.0  # For PostgreSQL async support (dashboard)
 
 # Testing
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-cov>=4.0.0
-vcrpy>=6.0.0
+pytest>=8.4.0
+pytest-asyncio>=0.25.0
+pytest-cov>=6.2.0
+vcrpy>=7.0.0
 
 # Development and utilities
 python-dotenv>=1.0.0

--- a/shit_tests/pytest.ini
+++ b/shit_tests/pytest.ini
@@ -47,7 +47,7 @@ asyncio_mode = auto
 timeout = 300
 
 # Minimum version requirements
-minversion = 7.0
+minversion = 8.4
 
 # Filter warnings
 filterwarnings =

--- a/shit_tests/requirements-test.txt
+++ b/shit_tests/requirements-test.txt
@@ -1,9 +1,9 @@
 # Test-specific dependencies for Shitpost Alpha
 
 # Core testing framework
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-cov>=4.0.0
+pytest>=8.4.0
+pytest-asyncio>=0.25.0
+pytest-cov>=6.2.0
 pytest-mock>=3.10.0
 pytest-xdist>=3.0.0  # For parallel test execution
 
@@ -12,7 +12,7 @@ factory-boy>=3.2.0  # For test data generation
 faker>=18.0.0  # For generating fake data
 freezegun>=1.2.0  # For mocking datetime
 responses>=0.23.0  # For mocking HTTP requests
-vcrpy>=6.0.0  # For recording HTTP interactions
+vcrpy>=7.0.0  # For recording HTTP interactions
 
 # Database testing
 pytest-postgresql>=5.0.0  # For PostgreSQL testing (if needed)
@@ -45,7 +45,7 @@ pytest-datadir>=1.4.0  # For test data files
 pytest-tmpdir>=1.0.0  # For temporary directories
 
 # Async testing utilities
-pytest-asyncio>=0.21.0
+pytest-asyncio>=0.25.0
 asyncio-mqtt>=0.16.0
 
 # Mock external services


### PR DESCRIPTION
## Summary
- **Security**: certifi 2026.1.4, urllib3 2.6.3
- **SDK**: anthropic 0.83.0, boto3 1.42.0
- **Framework**: SQLAlchemy 2.0.47
- **Testing**: pytest 8.4.0, pytest-asyncio 0.25.0, pytest-cov 6.2.0, vcrpy 7.0.0
- Updated pytest minversion to 8.4 to match enforced floor

## Test plan
- [x] `pip install -r requirements.txt` — clean install, no conflicts
- [x] `pip check` — no broken dependencies
- [x] Full test suite: 2288 passed, 5 failed (pre-existing config test failures, not regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)