### PR TITLE
fix: per-asset sentiment extraction and NaN display guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`OUTCOMES_MATURED` event type** — New terminal event emitted after maturation runs, available for future downstream consumers
 
 ### Fixed
+- **Sentiment extraction bug** — Per-asset sentiment now correctly looked up from `market_impact` dict instead of applying first sentiment to all assets; added `fix-sentiments` CLI command to recalculate affected multi-asset outcomes
+- **NaN display guards** — Extracted `safe_get()` to shared `components/utils.py` with `safe_format_pct()` and `safe_format_dollar()` helpers; applied across all UI card components to prevent "+nan%" and "$nan" display
 - **Incomplete outcomes never re-evaluated** — Fixed early-return logic in `_calculate_single_outcome()` that skipped re-evaluation of incomplete outcomes, causing T+7 and T+30 data to permanently stay NULL
 - **Asyncio deprecation warnings** — Replaced 8 instances of deprecated `asyncio.get_event_loop()` with modern alternatives (`asyncio.to_thread()` and `asyncio.get_running_loop()`) for Python 3.13 compatibility
 

--- a/documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md
+++ b/documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md
@@ -1,0 +1,992 @@
+# Phase 02: Fix Sentiment Extraction Bug & NaN Display Guards
+
+> **Status**: 🔧 IN PROGRESS
+> **Started**: 2026-03-04
+
+## Header
+
+| Field | Value |
+|---|---|
+| **PR Title** | fix: per-asset sentiment extraction and NaN display guards |
+| **Risk Level** | Low |
+| **Estimated Effort** | Low (2-3 hours) |
+| **Files Modified** | 8 |
+| **Files Created** | 2 |
+| **Files Deleted** | 0 |
+
+## Context
+
+Two independent bugs degrade data quality and user experience:
+
+1. **Sentiment Extraction Bug**: `OutcomeCalculator._extract_sentiment()` in `shit/market_data/outcome_calculator.py` extracts the *first* sentiment value from the `market_impact` dict and applies it to ALL assets in the prediction. For a prediction with `{"AAPL": "bullish", "TSLA": "bearish"}`, both AAPL and TSLA get labeled "bullish" in `prediction_outcomes.prediction_sentiment`. This corrupts accuracy calculations -- a bearish TSLA prediction is recorded as bullish, so a price drop is marked "incorrect" when it should be "correct."
+
+2. **NaN Display Bug**: When `prediction_outcomes` rows have NULL values for `return_t7`, `pnl_t7`, etc., Pandas loads them as `float('nan')`. The `_safe_get()` helper in `shitty_ui/components/cards/feed.py` correctly converts NaN to a default value, but most other card components and callbacks use bare `row.get()` without NaN protection. This causes the UI to display "+nan%", "$nan", or crash on format strings.
+
+## Dependencies
+
+- **Depends on**: None (standalone bug fixes)
+- **Unlocks**: Phase 01 (Outcome Maturation Pipeline) -- once sentiment is correctly per-asset, outcomes calculated by the maturation pipeline will be accurate
+
+## Detailed Implementation Plan
+
+### Part A: Fix Sentiment Extraction Bug
+
+#### Step 1: Change `_extract_sentiment()` to accept an asset parameter
+
+**File**: `shit/market_data/outcome_calculator.py`
+
+**Current code (lines 462-473)**:
+```python
+def _extract_sentiment(self, market_impact: Dict[str, Any]) -> Optional[str]:
+    """Extract primary sentiment from market_impact dict."""
+    if not market_impact:
+        return None
+
+    # market_impact is typically {asset: sentiment}
+    sentiments = list(market_impact.values())
+    if not sentiments:
+        return None
+
+    # Return most common sentiment, or first one
+    return sentiments[0].lower() if sentiments else None
+```
+
+**New code**:
+```python
+def _extract_sentiment(
+    self, market_impact: Dict[str, Any], asset: Optional[str] = None
+) -> Optional[str]:
+    """Extract sentiment from market_impact dict, optionally for a specific asset.
+
+    Args:
+        market_impact: Dict mapping asset tickers to sentiment strings,
+            e.g. {"AAPL": "bullish", "TSLA": "bearish"}.
+        asset: If provided, look up this specific asset's sentiment.
+            Tries exact match, then case-insensitive match.
+            Falls back to the first sentiment if the asset is not found.
+
+    Returns:
+        Lowercase sentiment string, or None if market_impact is empty.
+    """
+    if not market_impact:
+        return None
+
+    sentiments = list(market_impact.values())
+    if not sentiments:
+        return None
+
+    if asset is not None:
+        # Try exact match first
+        sentiment = market_impact.get(asset)
+        if sentiment is None:
+            # Try case-insensitive match (assets may be stored as "aapl" or "AAPL")
+            sentiment = market_impact.get(asset.upper())
+        if sentiment is None:
+            sentiment = market_impact.get(asset.lower())
+        if sentiment is None:
+            # Try iterating for case-insensitive key match
+            asset_upper = asset.upper()
+            for key, val in market_impact.items():
+                if key.upper() == asset_upper:
+                    sentiment = val
+                    break
+        if sentiment is not None and isinstance(sentiment, str):
+            return sentiment.lower()
+        # Asset not found in market_impact -- fall back to first sentiment
+
+    return sentiments[0].lower() if isinstance(sentiments[0], str) else None
+```
+
+#### Step 2: Pass asset into `_extract_sentiment()` inside the asset loop
+
+**File**: `shit/market_data/outcome_calculator.py`
+
+**Current code (lines 102-121)**:
+```python
+# Get sentiment from market_impact
+sentiment = (
+    self._extract_sentiment(prediction.market_impact)
+    if prediction.market_impact
+    else None
+)
+
+outcomes = []
+
+# Calculate outcome for each asset
+for asset in prediction.assets:
+    try:
+        outcome = self._calculate_single_outcome(
+            prediction_id=prediction_id,
+            symbol=asset,
+            prediction_date=prediction_date,
+            sentiment=sentiment,
+            confidence=prediction.confidence,
+            force_refresh=force_refresh,
+        )
+```
+
+**New code (replace lines 102-121)**:
+```python
+outcomes = []
+
+# Calculate outcome for each asset
+for asset in prediction.assets:
+    try:
+        # Extract per-asset sentiment from market_impact
+        sentiment = (
+            self._extract_sentiment(prediction.market_impact, asset=asset)
+            if prediction.market_impact
+            else None
+        )
+
+        outcome = self._calculate_single_outcome(
+            prediction_id=prediction_id,
+            symbol=asset,
+            prediction_date=prediction_date,
+            sentiment=sentiment,
+            confidence=prediction.confidence,
+            force_refresh=force_refresh,
+        )
+```
+
+**Why**: The sentiment extraction now happens inside the loop, passing the current `asset` to `_extract_sentiment()`. Each asset gets its own per-asset sentiment from the `market_impact` dict. If the asset is not found in the dict (unlikely but possible), it falls back to the first sentiment, preserving backward compatibility.
+
+#### Step 3: Flag existing multi-asset outcomes for recalculation
+
+After fixing the extraction, existing `prediction_outcomes` rows with incorrect sentiment need to be recalculated. Add a one-time CLI command.
+
+**File**: `shit/market_data/__main__.py`
+
+Add a new CLI command `fix-sentiments` that:
+
+1. Queries all predictions where `assets` has more than one entry AND `market_impact` has more than one key
+2. For each, calls `calculate_outcome_for_prediction(prediction_id, force_refresh=True)`
+3. Logs how many outcomes were recalculated
+
+**Add after the existing CLI commands** (find the `argparse` block or `click` group):
+
+```python
+elif args.command == "fix-sentiments":
+    """Recalculate outcomes for multi-asset predictions with incorrect sentiment."""
+    from shitvault.shitpost_models import Prediction
+    from sqlalchemy import func
+
+    with OutcomeCalculator() as calc:
+        # Find predictions with multiple assets where market_impact has data
+        preds = (
+            calc.session.query(Prediction)
+            .filter(
+                Prediction.analysis_status == "completed",
+                Prediction.assets.isnot(None),
+                Prediction.market_impact.isnot(None),
+                func.jsonb_array_length(Prediction.assets) > 1,
+            )
+            .all()
+        )
+
+        logger.info(f"Found {len(preds)} multi-asset predictions to re-evaluate")
+        recalculated = 0
+        errors = 0
+
+        for pred in preds:
+            try:
+                outcomes = calc.calculate_outcome_for_prediction(
+                    pred.id, force_refresh=True
+                )
+                recalculated += len(outcomes)
+            except Exception as e:
+                errors += 1
+                logger.error(f"Error recalculating prediction {pred.id}: {e}")
+
+        logger.info(
+            f"Recalculated {recalculated} outcomes, {errors} errors"
+        )
+```
+
+Read the existing `__main__.py` to determine the exact CLI framework used (argparse vs click) and adapt accordingly.
+
+**File to read**: `shit/market_data/__main__.py`
+
+**Important**: This command must be added to the argparse subcommand definitions. Check the existing file for the exact pattern.
+
+### Part B: NaN Display Guards
+
+#### Step 4: Create shared `safe_get` utility
+
+**Create new file**: `shitty_ui/components/utils.py`
+
+```python
+"""Shared utility functions for UI components.
+
+Provides NaN-safe data extraction and other helpers used across
+multiple card types and callback modules.
+"""
+
+import math
+from typing import Any, Optional
+
+
+def safe_get(row, key: str, default: Any = None) -> Any:
+    """NaN-safe field extraction from a Pandas Series or dict.
+
+    Pandas Series.get() returns NaN (not the default) when the key
+    exists but the value is NaN. This helper normalizes NaN to the
+    provided default, preventing '+nan%' and '$nan' display bugs.
+
+    Args:
+        row: Dict-like object (Pandas Series or plain dict).
+        key: Field name to extract.
+        default: Value to return if the field is missing or NaN.
+
+    Returns:
+        The field value, or default if missing/None/NaN.
+    """
+    value = row.get(key, default)
+    if value is None:
+        return default
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return default
+    except (TypeError, ValueError):
+        pass
+    return value
+
+
+def safe_format_pct(value: Optional[float], fmt: str = "+.2f") -> str:
+    """Format a float as a percentage string, returning '--' for None/NaN.
+
+    Args:
+        value: Float value to format, or None.
+        fmt: Format spec string (default '+.2f' for '+1.23').
+
+    Returns:
+        Formatted string like '+1.23%' or '--'.
+    """
+    if value is None:
+        return "--"
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return "--"
+    except (TypeError, ValueError):
+        return "--"
+    return f"{value:{fmt}}%"
+
+
+def safe_format_dollar(value: Optional[float], fmt: str = "+,.0f") -> str:
+    """Format a float as a dollar string, returning '--' for None/NaN.
+
+    Args:
+        value: Float value to format, or None.
+        fmt: Format spec string (default '+,.0f' for '+$1,234').
+
+    Returns:
+        Formatted string like '$+1,234' or '--'.
+    """
+    if value is None:
+        return "--"
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return "--"
+    except (TypeError, ValueError):
+        return "--"
+    return f"${value:{fmt}}"
+```
+
+#### Step 5: Update `feed.py` to import from shared utility
+
+**File**: `shitty_ui/components/cards/feed.py`
+
+**Current code (lines 1-41)**:
+The file defines `_safe_get()` locally at lines 26-41.
+
+**Change**:
+1. Remove the local `_safe_get()` definition (lines 26-41)
+2. Add import at top of file: `from components.utils import safe_get`
+3. Replace all `_safe_get(` calls with `safe_get(` (lines 139-149)
+
+**Before (line 8)**:
+```python
+import math
+```
+
+**After**:
+Remove the `import math` line (no longer needed in this file).
+
+**Before (lines 26-41)**:
+```python
+def _safe_get(row, key, default=None):
+    """
+    NaN-safe field extraction from a Pandas Series or dict.
+    ...
+    """
+    value = row.get(key, default)
+    if value is None:
+        return default
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return default
+    except (TypeError, ValueError):
+        pass
+    return value
+```
+
+**After**: Delete these lines entirely.
+
+**Before (line 1-7, add import)**:
+```python
+from components.utils import safe_get
+```
+
+**Rename all usages (lines 139-149)**: Change `_safe_get(` to `safe_get(`:
+```python
+    timestamp = safe_get(row, "timestamp")
+    post_text = safe_get(row, "text", "")
+    confidence = safe_get(row, "confidence", 0) or 0
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    symbol = safe_get(row, "symbol")
+    prediction_sentiment = safe_get(row, "prediction_sentiment")
+    return_t7 = safe_get(row, "return_t7")
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
+    thesis = safe_get(row, "thesis", "")
+```
+
+#### Step 6: Update `cards/__init__.py` to re-export `safe_get` instead of `_safe_get`
+
+**File**: `shitty_ui/components/cards/__init__.py`
+
+**Current (line 93)**:
+```python
+    _safe_get,
+```
+
+**After**:
+```python
+    safe_get,
+```
+
+**Current (line 122)**:
+```python
+    "_safe_get",
+```
+
+**After**:
+```python
+    "safe_get",
+```
+
+No backward-compat alias needed — `_safe_get` was always private (`_` prefix). Clean break to `safe_get`.
+
+#### Step 7: Apply NaN guards to `timeline.py`
+
+**File**: `shitty_ui/components/cards/timeline.py`
+
+**Add import (after line 9)**:
+```python
+from components.utils import safe_get
+```
+
+**Current code (lines 25-34)** in `create_prediction_timeline_card`:
+```python
+    prediction_date = row.get("prediction_date")
+    timestamp = row.get("timestamp")
+    tweet_text = row.get("text", "")
+    sentiment = row.get("prediction_sentiment", "neutral")
+    confidence = row.get("prediction_confidence", 0)
+    return_t7 = row.get("return_t7")
+    correct_t7 = row.get("correct_t7")
+    pnl_t7 = row.get("pnl_t7")
+    price_at = row.get("price_at_prediction")
+    price_after = row.get("price_t7")
+```
+
+**New code**:
+```python
+    prediction_date = safe_get(row, "prediction_date")
+    timestamp = safe_get(row, "timestamp")
+    tweet_text = safe_get(row, "text", "")
+    sentiment = safe_get(row, "prediction_sentiment", "neutral")
+    confidence = safe_get(row, "prediction_confidence", 0)
+    return_t7 = safe_get(row, "return_t7")
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
+    price_at = safe_get(row, "price_at_prediction")
+    price_after = safe_get(row, "price_t7")
+```
+
+Also fix `create_related_asset_link` (lines 235-237):
+
+**Current**:
+```python
+    symbol = row.get("related_symbol", "???")
+    count = row.get("co_occurrence_count", 0)
+    avg_return = row.get("avg_return_t7")
+```
+
+**New**:
+```python
+    symbol = safe_get(row, "related_symbol", "???")
+    count = safe_get(row, "co_occurrence_count", 0)
+    avg_return = safe_get(row, "avg_return_t7")
+```
+
+#### Step 8: Apply NaN guards to `hero.py`
+
+**File**: `shitty_ui/components/cards/hero.py`
+
+**Add import (after line 5)**:
+```python
+from components.utils import safe_get
+```
+
+**Current code (lines 21-33)** in `create_hero_signal_card`:
+```python
+    timestamp = row.get("timestamp")
+    text_content = row.get("text", "")
+    ...
+    confidence = row.get("confidence", 0)
+    assets = row.get("assets", [])
+    market_impact = row.get("market_impact", {})
+    ...
+    outcome_count = row.get("outcome_count", 0) or 0
+    correct_count = row.get("correct_count", 0) or 0
+    incorrect_count = row.get("incorrect_count", 0) or 0
+    total_pnl_t7 = row.get("total_pnl_t7")
+```
+
+**New code**:
+```python
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
+    ...
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    ...
+    outcome_count = safe_get(row, "outcome_count", 0) or 0
+    correct_count = safe_get(row, "correct_count", 0) or 0
+    incorrect_count = safe_get(row, "incorrect_count", 0) or 0
+    total_pnl_t7 = safe_get(row, "total_pnl_t7")
+```
+
+Also fix line 65:
+**Current**:
+```python
+    pnl_display = total_pnl_t7 if total_pnl_t7 is not None else row.get("pnl_t7")
+```
+
+**New**:
+```python
+    pnl_display = total_pnl_t7 if total_pnl_t7 is not None else safe_get(row, "pnl_t7")
+```
+
+#### Step 9: Apply NaN guards to `signal.py`
+
+**File**: `shitty_ui/components/cards/signal.py`
+
+**Add import (after line 9)**:
+```python
+from components.utils import safe_get
+```
+
+**Current code (lines 28-36)** in `create_signal_card`:
+```python
+    timestamp = row.get("timestamp")
+    text_content = row.get("text", "")
+    ...
+    confidence = row.get("confidence", 0)
+    assets = row.get("assets", [])
+    market_impact = row.get("market_impact", {})
+    correct_t7 = row.get("correct_t7")
+    pnl_t7 = row.get("pnl_t7")
+```
+
+**New code**:
+```python
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
+    ...
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
+```
+
+**Current code (lines 140-153)** in `create_unified_signal_card`:
+```python
+    timestamp = row.get("timestamp")
+    text_content = row.get("text", "")
+    ...
+    confidence = row.get("confidence", 0)
+    assets = row.get("assets", [])
+    market_impact = row.get("market_impact", {})
+    thesis = row.get("thesis", "")
+
+    # Aggregated outcome data (from GROUP BY query)
+    outcome_count = row.get("outcome_count", 0) or 0
+    correct_count = row.get("correct_count", 0) or 0
+    incorrect_count = row.get("incorrect_count", 0) or 0
+    total_pnl_t7 = row.get("total_pnl_t7")
+```
+
+**New code**:
+```python
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
+    ...
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    thesis = safe_get(row, "thesis", "")
+
+    # Aggregated outcome data (from GROUP BY query)
+    outcome_count = safe_get(row, "outcome_count", 0) or 0
+    correct_count = safe_get(row, "correct_count", 0) or 0
+    incorrect_count = safe_get(row, "incorrect_count", 0) or 0
+    total_pnl_t7 = safe_get(row, "total_pnl_t7")
+```
+
+#### Step 10: Apply NaN guards to `dashboard_callbacks/content.py`
+
+**File**: `shitty_ui/pages/dashboard_callbacks/content.py`
+
+**Add import (after line 8)**:
+```python
+from components.utils import safe_format_pct, safe_format_dollar
+```
+
+**Current code (line 130)**:
+```python
+                            f"{kpis['avg_return_t7']:+.2f}%",
+```
+
+**New code**:
+```python
+                            safe_format_pct(kpis['avg_return_t7']),
+```
+
+**Current code (line 146)**:
+```python
+                            f"${kpis['total_pnl']:+,.0f}",
+```
+
+**New code**:
+```python
+                            safe_format_dollar(kpis['total_pnl']),
+```
+
+**Why**: Although `get_dashboard_kpis()` returns 0.0 defaults, edge cases (e.g., cache invalidation, database returning NULL for AVG of an empty set that sneaks past the `or 0.0` guard) can leak NaN. Defensive formatting at the display layer is the last line of defense.
+
+#### Step 11: Apply NaN guards to `pages/assets.py`
+
+**File**: `shitty_ui/pages/assets.py`
+
+**Add import (after line 8)**:
+```python
+from components.utils import safe_format_pct, safe_format_dollar
+```
+
+**Current code (line 346)** inside `update_asset_page`:
+```python
+                            f"${stats['total_pnl_t7']:,.0f}",
+```
+
+**New code**:
+```python
+                            safe_format_dollar(stats['total_pnl_t7'], fmt=",.0f"),
+```
+
+Note: `safe_format_dollar` uses `+,.0f` by default (with sign). For the asset page stat card, we want `,.0f` (no forced sign). The function's `fmt` parameter supports this.
+
+**Current code (line 361)**:
+```python
+                            f"{stats['avg_return_t7']:+.2f}%",
+```
+
+**New code**:
+```python
+                            safe_format_pct(stats['avg_return_t7']),
+```
+
+Also guard the color conditionals around these values. Currently line 350:
+```python
+                            (
+                                COLORS["success"]
+                                if stats["total_pnl_t7"] > 0
+                                else COLORS["danger"]
+                            ),
+```
+
+**New code**:
+```python
+                            (
+                                COLORS["success"]
+                                if (stats["total_pnl_t7"] or 0) > 0
+                                else COLORS["danger"]
+                            ),
+```
+
+And line 365:
+```python
+                            (
+                                COLORS["success"]
+                                if stats["avg_return_t7"] > 0
+                                else COLORS["danger"]
+                            ),
+```
+
+**New code**:
+```python
+                            (
+                                COLORS["success"]
+                                if (stats["avg_return_t7"] or 0) > 0
+                                else COLORS["danger"]
+                            ),
+```
+
+**Why**: Comparing `NaN > 0` returns `False` in Python (so it would always show danger color), but it is semantically wrong. Using `or 0` normalizes NaN/None to 0 for the color comparison.
+
+## Test Plan
+
+### New test file: `shit_tests/shitty_ui/test_utils.py`
+
+```python
+"""Tests for shitty_ui/components/utils.py -- NaN-safe utilities."""
+
+import sys
+import os
+import math
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+from components.utils import safe_get, safe_format_pct, safe_format_dollar
+
+
+class TestSafeGet:
+    """Tests for the safe_get NaN-guard helper."""
+
+    def test_returns_value_for_normal_float(self):
+        assert safe_get({"key": 1.5}, "key") == 1.5
+
+    def test_returns_default_for_nan(self):
+        assert safe_get({"key": float("nan")}, "key", 0.0) == 0.0
+
+    def test_returns_default_for_missing_key(self):
+        assert safe_get({}, "key", "fallback") == "fallback"
+
+    def test_returns_none_for_missing_key_no_default(self):
+        assert safe_get({}, "key") is None
+
+    def test_returns_default_for_none_value(self):
+        assert safe_get({"key": None}, "key", 42) == 42
+
+    def test_returns_string_value_unchanged(self):
+        assert safe_get({"key": "hello"}, "key") == "hello"
+
+    def test_returns_list_value_unchanged(self):
+        assert safe_get({"key": [1, 2]}, "key") == [1, 2]
+
+    def test_returns_zero_float_not_treated_as_nan(self):
+        assert safe_get({"key": 0.0}, "key", 999) == 0.0
+
+    def test_returns_negative_float_unchanged(self):
+        assert safe_get({"key": -3.14}, "key") == -3.14
+
+    def test_works_with_pandas_series(self):
+        import pandas as pd
+        row = pd.Series({"val": float("nan"), "ok": 42})
+        assert safe_get(row, "val", 0) == 0
+        assert safe_get(row, "ok", 0) == 42
+
+    def test_returns_bool_unchanged(self):
+        assert safe_get({"key": True}, "key") is True
+        assert safe_get({"key": False}, "key") is False
+
+
+class TestSafeFormatPct:
+    """Tests for safe_format_pct."""
+
+    def test_formats_positive_float(self):
+        assert safe_format_pct(2.5) == "+2.50%"
+
+    def test_formats_negative_float(self):
+        assert safe_format_pct(-1.23) == "-1.23%"
+
+    def test_returns_dash_for_none(self):
+        assert safe_format_pct(None) == "--"
+
+    def test_returns_dash_for_nan(self):
+        assert safe_format_pct(float("nan")) == "--"
+
+    def test_formats_zero(self):
+        assert safe_format_pct(0.0) == "+0.00%"
+
+    def test_custom_format(self):
+        assert safe_format_pct(5.0, fmt=".1f") == "5.0%"
+
+
+class TestSafeFormatDollar:
+    """Tests for safe_format_dollar."""
+
+    def test_formats_positive_amount(self):
+        assert safe_format_dollar(1234.0) == "$+1,234"
+
+    def test_formats_negative_amount(self):
+        assert safe_format_dollar(-500.0) == "$-500"
+
+    def test_returns_dash_for_none(self):
+        assert safe_format_dollar(None) == "--"
+
+    def test_returns_dash_for_nan(self):
+        assert safe_format_dollar(float("nan")) == "--"
+
+    def test_formats_zero(self):
+        assert safe_format_dollar(0.0) == "$+0"
+
+    def test_custom_format_no_sign(self):
+        assert safe_format_dollar(1234.0, fmt=",.0f") == "$1,234"
+```
+
+### Modified test file: `shit_tests/shit/market_data/test_outcome_calculator.py`
+
+Update `TestExtractSentiment` class to test the new per-asset behavior:
+
+```python
+class TestExtractSentiment:
+    def test_extracts_first_sentiment_when_no_asset(self, calculator):
+        result = calculator._extract_sentiment({"AAPL": "Bullish"})
+        assert result == "bullish"
+
+    def test_returns_none_for_empty_dict(self, calculator):
+        assert calculator._extract_sentiment({}) is None
+
+    def test_returns_none_for_none(self, calculator):
+        assert calculator._extract_sentiment(None) is None
+
+    def test_lowercases_sentiment(self, calculator):
+        result = calculator._extract_sentiment({"TSLA": "BEARISH"})
+        assert result == "bearish"
+
+    def test_multi_asset_returns_first_when_no_asset_specified(self, calculator):
+        result = calculator._extract_sentiment({"AAPL": "bullish", "TSLA": "bearish"})
+        assert result in ("bullish", "bearish")  # dict ordering
+
+    # --- New per-asset tests ---
+
+    def test_per_asset_exact_match(self, calculator):
+        mi = {"AAPL": "bullish", "TSLA": "bearish"}
+        assert calculator._extract_sentiment(mi, asset="AAPL") == "bullish"
+        assert calculator._extract_sentiment(mi, asset="TSLA") == "bearish"
+
+    def test_per_asset_case_insensitive(self, calculator):
+        mi = {"AAPL": "bullish", "TSLA": "bearish"}
+        assert calculator._extract_sentiment(mi, asset="aapl") == "bullish"
+        assert calculator._extract_sentiment(mi, asset="tsla") == "bearish"
+
+    def test_per_asset_falls_back_to_first_when_not_found(self, calculator):
+        mi = {"AAPL": "bullish"}
+        result = calculator._extract_sentiment(mi, asset="GOOG")
+        assert result == "bullish"  # fallback to first
+
+    def test_per_asset_handles_mixed_case_keys(self, calculator):
+        mi = {"Aapl": "bullish"}
+        assert calculator._extract_sentiment(mi, asset="AAPL") == "bullish"
+```
+
+### Modified test: verify per-asset sentiment flows through `calculate_outcome_for_prediction`
+
+Add a new test to `TestCalculateOutcomeForPrediction`:
+
+```python
+def test_passes_per_asset_sentiment(self, calculator, mock_session):
+    """Verify each asset gets its own sentiment from market_impact."""
+    pred = _make_prediction(
+        assets=["AAPL", "TSLA"],
+        market_impact={"AAPL": "bullish", "TSLA": "bearish"},
+    )
+    mock_session.query.return_value.filter.return_value.first.return_value = pred
+
+    mock_outcome = MagicMock(spec=PredictionOutcome)
+    calculator._calculate_single_outcome = MagicMock(return_value=mock_outcome)
+
+    calculator.calculate_outcome_for_prediction(1)
+
+    calls = calculator._calculate_single_outcome.call_args_list
+    assert len(calls) == 2
+    # First call: AAPL should get "bullish"
+    assert calls[0].kwargs.get("sentiment") == "bullish" or calls[0][1].get("sentiment") == "bullish"
+    # Second call: TSLA should get "bearish"
+    assert calls[1].kwargs.get("sentiment") == "bearish" or calls[1][1].get("sentiment") == "bearish"
+```
+
+**Note**: The `_calculate_single_outcome` is called with keyword arguments, so check `call_args_list[N]` using kwargs:
+```python
+    calls = calculator._calculate_single_outcome.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["sentiment"] == "bullish"
+    assert calls[1].kwargs["sentiment"] == "bearish"
+```
+
+### Modified test file: `shit_tests/shitty_ui/test_cards.py`
+
+Add NaN-resilience tests:
+
+```python
+class TestNanResilience:
+    """Verify cards don't render 'nan' when row values are NaN."""
+
+    def test_timeline_card_nan_return(self):
+        """Timeline card should show '--' not '+nan%' when return_t7 is NaN."""
+        card = create_prediction_timeline_card(
+            _make_timeline_row(return_t7=float("nan"), pnl_t7=float("nan"))
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+        assert "--" in text
+
+    def test_timeline_card_nan_price(self):
+        """Timeline card handles NaN prices without crashing."""
+        card = create_prediction_timeline_card(
+            _make_timeline_row(
+                price_at_prediction=float("nan"),
+                price_t7=float("nan"),
+            )
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_hero_card_nan_confidence(self):
+        """Hero card handles NaN confidence without crashing."""
+        card = create_hero_signal_card(_make_row(confidence=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_signal_card_nan_pnl(self):
+        """Signal card handles NaN pnl_t7 without crashing."""
+        card = create_signal_card(_make_row(pnl_t7=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_unified_card_nan_total_pnl(self):
+        """Unified card handles NaN total_pnl_t7 without crashing."""
+        card = create_unified_signal_card(
+            _make_row(total_pnl_t7=float("nan"))
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_feed_card_nan_return(self):
+        """Feed card handles NaN return_t7 without crashing."""
+        card = create_feed_signal_card(_make_row(return_t7=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_related_asset_link_nan_return(self):
+        """Related asset link handles NaN avg_return_t7."""
+        card = create_related_asset_link({
+            "related_symbol": "TSLA",
+            "co_occurrence_count": 3,
+            "avg_return_t7": float("nan"),
+        })
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+        assert "--" in text
+```
+
+### Existing tests to verify pass
+
+Run the full test suite to ensure no regressions:
+```bash
+source venv/bin/activate && pytest shit_tests/shit/market_data/test_outcome_calculator.py -v
+source venv/bin/activate && pytest shit_tests/shitty_ui/test_cards.py -v
+source venv/bin/activate && pytest shit_tests/shitty_ui/test_utils.py -v
+source venv/bin/activate && pytest -v
+```
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Fixed
+- **Sentiment Extraction Bug** - Per-asset sentiment now correctly looked up from `market_impact` dict instead of applying first sentiment to all assets
+  - `OutcomeCalculator._extract_sentiment()` accepts optional `asset` parameter for case-insensitive lookup
+  - Sentiment extraction moved inside the asset loop in `calculate_outcome_for_prediction()`
+  - Added `fix-sentiments` CLI command to recalculate affected multi-asset outcomes
+- **NaN Display Guards** - Extracted `safe_get()` from feed.py to shared `components/utils.py` and applied across all UI card components
+  - Added `safe_format_pct()` and `safe_format_dollar()` formatting helpers
+  - Applied NaN guards to: timeline.py, hero.py, signal.py, content.py, assets.py
+  - Dashboard KPI cards and asset stat cards no longer show "+nan%" or "$nan"
+```
+
+## Stress Testing & Edge Cases
+
+### Sentiment extraction edge cases
+- **Single asset prediction**: `_extract_sentiment({"AAPL": "bullish"}, asset="AAPL")` -- direct match
+- **Asset not in market_impact**: `_extract_sentiment({"AAPL": "bullish"}, asset="GOOG")` -- falls back to first
+- **Empty market_impact**: `_extract_sentiment({}, asset="AAPL")` -- returns None
+- **None market_impact**: `_extract_sentiment(None, asset="AAPL")` -- returns None
+- **Case mismatch**: `_extract_sentiment({"aapl": "bullish"}, asset="AAPL")` -- case-insensitive match
+- **Non-string sentiment value**: `_extract_sentiment({"AAPL": 123})` -- guard against non-string; `isinstance` check returns None on fall-through
+
+### NaN edge cases
+- `float('nan')` in numeric fields (`return_t7`, `pnl_t7`, `confidence`)
+- `float('nan')` in price fields (`price_at_prediction`, `price_t7`)
+- `None` values (already handled by most code, but `safe_get` unifies the behavior)
+- Mixed NaN and valid values in the same row
+- `0.0` values (must NOT be treated as NaN)
+- Boolean `False` (must NOT be treated as NaN)
+- Pandas `pd.NA` (would fail `isinstance(value, float)` check -- passes through unchanged, which is correct since it is not `float('nan')`)
+
+## Verification Checklist
+
+- [ ] `_extract_sentiment({"AAPL": "bullish", "TSLA": "bearish"}, asset="TSLA")` returns `"bearish"`
+- [ ] `_extract_sentiment({"AAPL": "bullish", "TSLA": "bearish"}, asset="AAPL")` returns `"bullish"`
+- [ ] `_extract_sentiment({"AAPL": "bullish"})` still returns `"bullish"` (backward compat, no asset arg)
+- [ ] All existing `TestExtractSentiment` tests pass
+- [ ] New per-asset sentiment tests pass
+- [ ] `safe_get({"x": float("nan")}, "x", 0)` returns `0`
+- [ ] `safe_get({"x": 0.0}, "x", 999)` returns `0.0` (not 999)
+- [ ] No card component renders "nan" in its text output
+- [ ] Dashboard KPI cards display "--" instead of "+nan%" when data is missing
+- [ ] Asset page stat cards display "--" instead of "$nan" when data is missing
+- [ ] Full test suite passes: `source venv/bin/activate && pytest -v`
+- [ ] Linting passes: `source venv/bin/activate && python -m ruff check .`
+- [ ] `fix-sentiments` CLI command runs without error (dry-run against production)
+
+## What NOT To Do
+
+1. **Do NOT change the `_extract_sentiment()` return type or None semantics.** It currently returns `Optional[str]`. The callers expect `None` for empty/missing impact. Do not change this to return `"neutral"` -- that would mask missing data.
+
+2. **Do NOT apply `safe_get` to `post.py`.** The post card (`shitty_ui/components/cards/post.py`) does not display float metrics (return_t7, pnl_t7). It uses `row.get()` for string/list fields where NaN is not a risk. Touching this file adds unnecessary churn.
+
+3. **Do NOT change the data layer queries** to coalesce NaN at the SQL level. The NaN problem comes from Pandas converting SQL NULL to NaN. The fix belongs at the display layer (`safe_get`), not the data layer, because (a) the data layer correctly returns `None`/0.0 from dict results, and (b) DataFrame rows naturally contain NaN for NULL columns.
+
+4. **Do NOT run `fix-sentiments` in production without user approval.** It calls `force_refresh=True` which will re-fetch market prices and rewrite outcome rows. Follow the CLAUDE.md safety rules.
+
+5. **`_safe_get` backward-compat alias is NOT needed.** It was always private (`_` prefix). Replace with `safe_get` cleanly — no alias.
+
+6. **Do NOT use `pd.isna()` or `pd.isnull()` in the utility.** The `math.isnan()` approach is correct because `safe_get` receives individual values, not Series. Using `pd.isna()` would add a pandas dependency to a generic utility and behave differently for `pd.NA` vs `float('nan')`.
+```
+
+---
+
+- Wrote: /Users/chris/Projects/shitpost-alpha/documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md
+- PR title: fix: per-asset sentiment extraction and NaN display guards
+- Effort: Low (2-3 hours)
+- Risk: Low
+- Files modified: 8 | Files created: 2
+- Dependencies: None
+- Unlocks: Phase 01 (Outcome Maturation Pipeline)
+
+### Critical Files for Implementation
+- `/Users/chris/Projects/shitpost-alpha/shit/market_data/outcome_calculator.py` - Core bug: `_extract_sentiment()` needs per-asset lookup and must be called inside the asset loop
+- `/Users/chris/Projects/shitpost-alpha/shitty_ui/components/cards/feed.py` - Source of `_safe_get()` pattern to extract to shared utility
+- `/Users/chris/Projects/shitpost-alpha/shitty_ui/components/utils.py` - New file: shared `safe_get`, `safe_format_pct`, `safe_format_dollar` utilities
+- `/Users/chris/Projects/shitpost-alpha/shitty_ui/components/cards/timeline.py` - Worst NaN offender: bare `row.get()` for `return_t7` renders "+nan%"
+- `/Users/chris/Projects/shitpost-alpha/shitty_ui/pages/dashboard_callbacks/content.py` - KPI format strings need NaN-safe formatting helpers

--- a/documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md
+++ b/documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md
@@ -1,7 +1,8 @@
 # Phase 02: Fix Sentiment Extraction Bug & NaN Display Guards
 
-> **Status**: 🔧 IN PROGRESS
+> **Status**: ✅ COMPLETE
 > **Started**: 2026-03-04
+> **Completed**: 2026-03-04
 
 ## Header
 

--- a/shit/market_data/cli.py
+++ b/shit/market_data/cli.py
@@ -181,6 +181,68 @@ def calculate_outcomes(limit: Optional[int], days: Optional[int], force: bool):
         raise click.Abort()
 
 
+@cli.command(name="fix-sentiments")
+@click.option("--dry-run", is_flag=True, help="Show what would be recalculated without making changes")
+def fix_sentiments(dry_run: bool):
+    """Recalculate outcomes for multi-asset predictions with incorrect sentiment.
+
+    Finds predictions with multiple assets where market_impact has per-asset
+    sentiment data, then force-refreshes their outcomes so each asset gets
+    its correct sentiment from the market_impact dict.
+    """
+    from shitvault.shitpost_models import Prediction
+    from sqlalchemy import func
+
+    print_info("Finding multi-asset predictions to fix sentiment...")
+
+    try:
+        with OutcomeCalculator() as calculator:
+            preds = (
+                calculator.session.query(Prediction)
+                .filter(
+                    Prediction.analysis_status == "completed",
+                    Prediction.assets.isnot(None),
+                    Prediction.market_impact.isnot(None),
+                    func.jsonb_array_length(Prediction.assets) > 1,
+                )
+                .all()
+            )
+
+            rprint(f"\n  Found [bold]{len(preds)}[/bold] multi-asset predictions")
+
+            if dry_run:
+                for pred in preds:
+                    rprint(
+                        f"  Would recalculate prediction {pred.id}: "
+                        f"assets={pred.assets}, market_impact={pred.market_impact}"
+                    )
+                print_info("Dry run complete — no changes made")
+                return
+
+            recalculated = 0
+            errors = 0
+
+            for pred in preds:
+                try:
+                    outcomes = calculator.calculate_outcome_for_prediction(
+                        pred.id, force_refresh=True
+                    )
+                    recalculated += len(outcomes)
+                except Exception as e:
+                    errors += 1
+                    rprint(f"  [red]Error recalculating prediction {pred.id}: {e}[/red]")
+
+            rprint(f"\n  Recalculated: [green]{recalculated}[/green] outcomes")
+            if errors:
+                rprint(f"  Errors: [red]{errors}[/red]")
+
+            print_success(f"✅ Fixed sentiments for {len(preds)} predictions")
+
+    except Exception as e:
+        print_error(f"❌ Error fixing sentiments: {e}")
+        raise click.Abort()
+
+
 @cli.command(name="mature-outcomes")
 @click.option("--limit", "-l", type=int, help="Limit number of incomplete outcomes to process")
 @click.option("--emit-event", is_flag=True, help="Emit outcomes_matured event when done")

--- a/shit/market_data/outcome_calculator.py
+++ b/shit/market_data/outcome_calculator.py
@@ -99,18 +99,18 @@ class OutcomeCalculator:
             )
             return []
 
-        # Get sentiment from market_impact
-        sentiment = (
-            self._extract_sentiment(prediction.market_impact)
-            if prediction.market_impact
-            else None
-        )
-
         outcomes = []
 
         # Calculate outcome for each asset
         for asset in prediction.assets:
             try:
+                # Extract per-asset sentiment from market_impact
+                sentiment = (
+                    self._extract_sentiment(prediction.market_impact, asset=asset)
+                    if prediction.market_impact
+                    else None
+                )
+
                 outcome = self._calculate_single_outcome(
                     prediction_id=prediction_id,
                     symbol=asset,
@@ -570,15 +570,44 @@ class OutcomeCalculator:
 
         return None
 
-    def _extract_sentiment(self, market_impact: Dict[str, Any]) -> Optional[str]:
-        """Extract primary sentiment from market_impact dict."""
+    def _extract_sentiment(
+        self, market_impact: Dict[str, Any], asset: Optional[str] = None
+    ) -> Optional[str]:
+        """Extract sentiment from market_impact dict, optionally for a specific asset.
+
+        Args:
+            market_impact: Dict mapping asset tickers to sentiment strings,
+                e.g. {"AAPL": "bullish", "TSLA": "bearish"}.
+            asset: If provided, look up this specific asset's sentiment.
+                Tries exact match, then case-insensitive match.
+                Falls back to the first sentiment if the asset is not found.
+
+        Returns:
+            Lowercase sentiment string, or None if market_impact is empty.
+        """
         if not market_impact:
             return None
 
-        # market_impact is typically {asset: sentiment}
         sentiments = list(market_impact.values())
         if not sentiments:
             return None
 
-        # Return most common sentiment, or first one
-        return sentiments[0].lower() if sentiments else None
+        if asset is not None:
+            # Try exact match first
+            sentiment = market_impact.get(asset)
+            if sentiment is None:
+                sentiment = market_impact.get(asset.upper())
+            if sentiment is None:
+                sentiment = market_impact.get(asset.lower())
+            if sentiment is None:
+                # Case-insensitive key iteration
+                asset_upper = asset.upper()
+                for key, val in market_impact.items():
+                    if key.upper() == asset_upper:
+                        sentiment = val
+                        break
+            if sentiment is not None and isinstance(sentiment, str):
+                return sentiment.lower()
+            # Asset not found in market_impact — fall back to first sentiment
+
+        return sentiments[0].lower() if isinstance(sentiments[0], str) else None

--- a/shit_tests/shit/market_data/test_outcome_calculator.py
+++ b/shit_tests/shit/market_data/test_outcome_calculator.py
@@ -98,9 +98,30 @@ class TestExtractSentiment:
         result = calculator._extract_sentiment({"TSLA": "BEARISH"})
         assert result == "bearish"
 
-    def test_multi_asset_returns_first(self, calculator):
+    def test_multi_asset_returns_first_when_no_asset_specified(self, calculator):
         result = calculator._extract_sentiment({"AAPL": "bullish", "TSLA": "bearish"})
         assert result in ("bullish", "bearish")  # dict ordering
+
+    # --- Per-asset tests ---
+
+    def test_per_asset_exact_match(self, calculator):
+        mi = {"AAPL": "bullish", "TSLA": "bearish"}
+        assert calculator._extract_sentiment(mi, asset="AAPL") == "bullish"
+        assert calculator._extract_sentiment(mi, asset="TSLA") == "bearish"
+
+    def test_per_asset_case_insensitive(self, calculator):
+        mi = {"AAPL": "bullish", "TSLA": "bearish"}
+        assert calculator._extract_sentiment(mi, asset="aapl") == "bullish"
+        assert calculator._extract_sentiment(mi, asset="tsla") == "bearish"
+
+    def test_per_asset_falls_back_to_first_when_not_found(self, calculator):
+        mi = {"AAPL": "bullish"}
+        result = calculator._extract_sentiment(mi, asset="GOOG")
+        assert result == "bullish"  # fallback to first
+
+    def test_per_asset_handles_mixed_case_keys(self, calculator):
+        mi = {"Aapl": "bullish"}
+        assert calculator._extract_sentiment(mi, asset="AAPL") == "bullish"
 
 
 # ─── _get_source_date ──────────────────────────────────────────────
@@ -224,6 +245,24 @@ class TestCalculateOutcomeForPrediction:
         result = calculator.calculate_outcome_for_prediction(1)
         assert len(result) == 3
         assert calculator._calculate_single_outcome.call_count == 3
+
+    def test_passes_per_asset_sentiment(self, calculator, mock_session):
+        """Verify each asset gets its own sentiment from market_impact."""
+        pred = _make_prediction(
+            assets=["AAPL", "TSLA"],
+            market_impact={"AAPL": "bullish", "TSLA": "bearish"},
+        )
+        mock_session.query.return_value.filter.return_value.first.return_value = pred
+
+        mock_outcome = MagicMock(spec=PredictionOutcome)
+        calculator._calculate_single_outcome = MagicMock(return_value=mock_outcome)
+
+        calculator.calculate_outcome_for_prediction(1)
+
+        calls = calculator._calculate_single_outcome.call_args_list
+        assert len(calls) == 2
+        assert calls[0].kwargs["sentiment"] == "bullish"
+        assert calls[1].kwargs["sentiment"] == "bearish"
 
 
 # ─── _calculate_single_outcome ───────────────────────────────────────

--- a/shit_tests/shitty_ui/test_cards.py
+++ b/shit_tests/shitty_ui/test_cards.py
@@ -15,6 +15,7 @@ from components.cards import (
     create_signal_card,
     create_post_card,
     create_prediction_timeline_card,
+    create_related_asset_link,
     create_feed_signal_card,
     create_empty_state_html,
     create_unified_signal_card,
@@ -1000,3 +1001,63 @@ class TestHeroCardMobileWidth:
         """Test that hero card flex property allows shrinking (flex-basis 0)."""
         card = create_hero_signal_card(_make_row())
         assert "1 1 0" in card.style.get("flex", "")
+
+
+class TestNanResilience:
+    """Verify cards don't render 'nan' when row values are NaN."""
+
+    def test_timeline_card_nan_return(self):
+        """Timeline card should show '--' not '+nan%' when return_t7 is NaN."""
+        card = create_prediction_timeline_card(
+            _make_timeline_row(return_t7=float("nan"), pnl_t7=float("nan"))
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_timeline_card_nan_price(self):
+        """Timeline card handles NaN prices without crashing."""
+        card = create_prediction_timeline_card(
+            _make_timeline_row(
+                price_at_prediction=float("nan"),
+                price_t7=float("nan"),
+            )
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_hero_card_nan_confidence(self):
+        """Hero card handles NaN confidence without crashing."""
+        card = create_hero_signal_card(_make_row(confidence=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_signal_card_nan_pnl(self):
+        """Signal card handles NaN pnl_t7 without crashing."""
+        card = create_signal_card(_make_row(pnl_t7=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_unified_card_nan_total_pnl(self):
+        """Unified card handles NaN total_pnl_t7 without crashing."""
+        card = create_unified_signal_card(
+            _make_row(total_pnl_t7=float("nan"))
+        )
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_feed_card_nan_return(self):
+        """Feed card handles NaN return_t7 without crashing."""
+        card = create_feed_signal_card(_make_row(return_t7=float("nan")))
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+
+    def test_related_asset_link_nan_return(self):
+        """Related asset link handles NaN avg_return_t7."""
+        card = create_related_asset_link({
+            "related_symbol": "TSLA",
+            "co_occurrence_count": 3,
+            "avg_return_t7": float("nan"),
+        })
+        text = _extract_text(card)
+        assert "nan" not in text.lower()
+        assert "--" in text

--- a/shit_tests/shitty_ui/test_layout.py
+++ b/shit_tests/shitty_ui/test_layout.py
@@ -1170,60 +1170,60 @@ class TestCreateFeedSignalCard:
 
 
 class TestSafeGet:
-    """Tests for _safe_get NaN-handling helper."""
+    """Tests for safe_get NaN-handling helper."""
 
     def test_returns_value_when_present(self):
         """Test normal dict access."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": "value"}, "key") == "value"
+        assert safe_get({"key": "value"}, "key") == "value"
 
     def test_returns_default_when_missing(self):
         """Test missing key returns default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"other": "value"}, "key", "default") == "default"
+        assert safe_get({"other": "value"}, "key", "default") == "default"
 
     def test_returns_default_for_nan(self):
         """Test NaN is normalized to default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": float("nan")}, "key", "default") == "default"
+        assert safe_get({"key": float("nan")}, "key", "default") == "default"
 
     def test_returns_default_for_none(self):
         """Test None is normalized to default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": None}, "key", "default") == "default"
+        assert safe_get({"key": None}, "key", "default") == "default"
 
     def test_preserves_zero(self):
         """Test that 0 is NOT replaced with default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": 0}, "key", 99) == 0
+        assert safe_get({"key": 0}, "key", 99) == 0
 
     def test_preserves_empty_string(self):
         """Test that empty string is NOT replaced with default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": ""}, "key", "default") == ""
+        assert safe_get({"key": ""}, "key", "default") == ""
 
     def test_preserves_false(self):
         """Test that False is NOT replaced with default."""
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
-        assert _safe_get({"key": False}, "key", True) is False
+        assert safe_get({"key": False}, "key", True) is False
 
     def test_works_with_pandas_series(self):
         """Test with Pandas Series (the actual use case)."""
         import pandas as pd
-        from components.cards import _safe_get
+        from components.cards import safe_get
 
         series = pd.Series({"a": 1, "b": float("nan"), "c": "hello"})
-        assert _safe_get(series, "a") == 1
-        assert _safe_get(series, "b", "default") == "default"
-        assert _safe_get(series, "c") == "hello"
-        assert _safe_get(series, "missing", "default") == "default"
+        assert safe_get(series, "a") == 1
+        assert safe_get(series, "b", "default") == "default"
+        assert safe_get(series, "c") == "hello"
+        assert safe_get(series, "missing", "default") == "default"
 
 
 class TestSignalFeedCallbackErrorHandling:

--- a/shit_tests/shitty_ui/test_utils.py
+++ b/shit_tests/shitty_ui/test_utils.py
@@ -1,0 +1,94 @@
+"""Tests for shitty_ui/components/utils.py -- NaN-safe utilities."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+from components.utils import safe_get, safe_format_pct, safe_format_dollar
+
+
+class TestSafeGet:
+    """Tests for the safe_get NaN-guard helper."""
+
+    def test_returns_value_for_normal_float(self):
+        assert safe_get({"key": 1.5}, "key") == 1.5
+
+    def test_returns_default_for_nan(self):
+        assert safe_get({"key": float("nan")}, "key", 0.0) == 0.0
+
+    def test_returns_default_for_missing_key(self):
+        assert safe_get({}, "key", "fallback") == "fallback"
+
+    def test_returns_none_for_missing_key_no_default(self):
+        assert safe_get({}, "key") is None
+
+    def test_returns_default_for_none_value(self):
+        assert safe_get({"key": None}, "key", 42) == 42
+
+    def test_returns_string_value_unchanged(self):
+        assert safe_get({"key": "hello"}, "key") == "hello"
+
+    def test_returns_list_value_unchanged(self):
+        assert safe_get({"key": [1, 2]}, "key") == [1, 2]
+
+    def test_returns_zero_float_not_treated_as_nan(self):
+        assert safe_get({"key": 0.0}, "key", 999) == 0.0
+
+    def test_returns_negative_float_unchanged(self):
+        assert safe_get({"key": -3.14}, "key") == -3.14
+
+    def test_works_with_pandas_series(self):
+        import pandas as pd
+
+        row = pd.Series({"val": float("nan"), "ok": 42})
+        assert safe_get(row, "val", 0) == 0
+        assert safe_get(row, "ok", 0) == 42
+
+    def test_returns_bool_unchanged(self):
+        assert safe_get({"key": True}, "key") is True
+        assert safe_get({"key": False}, "key") is False
+
+
+class TestSafeFormatPct:
+    """Tests for safe_format_pct."""
+
+    def test_formats_positive_float(self):
+        assert safe_format_pct(2.5) == "+2.50%"
+
+    def test_formats_negative_float(self):
+        assert safe_format_pct(-1.23) == "-1.23%"
+
+    def test_returns_dash_for_none(self):
+        assert safe_format_pct(None) == "--"
+
+    def test_returns_dash_for_nan(self):
+        assert safe_format_pct(float("nan")) == "--"
+
+    def test_formats_zero(self):
+        assert safe_format_pct(0.0) == "+0.00%"
+
+    def test_custom_format(self):
+        assert safe_format_pct(5.0, fmt=".1f") == "5.0%"
+
+
+class TestSafeFormatDollar:
+    """Tests for safe_format_dollar."""
+
+    def test_formats_positive_amount(self):
+        assert safe_format_dollar(1234.0) == "$+1,234"
+
+    def test_formats_negative_amount(self):
+        assert safe_format_dollar(-500.0) == "$-500"
+
+    def test_returns_dash_for_none(self):
+        assert safe_format_dollar(None) == "--"
+
+    def test_returns_dash_for_nan(self):
+        assert safe_format_dollar(float("nan")) == "--"
+
+    def test_formats_zero(self):
+        assert safe_format_dollar(0.0) == "$+0"
+
+    def test_custom_format_no_sign(self):
+        assert safe_format_dollar(1234.0, fmt=",.0f") == "$1,234"

--- a/shitty_ui/components/cards/__init__.py
+++ b/shitty_ui/components/cards/__init__.py
@@ -90,11 +90,11 @@ from components.cards.signal import (  # noqa: E402
     create_unified_signal_card,
 )
 from components.cards.feed import (  # noqa: E402
-    _safe_get,
     _build_expandable_thesis,
     create_feed_signal_card,
     create_new_signals_banner,
 )
+from components.utils import safe_get  # noqa: E402
 from components.cards.post import create_post_card  # noqa: E402
 from components.cards.timeline import (  # noqa: E402
     create_prediction_timeline_card,
@@ -119,7 +119,7 @@ __all__ = [
     "create_signal_card",
     "create_unified_signal_card",
     # Feed
-    "_safe_get",
+    "safe_get",
     "_build_expandable_thesis",
     "create_feed_signal_card",
     "create_new_signals_banner",

--- a/shitty_ui/components/cards/feed.py
+++ b/shitty_ui/components/cards/feed.py
@@ -5,7 +5,6 @@ thesis, and return/P&L metrics. Also includes the new-signals banner and
 shared helpers used by both feed and post cards.
 """
 
-import math
 from datetime import datetime, timedelta, timezone
 
 from dash import html
@@ -21,24 +20,7 @@ from components.sparkline import (
     create_sparkline_component,
     create_sparkline_placeholder,
 )
-
-
-def _safe_get(row, key, default=None):
-    """
-    NaN-safe field extraction from a Pandas Series or dict.
-
-    Pandas Series.get() returns NaN (not the default) when the key exists
-    but the value is NaN. This helper normalizes NaN to the provided default.
-    """
-    value = row.get(key, default)
-    if value is None:
-        return default
-    try:
-        if isinstance(value, float) and math.isnan(value):
-            return default
-    except (TypeError, ValueError):
-        pass
-    return value
+from components.utils import safe_get
 
 
 def _build_expandable_thesis(
@@ -136,17 +118,17 @@ def create_feed_signal_card(
     Returns:
         html.Div containing the rendered card.
     """
-    timestamp = _safe_get(row, "timestamp")
-    post_text = _safe_get(row, "text", "")
-    confidence = _safe_get(row, "confidence", 0) or 0
-    assets = _safe_get(row, "assets", [])
-    market_impact = _safe_get(row, "market_impact", {})
-    symbol = _safe_get(row, "symbol")
-    prediction_sentiment = _safe_get(row, "prediction_sentiment")
-    return_t7 = _safe_get(row, "return_t7")
-    correct_t7 = _safe_get(row, "correct_t7")
-    pnl_t7 = _safe_get(row, "pnl_t7")
-    thesis = _safe_get(row, "thesis", "")
+    timestamp = safe_get(row, "timestamp")
+    post_text = safe_get(row, "text", "")
+    confidence = safe_get(row, "confidence", 0) or 0
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    symbol = safe_get(row, "symbol")
+    prediction_sentiment = safe_get(row, "prediction_sentiment")
+    return_t7 = safe_get(row, "return_t7")
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
+    thesis = safe_get(row, "thesis", "")
 
     # Determine if "New" badge should show (post < 24 hours old)
     is_new = False

--- a/shitty_ui/components/cards/hero.py
+++ b/shitty_ui/components/cards/hero.py
@@ -14,23 +14,24 @@ from components.helpers import (
     create_outcome_badge,
     format_asset_display,
 )
+from components.utils import safe_get
 
 
 def create_hero_signal_card(row) -> html.Div:
     """Create a hero signal card for a high-confidence prediction."""
-    timestamp = row.get("timestamp")
-    text_content = row.get("text", "")
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
     text_content = strip_urls(text_content)
     preview = text_content[:200] + "..." if len(text_content) > 200 else text_content
-    confidence = row.get("confidence", 0)
-    assets = row.get("assets", [])
-    market_impact = row.get("market_impact", {})
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
     # Derive outcome from aggregated counts (new dedup columns)
     # Fall back to correct_t7 for backward compatibility
-    outcome_count = row.get("outcome_count", 0) or 0
-    correct_count = row.get("correct_count", 0) or 0
-    incorrect_count = row.get("incorrect_count", 0) or 0
-    total_pnl_t7 = row.get("total_pnl_t7")
+    outcome_count = safe_get(row, "outcome_count", 0) or 0
+    correct_count = safe_get(row, "correct_count", 0) or 0
+    incorrect_count = safe_get(row, "incorrect_count", 0) or 0
+    total_pnl_t7 = safe_get(row, "total_pnl_t7")
 
     if outcome_count > 0 and correct_count + incorrect_count > 0:
         # At least some outcomes evaluated -- majority wins
@@ -62,7 +63,7 @@ def create_hero_signal_card(row) -> html.Div:
     }.get(sentiment, "minus")
 
     # Outcome badge -- uses aggregated P&L when available
-    pnl_display = total_pnl_t7 if total_pnl_t7 is not None else row.get("pnl_t7")
+    pnl_display = total_pnl_t7 if total_pnl_t7 is not None else safe_get(row, "pnl_t7")
     outcome = create_outcome_badge(correct_t7, pnl_display, font_size="0.8rem")
 
     return html.Div(

--- a/shitty_ui/components/cards/signal.py
+++ b/shitty_ui/components/cards/signal.py
@@ -21,19 +21,20 @@ from components.sparkline import (
     create_sparkline_component,
     create_sparkline_placeholder,
 )
+from components.utils import safe_get
 
 
 def create_signal_card(row):
     """Create a signal card for recent predictions with time-ago format."""
-    timestamp = row.get("timestamp")
-    text_content = row.get("text", "")
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
     text_content = strip_urls(text_content)
     preview = text_content[:120] + "..." if len(text_content) > 120 else text_content
-    confidence = row.get("confidence", 0)
-    assets = row.get("assets", [])
-    market_impact = row.get("market_impact", {})
-    correct_t7 = row.get("correct_t7")
-    pnl_t7 = row.get("pnl_t7")
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
 
     # Determine sentiment from market_impact
     sentiment = extract_sentiment(market_impact)
@@ -137,20 +138,20 @@ def create_unified_signal_card(row, sparkline_prices: dict = None) -> html.Div:
     Returns:
         html.Div containing the rendered card.
     """
-    timestamp = row.get("timestamp")
-    text_content = row.get("text", "")
+    timestamp = safe_get(row, "timestamp")
+    text_content = safe_get(row, "text", "")
     text_content = strip_urls(text_content)
     preview = text_content[:200] + "..." if len(text_content) > 200 else text_content
-    confidence = row.get("confidence", 0)
-    assets = row.get("assets", [])
-    market_impact = row.get("market_impact", {})
-    thesis = row.get("thesis", "")
+    confidence = safe_get(row, "confidence", 0)
+    assets = safe_get(row, "assets", [])
+    market_impact = safe_get(row, "market_impact", {})
+    thesis = safe_get(row, "thesis", "")
 
     # Aggregated outcome data (from GROUP BY query)
-    outcome_count = row.get("outcome_count", 0) or 0
-    correct_count = row.get("correct_count", 0) or 0
-    incorrect_count = row.get("incorrect_count", 0) or 0
-    total_pnl_t7 = row.get("total_pnl_t7")
+    outcome_count = safe_get(row, "outcome_count", 0) or 0
+    correct_count = safe_get(row, "correct_count", 0) or 0
+    incorrect_count = safe_get(row, "incorrect_count", 0) or 0
+    total_pnl_t7 = safe_get(row, "total_pnl_t7")
 
     # Derive overall correctness from aggregated counts
     if outcome_count > 0 and correct_count + incorrect_count > 0:

--- a/shitty_ui/components/cards/timeline.py
+++ b/shitty_ui/components/cards/timeline.py
@@ -10,6 +10,7 @@ from dash import html, dcc
 
 from constants import COLORS
 from components.cards import strip_urls, get_sentiment_style
+from components.utils import safe_get
 
 
 def create_prediction_timeline_card(row: dict) -> html.Div:
@@ -22,16 +23,16 @@ def create_prediction_timeline_card(row: dict) -> html.Div:
     Returns:
         html.Div component for one timeline entry
     """
-    prediction_date = row.get("prediction_date")
-    timestamp = row.get("timestamp")
-    tweet_text = row.get("text", "")
-    sentiment = row.get("prediction_sentiment", "neutral")
-    confidence = row.get("prediction_confidence", 0)
-    return_t7 = row.get("return_t7")
-    correct_t7 = row.get("correct_t7")
-    pnl_t7 = row.get("pnl_t7")
-    price_at = row.get("price_at_prediction")
-    price_after = row.get("price_t7")
+    prediction_date = safe_get(row, "prediction_date")
+    timestamp = safe_get(row, "timestamp")
+    tweet_text = safe_get(row, "text", "")
+    sentiment = safe_get(row, "prediction_sentiment", "neutral")
+    confidence = safe_get(row, "prediction_confidence", 0)
+    return_t7 = safe_get(row, "return_t7")
+    correct_t7 = safe_get(row, "correct_t7")
+    pnl_t7 = safe_get(row, "pnl_t7")
+    price_at = safe_get(row, "price_at_prediction")
+    price_after = safe_get(row, "price_t7")
 
     # Sentiment styling
     s_style = get_sentiment_style(sentiment)
@@ -232,9 +233,9 @@ def create_related_asset_link(row: dict) -> html.Div:
     Returns:
         html.Div component
     """
-    symbol = row.get("related_symbol", "???")
-    count = row.get("co_occurrence_count", 0)
-    avg_return = row.get("avg_return_t7")
+    symbol = safe_get(row, "related_symbol", "???")
+    count = safe_get(row, "co_occurrence_count", 0)
+    avg_return = safe_get(row, "avg_return_t7")
 
     return_color = COLORS["text_muted"]
     return_str = "--"

--- a/shitty_ui/components/utils.py
+++ b/shitty_ui/components/utils.py
@@ -1,0 +1,74 @@
+"""Shared utility functions for UI components.
+
+Provides NaN-safe data extraction and formatting helpers used across
+multiple card types and callback modules.
+"""
+
+import math
+from typing import Any, Optional
+
+
+def safe_get(row, key: str, default: Any = None) -> Any:
+    """NaN-safe field extraction from a Pandas Series or dict.
+
+    Pandas Series.get() returns NaN (not the default) when the key
+    exists but the value is NaN. This helper normalizes NaN to the
+    provided default, preventing '+nan%' and '$nan' display bugs.
+
+    Args:
+        row: Dict-like object (Pandas Series or plain dict).
+        key: Field name to extract.
+        default: Value to return if the field is missing or NaN.
+
+    Returns:
+        The field value, or default if missing/None/NaN.
+    """
+    value = row.get(key, default)
+    if value is None:
+        return default
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return default
+    except (TypeError, ValueError):
+        pass
+    return value
+
+
+def safe_format_pct(value: Optional[float], fmt: str = "+.2f") -> str:
+    """Format a float as a percentage string, returning '--' for None/NaN.
+
+    Args:
+        value: Float value to format, or None.
+        fmt: Format spec string (default '+.2f' for '+1.23').
+
+    Returns:
+        Formatted string like '+1.23%' or '--'.
+    """
+    if value is None:
+        return "--"
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return "--"
+    except (TypeError, ValueError):
+        return "--"
+    return f"{value:{fmt}}%"
+
+
+def safe_format_dollar(value: Optional[float], fmt: str = "+,.0f") -> str:
+    """Format a float as a dollar string, returning '--' for None/NaN.
+
+    Args:
+        value: Float value to format, or None.
+        fmt: Format spec string (default '+,.0f' for '$+1,234').
+
+    Returns:
+        Formatted string like '$+1,234' or '--'.
+    """
+    if value is None:
+        return "--"
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return "--"
+    except (TypeError, ValueError):
+        return "--"
+    return f"${value:{fmt}}"

--- a/shitty_ui/pages/assets.py
+++ b/shitty_ui/pages/assets.py
@@ -6,6 +6,7 @@ from dash import Dash, html, dcc, Input, Output, callback_context
 import dash_bootstrap_components as dbc
 
 from constants import COLORS, CHART_CONFIG
+from components.utils import safe_format_pct, safe_format_dollar
 from components.charts import build_annotated_price_chart, build_empty_signal_chart
 from components.cards import (
     create_error_card,
@@ -343,12 +344,12 @@ def register_asset_callbacks(app: Dash):
                     dbc.Col(
                         create_metric_card(
                             "Total P&L (7-day)",
-                            f"${stats['total_pnl_t7']:,.0f}",
+                            safe_format_dollar(stats["total_pnl_t7"], fmt=",.0f"),
                             "Based on $1,000 positions",
                             "dollar-sign",
                             (
                                 COLORS["success"]
-                                if stats["total_pnl_t7"] > 0
+                                if (stats["total_pnl_t7"] or 0) > 0
                                 else COLORS["danger"]
                             ),
                         ),
@@ -358,12 +359,12 @@ def register_asset_callbacks(app: Dash):
                     dbc.Col(
                         create_metric_card(
                             "Avg 7-Day Return",
-                            f"{stats['avg_return_t7']:+.2f}%",
+                            safe_format_pct(stats["avg_return_t7"]),
                             f"Confidence: {stats['avg_confidence']:.0%}",
                             "chart-line",
                             (
                                 COLORS["success"]
-                                if stats["avg_return_t7"] > 0
+                                if (stats["avg_return_t7"] or 0) > 0
                                 else COLORS["danger"]
                             ),
                         ),

--- a/shitty_ui/pages/dashboard_callbacks/content.py
+++ b/shitty_ui/pages/dashboard_callbacks/content.py
@@ -11,6 +11,7 @@ from dash import Dash, html, Input, Output
 import dash_bootstrap_components as dbc
 
 from constants import COLORS
+from components.utils import safe_format_pct, safe_format_dollar
 from components.cards import (
     create_error_card,
     create_metric_card,
@@ -127,11 +128,11 @@ def register_content_callbacks(app: Dash) -> None:
                     dbc.Col(
                         create_metric_card(
                             COPY["kpi_avg_return_title"],
-                            f"{kpis['avg_return_t7']:+.2f}%",
+                            safe_format_pct(kpis["avg_return_t7"]),
                             COPY["kpi_avg_return_subtitle"],
                             "chart-line",
                             COLORS["success"]
-                            if kpis["avg_return_t7"] > 0
+                            if (kpis["avg_return_t7"] or 0) > 0
                             else COLORS["danger"],
                             note=fallback_note,
                         ),
@@ -143,11 +144,11 @@ def register_content_callbacks(app: Dash) -> None:
                     dbc.Col(
                         create_metric_card(
                             COPY["kpi_pnl_title"],
-                            f"${kpis['total_pnl']:+,.0f}",
+                            safe_format_dollar(kpis["total_pnl"]),
                             COPY["kpi_pnl_subtitle"],
                             "dollar-sign",
                             COLORS["success"]
-                            if kpis["total_pnl"] > 0
+                            if (kpis["total_pnl"] or 0) > 0
                             else COLORS["danger"],
                             note=fallback_note,
                         ),


### PR DESCRIPTION
## Summary
- **Sentiment extraction bug** — `_extract_sentiment()` now accepts an `asset` parameter for per-asset sentiment lookup from `market_impact` dict. Moved sentiment extraction inside the asset loop so each asset gets its own sentiment (AAPL=bullish, TSLA=bearish) instead of all assets getting the first sentiment.
- **NaN display guards** — Extracted `_safe_get()` from `feed.py` to shared `components/utils.py` with `safe_get()`, `safe_format_pct()`, and `safe_format_dollar()` helpers. Applied across all UI card components (timeline, hero, signal, feed, dashboard KPIs, asset stats) to prevent "+nan%" and "$nan" display.
- **fix-sentiments CLI** — One-time repair command (`python -m shit.market_data fix-sentiments`) to recalculate multi-asset prediction outcomes with incorrect sentiment. Supports `--dry-run`.

## Plan Document
`documentation/planning/phases/alpha-quality_2026-03-04/02_fix-sentiment-bug-nan-guards.md`

## Files Changed
- `shit/market_data/outcome_calculator.py` — Per-asset sentiment extraction
- `shit/market_data/cli.py` — `fix-sentiments` CLI command
- `shitty_ui/components/utils.py` — New shared NaN-safe utilities
- `shitty_ui/components/cards/{feed,timeline,hero,signal,__init__}.py` — safe_get migration
- `shitty_ui/pages/{assets,dashboard_callbacks/content}.py` — NaN-safe formatting
- `shit_tests/` — 35 new tests

## Verification
- 40/40 outcome calculator tests pass
- 845 UI tests pass (3 pre-existing telegram failures)
- 35 new tests: 5 sentiment, 23 utility, 7 NaN resilience
- No new lint errors

## Test plan
- [x] Per-asset sentiment: exact match, case-insensitive, fallback, mixed case keys
- [x] Sentiment flows through calculate_outcome_for_prediction correctly
- [x] safe_get: NaN → default, None → default, 0.0 preserved, False preserved, Pandas Series
- [x] No card renders "nan" in text output (7 card types tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)