### PR TITLE
chore: migrate OpenAI Python SDK from v1.x to v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead backfill_prices module** — Deleted `shit/market_data/backfill_prices.py` (162 LOC), superseded by event-driven `auto_backfill_service.py`
 
 ### Changed
+- **OpenAI SDK v2 migration** — Upgraded `openai` dependency from v1.x to v2.x (`openai>=2.0.0,<3.0.0`), migrated `max_tokens` to `max_completion_tokens` for forward compatibility, removed dead `mock_openai_client` conftest fixture
 - **Alert callbacks** - Split monolithic `register_alert_callbacks()` (479 LOC) into 3 focused sub-modules: `alert_preferences.py`, `alert_history.py`, `alert_notifications.py`
 - **Dashboard callbacks** - Split monolithic `register_dashboard_callbacks()` (460 LOC) into 3 focused sub-modules: `period.py`, `content.py`, `table.py`
 - **Alert preferences** - Replaced `build_preferences_dict()`/`extract_preferences_tuple()` pair with `AlertPreferences` Pydantic model (backward-compatible wrappers retained)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ urllib3>=2.6.3
 boto3>=1.42.0
 
 # LLM providers
-openai>=1.0.0
+openai>=2.0.0,<3.0.0
 anthropic>=0.83.0
 
 # Database

--- a/shit/llm/llm_client.py
+++ b/shit/llm/llm_client.py
@@ -172,7 +172,7 @@ class LLMClient:
                             {"role": "system", "content": system_message or "You are a helpful AI assistant."},
                             {"role": "user", "content": prompt}
                         ],
-                        max_tokens=1000,
+                        max_completion_tokens=1000,
                         temperature=0.3
                     ),
                     timeout=30.0  # 30 second timeout

--- a/shit_tests/conftest.py
+++ b/shit_tests/conftest.py
@@ -391,17 +391,6 @@ def mock_aiohttp_session():
 
 
 @pytest.fixture
-def mock_openai_client():
-    """Mock OpenAI client for testing."""
-    with patch('openai.ChatCompletion.acreate') as mock_create:
-        mock_response = AsyncMock()
-        mock_response.choices = [AsyncMock()]
-        mock_response.choices[0].message.content = '{"assets": ["TSLA"], "market_impact": {"TSLA": "bearish"}, "confidence": 0.85, "thesis": "Test analysis"}'
-        mock_create.return_value = mock_response
-        yield mock_create
-
-
-@pytest.fixture
 def mock_anthropic_client():
     """Mock Anthropic client for testing."""
     with patch('anthropic.Anthropic') as mock_anthropic:

--- a/shit_tests/shit/llm/test_llm_client.py
+++ b/shit_tests/shit/llm/test_llm_client.py
@@ -345,6 +345,33 @@ class TestLLMClient:
             assert result == "Test response"
 
     @pytest.mark.asyncio
+    async def test_call_llm_uses_max_completion_tokens(self):
+        """Verify chat.completions.create receives max_completion_tokens (not max_tokens)."""
+        with patch('openai.AsyncOpenAI') as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.return_value = mock_client
+
+            mock_init_response = MagicMock()
+            mock_init_response.choices = [MagicMock(message=MagicMock(content="OK"))]
+
+            mock_call_response = MagicMock()
+            mock_call_response.choices = [MagicMock(message=MagicMock(content="Test response"))]
+
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[mock_init_response, mock_call_response]
+            )
+
+            client = LLMClient(provider="openai", model="gpt-4o", api_key="test-key")
+            await client.initialize()
+
+            await client._call_llm("Test prompt")
+
+            call_args = mock_client.chat.completions.create.call_args_list[1]
+            assert 'max_completion_tokens' in call_args.kwargs
+            assert call_args.kwargs['max_completion_tokens'] == 1000
+            assert 'max_tokens' not in call_args.kwargs
+
+    @pytest.mark.asyncio
     async def test_call_llm_error(self):
         """Test LLM call with error."""
         with patch('openai.AsyncOpenAI') as mock_openai:


### PR DESCRIPTION
## Summary
- Upgrade `openai` dependency from v1.102.0 to v2.24.0 (`>=2.0.0,<3.0.0`)
- Migrate `max_tokens` to `max_completion_tokens` in `llm_client.py` (OpenAI path only) for forward compatibility with reasoning models
- Remove dead `mock_openai_client` fixture from `conftest.py` (referenced v0.x API removed in v1.0)
- Add `test_call_llm_uses_max_completion_tokens` test to verify parameter migration

**Phase 07 of codebase-health tech debt remediation.**

## Test plan
- [x] 108 LLM tests pass with new SDK
- [x] Full suite: 2318 passed (5 pre-existing config failures + 1 flaky perf test)
- [x] New test validates `max_completion_tokens` parameter forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)