### PR TITLE
refactor: add service init factory and shared CLI arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead code cleanup** — Removed unused `validate_prompt_version()` function from prompt module and unused `Decimal` import from market data models
 
 ### Changed
+- **Service init factory** — Added `db_service()`, `s3_service()`, `db_and_s3_service()` async context managers in `shit/services.py`, replacing 4 instances of 12-line DB+S3 init boilerplate with guaranteed cleanup
+- **Shared CLI arguments** — Added `shit/cli/shared_args.py` with `add_standard_arguments()` and `validate_standard_args()`, deduplicating argument definitions across `shitpost_ai/cli.py` and `shitposts/cli.py`
 - **Signal query builder** — Extracted shared WHERE clause construction into `_build_signal_feed_filters()` helper, eliminating duplication between `get_signal_feed()` and `get_signal_feed_count()`
 - **Dependency upgrades** — Bumped 9 dependencies to current stable versions: certifi 2026.1.4, urllib3 2.6.3, anthropic 0.83.0, boto3 1.42.0, SQLAlchemy 2.0.47, pytest 8.4.0, pytest-asyncio 0.25.0, pytest-cov 6.2.0, vcrpy 7.0.0. Updated pytest minversion to 8.4.
 - **Event worker CLI** — Extracted shared `run_worker_main()` helper, eliminating ~100 lines of duplicated boilerplate across 4 event consumer modules

--- a/shit/__init__.py
+++ b/shit/__init__.py
@@ -7,3 +7,11 @@ including database operations, S3 integration, LLM processing, and logging.
 
 __version__ = "1.0.0"
 __author__ = "Shitpost Alpha Team"
+
+from shit.services import db_service, s3_service, db_and_s3_service
+
+__all__ = [
+    "db_service",
+    "s3_service",
+    "db_and_s3_service",
+]

--- a/shit/cli/__init__.py
+++ b/shit/cli/__init__.py
@@ -1,0 +1,13 @@
+"""
+Shared CLI utilities for Shitpost-Alpha.
+
+Provides reusable argument definitions and validation logic used by
+multiple CLI modules (shitpost_ai, shitposts, shitvault).
+"""
+
+from .shared_args import add_standard_arguments, validate_standard_args
+
+__all__ = [
+    "add_standard_arguments",
+    "validate_standard_args",
+]

--- a/shit/cli/shared_args.py
+++ b/shit/cli/shared_args.py
@@ -1,0 +1,85 @@
+"""
+Shared CLI Arguments
+
+Provides reusable argparse argument definitions shared across CLI modules.
+Each module can add these standard arguments to its own parser, then layer
+on module-specific extras.
+
+Usage::
+
+    import argparse
+    from shit.cli.shared_args import add_standard_arguments, validate_standard_args
+
+    parser = argparse.ArgumentParser(description="My CLI")
+    add_standard_arguments(parser)
+    # Add module-specific args here...
+
+    args = parser.parse_args()
+    validate_standard_args(args)
+"""
+
+import argparse
+
+
+def add_standard_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the standard set of CLI arguments to a parser.
+
+    Adds the following arguments:
+        --mode: choices=["incremental", "backfill", "range"], default="incremental"
+        --from / dest=start_date: Start date for range mode (YYYY-MM-DD)
+        --to / dest=end_date: End date for range mode (YYYY-MM-DD)
+        --limit: Maximum number of records to process (int)
+        --dry-run: Show what would be done without making changes
+        --verbose / -v: Enable verbose logging
+
+    Args:
+        parser: The ArgumentParser (or subparser) to add arguments to.
+    """
+    parser.add_argument(
+        "--mode",
+        choices=["incremental", "backfill", "range"],
+        default="incremental",
+        help="Processing mode (default: incremental)",
+    )
+    parser.add_argument(
+        "--from",
+        dest="start_date",
+        help="Start date for range mode (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--to",
+        dest="end_date",
+        help="End date for range mode (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of records to process (optional)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+
+def validate_standard_args(args: argparse.Namespace) -> None:
+    """Validate standard CLI arguments.
+
+    Checks that ``--from`` is provided when ``--mode range`` is selected.
+    The ``--to`` date is always optional (defaults to today).
+
+    Args:
+        args: Parsed command line arguments.
+
+    Raises:
+        SystemExit: If ``--mode range`` is used without ``--from``.
+    """
+    if args.mode == "range" and not args.start_date:
+        raise SystemExit("--from date is required for range mode")

--- a/shit/services.py
+++ b/shit/services.py
@@ -1,0 +1,81 @@
+"""
+Service Initialization Factory
+
+Async context managers for initializing and cleaning up database and S3
+services from centralized settings. Replaces the 12-line boilerplate
+that was copy-pasted across CLI and event consumer modules.
+
+Usage::
+
+    from shit.services import db_service, s3_service, db_and_s3_service
+
+    async with db_service() as db_client:
+        async with db_client.get_session() as session:
+            ...
+
+    async with db_and_s3_service() as (db_client, s3_data_lake):
+        ...
+"""
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Tuple
+
+from shit.config.shitpost_settings import settings
+from shit.db import DatabaseConfig, DatabaseClient
+from shit.s3 import S3Config, S3DataLake
+
+
+@asynccontextmanager
+async def db_service() -> AsyncGenerator[DatabaseClient, None]:
+    """Initialize and yield a DatabaseClient, cleaning up on exit.
+
+    Reads connection settings from the global ``settings`` singleton.
+
+    Yields:
+        Initialized DatabaseClient ready for use.
+    """
+    db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
+    db_client = DatabaseClient(db_config)
+    await db_client.initialize()
+    try:
+        yield db_client
+    finally:
+        await db_client.cleanup()
+
+
+@asynccontextmanager
+async def s3_service() -> AsyncGenerator[S3DataLake, None]:
+    """Initialize and yield an S3DataLake, cleaning up on exit.
+
+    Reads S3 settings from the global ``settings`` singleton.
+
+    Yields:
+        Initialized S3DataLake ready for use.
+    """
+    s3_config = S3Config(
+        bucket_name=settings.S3_BUCKET_NAME,
+        access_key_id=settings.AWS_ACCESS_KEY_ID,
+        secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        region=settings.AWS_REGION,
+    )
+    s3_data_lake = S3DataLake(s3_config)
+    await s3_data_lake.initialize()
+    try:
+        yield s3_data_lake
+    finally:
+        await s3_data_lake.cleanup()
+
+
+@asynccontextmanager
+async def db_and_s3_service() -> AsyncGenerator[Tuple[DatabaseClient, S3DataLake], None]:
+    """Initialize and yield both DatabaseClient and S3DataLake.
+
+    Both are cleaned up when the context exits, even if an error occurs.
+    Database cleanup runs first, then S3 cleanup.
+
+    Yields:
+        Tuple of (DatabaseClient, S3DataLake), both initialized.
+    """
+    async with db_service() as db_client:
+        async with s3_service() as s3_data_lake:
+            yield db_client, s3_data_lake

--- a/shit_tests/events/consumers/test_s3_processor.py
+++ b/shit_tests/events/consumers/test_s3_processor.py
@@ -83,9 +83,7 @@ class TestS3ProcessorWorker:
         What it verifies: The inner _process() coroutine iterates over
         each s3_key and calls s3_data_lake.get_raw_data + processor._process_single_s3_data.
         Mocking:
-          - settings (DATABASE_URL, S3 config)
-          - DatabaseClient (initialize, get_session, cleanup)
-          - S3DataLake (initialize, get_raw_data)
+          - db_and_s3_service (yields mock db_client + s3_data_lake)
           - S3Processor._process_single_s3_data
         Assertions:
           - get_raw_data called 3 times (once per key)
@@ -98,32 +96,25 @@ class TestS3ProcessorWorker:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         mock_db_client = AsyncMock()
-        mock_db_client.initialize = AsyncMock()
         mock_db_client.get_session = MagicMock(return_value=mock_session)
-        mock_db_client.cleanup = AsyncMock()
 
         mock_s3 = AsyncMock()
-        mock_s3.initialize = AsyncMock()
         mock_s3.get_raw_data = AsyncMock(return_value=mock_s3_data)
 
         mock_processor = AsyncMock()
         mock_processor._process_single_s3_data = AsyncMock()
 
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def fake_db_and_s3():
+            yield mock_db_client, mock_s3
+
         with (
-            patch("shitvault.event_consumer.settings") as mock_settings,
-            patch("shit.db.DatabaseConfig"),
-            patch("shit.db.DatabaseClient", return_value=mock_db_client),
-            patch("shit.s3.S3Config"),
-            patch("shit.s3.S3DataLake", return_value=mock_s3),
+            patch("shit.services.db_and_s3_service", fake_db_and_s3),
             patch("shitvault.s3_processor.S3Processor", return_value=mock_processor),
             patch("shit.events.producer.emit_event"),
         ):
-            mock_settings.DATABASE_URL = "sqlite:///test.db"
-            mock_settings.S3_BUCKET_NAME = "test-bucket"
-            mock_settings.AWS_ACCESS_KEY_ID = "test"
-            mock_settings.AWS_SECRET_ACCESS_KEY = "test"
-            mock_settings.AWS_REGION = "us-east-1"
-
             worker = S3ProcessorWorker.__new__(S3ProcessorWorker)
             result = worker.process_event(
                 "posts_harvested",
@@ -143,7 +134,7 @@ class TestS3ProcessorWorker:
         What it verifies: After processing S3 keys, if stats["signal_ids"] is non-empty,
         emit_event is called with EventType.SIGNALS_STORED and the correct payload.
         Mocking:
-          - Same as test_process_event_iterates_all_s3_keys
+          - db_and_s3_service (yields mock db_client + s3_data_lake)
           - Mock _process_single_s3_data to populate stats["signal_ids"]
           - emit_event to capture the call
         Assertions:
@@ -155,12 +146,9 @@ class TestS3ProcessorWorker:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         mock_db_client = AsyncMock()
-        mock_db_client.initialize = AsyncMock()
         mock_db_client.get_session = MagicMock(return_value=mock_session)
-        mock_db_client.cleanup = AsyncMock()
 
         mock_s3 = AsyncMock()
-        mock_s3.initialize = AsyncMock()
         mock_s3.get_raw_data = AsyncMock(return_value={"id": "p1"})
 
         async def fake_process(s3_data, stats, dry_run):
@@ -170,21 +158,17 @@ class TestS3ProcessorWorker:
         mock_processor = AsyncMock()
         mock_processor._process_single_s3_data = AsyncMock(side_effect=fake_process)
 
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def fake_db_and_s3():
+            yield mock_db_client, mock_s3
+
         with (
-            patch("shitvault.event_consumer.settings") as mock_settings,
-            patch("shit.db.DatabaseConfig"),
-            patch("shit.db.DatabaseClient", return_value=mock_db_client),
-            patch("shit.s3.S3Config"),
-            patch("shit.s3.S3DataLake", return_value=mock_s3),
+            patch("shit.services.db_and_s3_service", fake_db_and_s3),
             patch("shitvault.s3_processor.S3Processor", return_value=mock_processor),
             patch("shit.events.producer.emit_event") as mock_emit,
         ):
-            mock_settings.DATABASE_URL = "sqlite:///test.db"
-            mock_settings.S3_BUCKET_NAME = "test-bucket"
-            mock_settings.AWS_ACCESS_KEY_ID = "test"
-            mock_settings.AWS_SECRET_ACCESS_KEY = "test"
-            mock_settings.AWS_REGION = "us-east-1"
-
             worker = S3ProcessorWorker.__new__(S3ProcessorWorker)
             worker.process_event(
                 "posts_harvested",
@@ -205,7 +189,7 @@ class TestS3ProcessorWorker:
         What it verifies: When S3 processing produces no signal_ids (e.g., all
         posts were duplicates/skipped), emit_event is NOT called.
         Mocking:
-          - Same infrastructure mocks
+          - db_and_s3_service (yields mock db_client + s3_data_lake)
           - _process_single_s3_data does NOT append to signal_ids
         Assertions:
           - emit_event was NOT called
@@ -215,32 +199,25 @@ class TestS3ProcessorWorker:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         mock_db_client = AsyncMock()
-        mock_db_client.initialize = AsyncMock()
         mock_db_client.get_session = MagicMock(return_value=mock_session)
-        mock_db_client.cleanup = AsyncMock()
 
         mock_s3 = AsyncMock()
-        mock_s3.initialize = AsyncMock()
         mock_s3.get_raw_data = AsyncMock(return_value={"id": "p1"})
 
         mock_processor = AsyncMock()
         mock_processor._process_single_s3_data = AsyncMock()  # Does nothing to stats
 
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def fake_db_and_s3():
+            yield mock_db_client, mock_s3
+
         with (
-            patch("shitvault.event_consumer.settings") as mock_settings,
-            patch("shit.db.DatabaseConfig"),
-            patch("shit.db.DatabaseClient", return_value=mock_db_client),
-            patch("shit.s3.S3Config"),
-            patch("shit.s3.S3DataLake", return_value=mock_s3),
+            patch("shit.services.db_and_s3_service", fake_db_and_s3),
             patch("shitvault.s3_processor.S3Processor", return_value=mock_processor),
             patch("shit.events.producer.emit_event") as mock_emit,
         ):
-            mock_settings.DATABASE_URL = "sqlite:///test.db"
-            mock_settings.S3_BUCKET_NAME = "test-bucket"
-            mock_settings.AWS_ACCESS_KEY_ID = "test"
-            mock_settings.AWS_SECRET_ACCESS_KEY = "test"
-            mock_settings.AWS_REGION = "us-east-1"
-
             worker = S3ProcessorWorker.__new__(S3ProcessorWorker)
             worker.process_event(
                 "posts_harvested",
@@ -249,16 +226,16 @@ class TestS3ProcessorWorker:
 
             mock_emit.assert_not_called()
 
-    def test_db_client_cleanup_called_on_success_and_failure(self):
-        """Verify db_client.cleanup() is always called via the finally block.
+    def test_exception_propagates_from_process_event(self):
+        """Verify exceptions from S3 processing propagate to the caller.
 
-        What it verifies: The try/finally in _process() ensures db_client.cleanup()
-        is called even when processing raises an exception.
+        What it verifies: When s3_data_lake.get_raw_data raises an exception
+        inside the db_and_s3_service context manager, the error propagates up
+        (cleanup is handled automatically by the context manager).
         Mocking:
-          - Same infrastructure mocks
+          - db_and_s3_service (yields mock db_client + s3_data_lake)
           - s3_data_lake.get_raw_data raises an exception
         Assertions:
-          - db_client.cleanup was called (awaited) exactly once
           - The exception propagates up
         """
         mock_session = AsyncMock()
@@ -266,29 +243,22 @@ class TestS3ProcessorWorker:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         mock_db_client = AsyncMock()
-        mock_db_client.initialize = AsyncMock()
         mock_db_client.get_session = MagicMock(return_value=mock_session)
-        mock_db_client.cleanup = AsyncMock()
 
         mock_s3 = AsyncMock()
-        mock_s3.initialize = AsyncMock()
         mock_s3.get_raw_data = AsyncMock(side_effect=RuntimeError("S3 exploded"))
 
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def fake_db_and_s3():
+            yield mock_db_client, mock_s3
+
         with (
-            patch("shitvault.event_consumer.settings") as mock_settings,
-            patch("shit.db.DatabaseConfig"),
-            patch("shit.db.DatabaseClient", return_value=mock_db_client),
-            patch("shit.s3.S3Config"),
-            patch("shit.s3.S3DataLake", return_value=mock_s3),
+            patch("shit.services.db_and_s3_service", fake_db_and_s3),
             patch("shitvault.s3_processor.S3Processor"),
             patch("shit.events.producer.emit_event"),
         ):
-            mock_settings.DATABASE_URL = "sqlite:///test.db"
-            mock_settings.S3_BUCKET_NAME = "test-bucket"
-            mock_settings.AWS_ACCESS_KEY_ID = "test"
-            mock_settings.AWS_SECRET_ACCESS_KEY = "test"
-            mock_settings.AWS_REGION = "us-east-1"
-
             worker = S3ProcessorWorker.__new__(S3ProcessorWorker)
 
             with pytest.raises(RuntimeError, match="S3 exploded"):
@@ -296,5 +266,3 @@ class TestS3ProcessorWorker:
                     "posts_harvested",
                     {"s3_keys": ["k1.json"], "source": "truth_social"},
                 )
-
-            mock_db_client.cleanup.assert_awaited_once()

--- a/shit_tests/shitvault/test_shitvault_cli.py
+++ b/shit_tests/shitvault/test_shitvault_cli.py
@@ -211,44 +211,37 @@ class TestCLICommands:
     @pytest.mark.asyncio
     async def test_process_s3_data_success(self, mock_args):
         """Test successful S3 data processing."""
+        mock_db_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
+
+        mock_s3 = AsyncMock()
+
+        mock_processor = AsyncMock()
+        mock_processor.process_s3_to_database.return_value = {
+            'total_processed': 10,
+            'successful': 8,
+            'failed': 2
+        }
+
+        async def fake_db_and_s3(*a, **kw):
+            yield mock_db_client, mock_s3
+
+        from contextlib import asynccontextmanager
+        mock_cm = asynccontextmanager(fake_db_and_s3)
+
         with patch('shitvault.cli.print_database_start'), \
              patch('shitvault.cli.print_database_complete'), \
-             patch('shitvault.cli.settings') as mock_settings, \
-             patch('shitvault.cli.DatabaseConfig'), \
-             patch('shitvault.cli.DatabaseClient') as mock_db_client_class, \
-             patch('shitvault.cli.S3Config'), \
-             patch('shitvault.cli.S3DataLake') as mock_s3_class, \
+             patch('shitvault.cli.db_and_s3_service', mock_cm), \
              patch('shitvault.cli.DatabaseOperations'), \
-             patch('shitvault.cli.S3Processor') as mock_processor_class:
-            
-            # Setup mocks
-            mock_db_client = AsyncMock()
-            mock_session = AsyncMock()
-            # Make get_session return a mock context manager
-            mock_session_cm = MagicMock()
-            mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_cm.__aexit__ = AsyncMock(return_value=False)
-            # get_session is a regular method that returns an async context manager
-            mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
-            mock_db_client_class.return_value = mock_db_client
-            
-            mock_s3 = AsyncMock()
-            mock_s3_class.return_value = mock_s3
-            
-            mock_processor = AsyncMock()
-            mock_processor.process_s3_to_database.return_value = {
-                'total_processed': 10,
-                'successful': 8,
-                'failed': 2
-            }
-            mock_processor_class.return_value = mock_processor
-            
+             patch('shitvault.cli.S3Processor', return_value=mock_processor):
+
             await process_s3_data(mock_args)
-            
-            mock_db_client.initialize.assert_called_once()
-            mock_s3.initialize.assert_called_once()
+
             mock_processor.process_s3_to_database.assert_called_once()
-            mock_db_client.cleanup.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_process_s3_data_with_dates(self, mock_args):
@@ -256,36 +249,33 @@ class TestCLICommands:
         mock_args.start_date = '2024-01-01'
         mock_args.end_date = '2024-01-31'
         mock_args.mode = 'range'
-        
+
+        mock_db_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
+
+        mock_s3 = AsyncMock()
+
+        mock_processor = AsyncMock()
+        mock_processor.process_s3_to_database.return_value = {'total_processed': 5}
+
+        async def fake_db_and_s3(*a, **kw):
+            yield mock_db_client, mock_s3
+
+        from contextlib import asynccontextmanager
+        mock_cm = asynccontextmanager(fake_db_and_s3)
+
         with patch('shitvault.cli.print_database_start'), \
              patch('shitvault.cli.print_database_complete'), \
-             patch('shitvault.cli.settings'), \
-             patch('shitvault.cli.DatabaseConfig'), \
-             patch('shitvault.cli.DatabaseClient') as mock_db_client_class, \
-             patch('shitvault.cli.S3Config'), \
-             patch('shitvault.cli.S3DataLake') as mock_s3_class, \
+             patch('shitvault.cli.db_and_s3_service', mock_cm), \
              patch('shitvault.cli.DatabaseOperations'), \
-             patch('shitvault.cli.S3Processor') as mock_processor_class:
-            
-            mock_db_client = AsyncMock()
-            mock_session = AsyncMock()
-            # Make get_session return a mock context manager
-            mock_session_cm = MagicMock()
-            mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_cm.__aexit__ = AsyncMock(return_value=False)
-            # get_session is a regular method that returns an async context manager
-            mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
-            mock_db_client_class.return_value = mock_db_client
-            
-            mock_s3 = AsyncMock()
-            mock_s3_class.return_value = mock_s3
-            
-            mock_processor = AsyncMock()
-            mock_processor.process_s3_to_database.return_value = {'total_processed': 5}
-            mock_processor_class.return_value = mock_processor
-            
+             patch('shitvault.cli.S3Processor', return_value=mock_processor):
+
             await process_s3_data(mock_args)
-            
+
             # Verify incremental parameter is False for range mode
             call_kwargs = mock_processor.process_s3_to_database.call_args[1]
             assert call_kwargs['incremental'] is False
@@ -293,21 +283,17 @@ class TestCLICommands:
     @pytest.mark.asyncio
     async def test_process_s3_data_error(self, mock_args):
         """Test error handling in process_s3_data."""
+        async def failing_db_and_s3(*a, **kw):
+            raise Exception("Database error")
+            yield  # noqa: unreachable — makes this an async generator
+
+        from contextlib import asynccontextmanager
+        mock_cm = asynccontextmanager(failing_db_and_s3)
+
         with patch('shitvault.cli.print_database_start'), \
              patch('shitvault.cli.print_database_error'), \
-             patch('shitvault.cli.settings'), \
-             patch('shitvault.cli.DatabaseConfig'), \
-             patch('shitvault.cli.DatabaseClient') as mock_db_client_class, \
-             patch('shitvault.cli.S3Config'), \
-             patch('shitvault.cli.S3DataLake') as mock_s3_class:
-            
-            mock_db_client = AsyncMock()
-            mock_db_client.initialize.side_effect = Exception("Database error")
-            mock_db_client_class.return_value = mock_db_client
-            
-            mock_s3 = AsyncMock()
-            mock_s3_class.return_value = mock_s3
-            
+             patch('shitvault.cli.db_and_s3_service', mock_cm):
+
             with pytest.raises(Exception, match="Database error"):
                 await process_s3_data(mock_args)
 
@@ -316,80 +302,72 @@ class TestCLICommands:
         """Test getting database statistics."""
         args = MagicMock()
         args.command = 'stats'
-        
+
+        mock_db_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
+
+        mock_stats = AsyncMock()
+        mock_stats.get_database_stats.return_value = {
+            'total_shitposts': 100,
+            'total_analyses': 75
+        }
+
+        async def fake_db(*a, **kw):
+            yield mock_db_client
+
+        from contextlib import asynccontextmanager
+        mock_cm = asynccontextmanager(fake_db)
+
         with patch('shitvault.cli.print_database_start'), \
              patch('shitvault.cli.print_database_complete'), \
-             patch('shitvault.cli.settings'), \
-             patch('shitvault.cli.DatabaseConfig'), \
-             patch('shitvault.cli.DatabaseClient') as mock_db_client_class, \
+             patch('shitvault.cli.db_service', mock_cm), \
              patch('shitvault.cli.DatabaseOperations'), \
-             patch('shitvault.cli.Statistics') as mock_stats_class:
-            
-            mock_db_client = AsyncMock()
-            mock_session = AsyncMock()
-            # Make get_session return a mock context manager
-            mock_session_cm = MagicMock()
-            mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_cm.__aexit__ = AsyncMock(return_value=False)
-            # get_session is a regular method that returns an async context manager
-            mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
-            mock_db_client_class.return_value = mock_db_client
-            
-            mock_stats = AsyncMock()
-            mock_stats.get_database_stats.return_value = {
-                'total_shitposts': 100,
-                'total_analyses': 75
-            }
-            mock_stats_class.return_value = mock_stats
-            
+             patch('shitvault.cli.Statistics', return_value=mock_stats):
+
             await get_database_stats(args)
-            
-            mock_db_client.initialize.assert_called_once()
+
             mock_stats.get_database_stats.assert_called_once()
-            mock_db_client.cleanup.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_processing_stats_success(self):
         """Test getting processing statistics."""
         args = MagicMock()
         args.command = 'processing-stats'
-        
+
+        mock_db_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
+
+        mock_s3 = AsyncMock()
+
+        mock_processor = AsyncMock()
+        mock_processor.get_s3_processing_stats.return_value = {
+            's3_stats': {},
+            'db_stats': {}
+        }
+
+        async def fake_db_and_s3(*a, **kw):
+            yield mock_db_client, mock_s3
+
+        from contextlib import asynccontextmanager
+        mock_cm = asynccontextmanager(fake_db_and_s3)
+
         with patch('shitvault.cli.print_database_start'), \
              patch('shitvault.cli.print_database_complete'), \
-             patch('shitvault.cli.settings'), \
-             patch('shitvault.cli.DatabaseConfig'), \
-             patch('shitvault.cli.DatabaseClient') as mock_db_client_class, \
-             patch('shitvault.cli.S3Config'), \
-             patch('shitvault.cli.S3DataLake') as mock_s3_class, \
+             patch('shitvault.cli.db_and_s3_service', mock_cm), \
              patch('shitvault.cli.DatabaseOperations'), \
-             patch('shitvault.cli.S3Processor') as mock_processor_class:
-            
-            mock_db_client = AsyncMock()
-            mock_session = AsyncMock()
-            # Make get_session return a mock context manager
-            mock_session_cm = MagicMock()
-            mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_cm.__aexit__ = AsyncMock(return_value=False)
-            # get_session is a regular method that returns an async context manager
-            mock_db_client.get_session = MagicMock(return_value=mock_session_cm)
-            mock_db_client_class.return_value = mock_db_client
-            
-            mock_s3 = AsyncMock()
-            mock_s3_class.return_value = mock_s3
-            
-            mock_processor = AsyncMock()
-            mock_processor.get_s3_processing_stats.return_value = {
-                's3_stats': {},
-                'db_stats': {}
-            }
-            mock_processor_class.return_value = mock_processor
-            
+             patch('shitvault.cli.S3Processor', return_value=mock_processor):
+
             await get_processing_stats(args)
-            
-            mock_db_client.initialize.assert_called_once()
-            mock_s3.initialize.assert_called_once()
+
             mock_processor.get_s3_processing_stats.assert_called_once()
-            mock_db_client.cleanup.assert_called_once()
 
 
 class TestMainFunction:

--- a/shitpost_ai/cli.py
+++ b/shitpost_ai/cli.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 from typing import Optional
 
+from shit.cli.shared_args import add_standard_arguments, validate_standard_args
 from shit.logging import (
     setup_analyzer_logging as setup_centralized_analyzer_logging,
     print_success,
@@ -31,47 +32,15 @@ def create_analyzer_parser(description: str, epilog: str = None) -> argparse.Arg
         epilog=epilog
     )
     
-    # Analysis mode
+    # Standard arguments shared across all CLIs
+    add_standard_arguments(parser)
+
+    # Analyzer-specific arguments
     parser.add_argument(
-        "--mode", 
-        choices=["incremental", "backfill", "range"], 
-        default="incremental", 
-        help="Analysis mode (default: incremental)"
-    )
-    
-    # Date range options
-    parser.add_argument(
-        "--from", 
-        dest="start_date", 
-        help="Start date for range mode (YYYY-MM-DD)"
-    )
-    parser.add_argument(
-        "--to", 
-        dest="end_date", 
-        help="End date for range mode (YYYY-MM-DD)"
-    )
-    
-    # Limits and options
-    parser.add_argument(
-        "--limit", 
-        type=int, 
-        help="Maximum number of posts to analyze (optional)"
-    )
-    parser.add_argument(
-        "--batch-size", 
-        type=int, 
+        "--batch-size",
+        type=int,
         default=5,
         help="Number of posts to analyze per batch (default: 5)"
-    )
-    parser.add_argument(
-        "--dry-run", 
-        action="store_true", 
-        help="Show what would be analyzed without storing results to database"
-    )
-    parser.add_argument(
-        "--verbose", "-v", 
-        action="store_true", 
-        help="Enable verbose logging"
     )
     
     return parser
@@ -86,10 +55,7 @@ def validate_analyzer_args(args) -> None:
     Raises:
         SystemExit: If arguments are invalid
     """
-    if args.mode == "range" and not args.start_date:
-        raise SystemExit("--from date is required for range mode")
-    
-    # Note: --to date is optional for range mode (defaults to today)
+    validate_standard_args(args)
 
 
 def setup_analyzer_logging(verbose: bool = False) -> None:

--- a/shitposts/cli.py
+++ b/shitposts/cli.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 from typing import Optional
 
+from shit.cli.shared_args import add_standard_arguments, validate_standard_args
 from shit.logging import (
     setup_harvester_logging as setup_centralized_harvester_logging,
     print_success,
@@ -31,42 +32,10 @@ def create_harvester_parser(description: str, epilog: str = None) -> argparse.Ar
         epilog=epilog
     )
     
-    # Harvesting mode
-    parser.add_argument(
-        "--mode", 
-        choices=["incremental", "backfill", "range"], 
-        default="incremental", 
-        help="Harvesting mode (default: incremental)"
-    )
-    
-    # Date range options
-    parser.add_argument(
-        "--from", 
-        dest="start_date", 
-        help="Start date for range mode (YYYY-MM-DD)"
-    )
-    parser.add_argument(
-        "--to", 
-        dest="end_date", 
-        help="End date for range mode (YYYY-MM-DD)"
-    )
-    
-    # Limits and options
-    parser.add_argument(
-        "--limit", 
-        type=int, 
-        help="Maximum number of posts to harvest (optional)"
-    )
-    parser.add_argument(
-        "--dry-run", 
-        action="store_true", 
-        help="Show what would be harvested without storing data to S3"
-    )
-    parser.add_argument(
-        "--verbose", "-v", 
-        action="store_true", 
-        help="Enable verbose logging"
-    )
+    # Standard arguments shared across all CLIs
+    add_standard_arguments(parser)
+
+    # Harvester-specific arguments
     parser.add_argument(
         "--max-id",
         type=str,
@@ -91,10 +60,7 @@ def validate_harvester_args(args) -> None:
     Raises:
         SystemExit: If arguments are invalid
     """
-    if args.mode == "range" and not args.start_date:
-        raise SystemExit("--from date is required for range mode")
-    
-    # Note: --to date is optional for range mode (defaults to today)
+    validate_standard_args(args)
 
 
 def setup_harvester_logging(verbose: bool = False) -> None:

--- a/shitvault/cli.py
+++ b/shitvault/cli.py
@@ -9,10 +9,9 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-from shit.config.shitpost_settings import settings
 from shit.utils.error_handling import handle_exceptions
-from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
-from shit.s3 import S3Config, S3DataLake
+from shit.db import DatabaseOperations
+from shit.services import db_service, db_and_s3_service
 from shit.logging import (
     setup_database_logging as setup_centralized_database_logging,
     get_service_logger,
@@ -143,49 +142,34 @@ async def process_s3_data(args):
             
         logger.info(f"Processing mode: {args.mode}")
         
-        # Initialize database and S3 components
-        db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
-        db_client = DatabaseClient(db_config)
-        await db_client.initialize()
-        
-        s3_config = S3Config(
-            bucket_name=settings.S3_BUCKET_NAME,
-            access_key_id=settings.AWS_ACCESS_KEY_ID,
-            secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            region=settings.AWS_REGION
-        )
-        s3_data_lake = S3DataLake(s3_config)
-        await s3_data_lake.initialize()
-        
-        logger.info("✅ Database and S3 connections initialized successfully")
-        logger.info("")
-        
-        # Create operations with proper session management
-        async with db_client.get_session() as session:
-            db_ops = DatabaseOperations(session)
-            s3_processor = S3Processor(db_ops, s3_data_lake)
-            
-            # Process S3 data
-            stats = await s3_processor.process_s3_to_database(
-                start_date=start_date,
-                end_date=end_date,
-                limit=args.limit,
-                incremental=(args.mode == 'incremental'),
-                dry_run=args.dry_run
-            )
-            
-            print_database_complete(stats)
+        # Initialize database and S3 using factory context managers
+        async with db_and_s3_service() as (db_client, s3_data_lake):
+            logger.info("✅ Database and S3 connections initialized successfully")
             logger.info("")
-            logger.info("═══════════════════════════════════════════════════════════")
-            logger.info("PROCESSING COMPLETED")
-            logger.info("═══════════════════════════════════════════════════════════")
-            logger.info(f"Total processed: {stats.get('total_processed', 0)}")
-            logger.info(f"Successful: {stats.get('successful', 0)}")
-            logger.info(f"Failed: {stats.get('failed', 0)}")
-            logger.info(f"Skipped: {stats.get('skipped', 0)}")
-        
-        # Cleanup
-        await db_client.cleanup()
+
+            # Create operations with proper session management
+            async with db_client.get_session() as session:
+                db_ops = DatabaseOperations(session)
+                s3_processor = S3Processor(db_ops, s3_data_lake)
+
+                # Process S3 data
+                stats = await s3_processor.process_s3_to_database(
+                    start_date=start_date,
+                    end_date=end_date,
+                    limit=args.limit,
+                    incremental=(args.mode == 'incremental'),
+                    dry_run=args.dry_run
+                )
+
+                print_database_complete(stats)
+                logger.info("")
+                logger.info("═══════════════════════════════════════════════════════════")
+                logger.info("PROCESSING COMPLETED")
+                logger.info("═══════════════════════════════════════════════════════════")
+                logger.info(f"Total processed: {stats.get('total_processed', 0)}")
+                logger.info(f"Successful: {stats.get('successful', 0)}")
+                logger.info(f"Failed: {stats.get('failed', 0)}")
+                logger.info(f"Skipped: {stats.get('skipped', 0)}")
         
     except Exception as e:
         print_database_error(e)
@@ -196,24 +180,18 @@ async def get_database_stats(args):
     """Get database statistics using modular architecture."""
     try:
         print_database_start(args)
-        
-        # Initialize database
-        db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
-        db_client = DatabaseClient(db_config)
-        await db_client.initialize()
-        
-        # Create operations with proper session management
-        async with db_client.get_session() as session:
-            db_ops = DatabaseOperations(session)
-            stats_ops = Statistics(db_ops)
-            
-            # Get stats
-            stats = await stats_ops.get_database_stats()
-            print_database_complete(stats)
-        
-        # Cleanup
-        await db_client.cleanup()
-        
+
+        # Initialize database using factory context manager
+        async with db_service() as db_client:
+            # Create operations with proper session management
+            async with db_client.get_session() as session:
+                db_ops = DatabaseOperations(session)
+                stats_ops = Statistics(db_ops)
+
+                # Get stats
+                stats = await stats_ops.get_database_stats()
+                print_database_complete(stats)
+
     except Exception as e:
         print_database_error(e)
         raise
@@ -223,33 +201,18 @@ async def get_processing_stats(args):
     """Get processing statistics using modular architecture."""
     try:
         print_database_start(args)
-        
-        # Initialize database and S3 components
-        db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
-        db_client = DatabaseClient(db_config)
-        await db_client.initialize()
-        
-        s3_config = S3Config(
-            bucket_name=settings.S3_BUCKET_NAME,
-            access_key_id=settings.AWS_ACCESS_KEY_ID,
-            secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            region=settings.AWS_REGION
-        )
-        s3_data_lake = S3DataLake(s3_config)
-        await s3_data_lake.initialize()
-        
-        # Create operations with proper session management
-        async with db_client.get_session() as session:
-            db_ops = DatabaseOperations(session)
-            s3_processor = S3Processor(db_ops, s3_data_lake)
-            
-            # Get processing stats
-            stats = await s3_processor.get_s3_processing_stats()
-            print_database_complete(stats)
-        
-        # Cleanup
-        await db_client.cleanup()
-        
+
+        # Initialize database and S3 using factory context managers
+        async with db_and_s3_service() as (db_client, s3_data_lake):
+            # Create operations with proper session management
+            async with db_client.get_session() as session:
+                db_ops = DatabaseOperations(session)
+                s3_processor = S3Processor(db_ops, s3_data_lake)
+
+                # Get processing stats
+                stats = await s3_processor.get_s3_processing_stats()
+                print_database_complete(stats)
+
     except Exception as e:
         print_database_error(e)
         raise

--- a/shitvault/event_consumer.py
+++ b/shitvault/event_consumer.py
@@ -7,7 +7,6 @@ Runs as a standalone worker via ``python -m shitvault.event_consumer --once``.
 
 import sys
 
-from shit.config.shitpost_settings import settings
 from shit.events.event_types import EventType, ConsumerGroup
 from shit.events.worker import EventWorker, run_worker_main
 from shit.logging import get_service_logger
@@ -34,8 +33,8 @@ class S3ProcessorWorker(EventWorker):
             Processing statistics dict.
         """
         import asyncio
-        from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
-        from shit.s3 import S3Config, S3DataLake
+        from shit.db import DatabaseOperations
+        from shit.services import db_and_s3_service
         from shitvault.s3_processor import S3Processor
 
         s3_keys = payload.get("s3_keys", [])
@@ -46,20 +45,7 @@ class S3ProcessorWorker(EventWorker):
             return {"total_processed": 0, "successful": 0}
 
         async def _process():
-            db_config = DatabaseConfig(database_url=settings.DATABASE_URL)
-            db_client = DatabaseClient(db_config)
-            await db_client.initialize()
-
-            s3_config = S3Config(
-                bucket_name=settings.S3_BUCKET_NAME,
-                access_key_id=settings.AWS_ACCESS_KEY_ID,
-                secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-                region=settings.AWS_REGION,
-            )
-            s3_data_lake = S3DataLake(s3_config)
-            await s3_data_lake.initialize()
-
-            try:
+            async with db_and_s3_service() as (db_client, s3_data_lake):
                 async with db_client.get_session() as session:
                     db_ops = DatabaseOperations(session)
                     processor = S3Processor(db_ops, s3_data_lake, source=source)
@@ -96,8 +82,6 @@ class S3ProcessorWorker(EventWorker):
                         )
 
                     return stats
-            finally:
-                await db_client.cleanup()
 
         return asyncio.run(_process())
 


### PR DESCRIPTION
## Summary
- **Service init factory** (`shit/services.py`): `db_service()`, `s3_service()`, `db_and_s3_service()` async context managers replacing 4 instances of 12-line DB+S3 init boilerplate with guaranteed cleanup
- **Shared CLI args** (`shit/cli/shared_args.py`): `add_standard_arguments()` and `validate_standard_args()` deduplicating 6 standard flags across `shitpost_ai/cli.py` and `shitposts/cli.py`
- Updated `shitvault/cli.py` (3 functions), `shitvault/event_consumer.py`, and corresponding tests

## Test plan
- [x] All 34 CLI + event consumer tests pass with updated mocks
- [x] Full test suite: 2288 passed, 5 pre-existing failures only

🤖 Generated with [Claude Code](https://claude.com/claude-code)