### PR TITLE
feat: add timeframe selector and thread T+1/T+3/T+7/T+30 through all dashboard layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Adaptive timeframe screener** — Screener and KPIs now use period-appropriate timeframes (T+1 for 7D, T+3 for 30D, T+7 for 90D/All) instead of hardcoded T+7, preventing structurally empty results when viewing short periods
-- **Shared `_timeframe_for_period()` helper** — Centralized timeframe mapping in `data/base.py` used by both screener and KPI queries
+- **Multi-timeframe dashboard** — New "Outcome Window" toggle (T+1, T+3, T+7, T+30) on the dashboard lets users view KPIs, screener, and insights across any prediction timeframe instead of only T+7
+- **Timeframe column mapping module** — `data/timeframe.py` provides `get_tf_columns()`, `TIMEFRAME_OPTIONS`, `VALID_TIMEFRAMES`, and `DEFAULT_TIMEFRAME` as single source of truth for timeframe→column mapping
+- 12 new tests for timeframe module (`test_timeframe.py`)
 
 ### Changed
+- **All query functions parameterized** — 20+ functions in `performance_queries.py`, `asset_queries.py`, and `insight_queries.py` now accept an explicit `timeframe` parameter (default "t7") instead of hardcoded T+7 column references
+- **Generic dict keys** — Return dicts use generic names (`accuracy`, `avg_return`, `total_pnl`) instead of `_t7` suffixed names. UI components and tests updated accordingly
 - **Professional dashboard copy** — Replaced 14 self-deprecating COPY entries in `brand_copy.py` and 9 insight body strings in `insight_queries.py` with professional, data-focused language. KPI subtitles now dynamically reflect the active timeframe.
+
+### Removed
+- **`_timeframe_for_period()` helper** — Removed auto-selection logic from `data/base.py`; replaced by explicit user-controlled timeframe selection via the UI toggle
 
 ### Removed
 - **Dead `MarketMovement` model** — Removed unused `MarketMovement` class, `market_movement_to_dict()`, and relationship from `Prediction`. Superseded by `PredictionOutcome` (database table preserved).

--- a/documentation/planning/phases/alpha-quality_2026-03-04/04_multi-timeframe-dashboard.md
+++ b/documentation/planning/phases/alpha-quality_2026-03-04/04_multi-timeframe-dashboard.md
@@ -1,3 +1,7 @@
+✅ COMPLETE
+Started: 2026-03-04
+Completed: 2026-03-04
+
 # Phase 04: Multi-Timeframe Dashboard
 
 **PR Title:** feat: add timeframe selector and thread T+1/T+3/T+7/T+30 through all dashboard layers
@@ -22,11 +26,20 @@ This phase adds a **Timeframe Selector** button group to the dashboard, creates 
 
 ## Dependencies
 
-- **None** — This phase can be implemented independently. No other phase modifies the same files.
+- **Phase 03** (PR #106) — Added `_timeframe_for_period()` and adaptive timeframe logic. Phase 04 supersedes this with explicit timeframe selection.
 
 ## Unlocks
 
 - **None** — Standalone enhancement.
+
+---
+
+## Challenge Round Decisions (2026-03-04)
+
+1. **Remove `_timeframe_for_period()`**: Phase 03's auto-selection logic is superseded by the explicit timeframe selector. Remove from `data/base.py` and all callsites. `data/timeframe.py` becomes the single source of truth.
+2. **Replace screener `timeframe_label` with `timeframe`**: `build_screener_table()` gets `timeframe: str = "t7"` instead of `timeframe_label: str = "7d"`. Label derived internally via `get_tf_columns()`.
+3. **Implement from current code**: Plan's before/after examples are stale (Phase 03 shifted line numbers and modified content.py). Implementation follows the plan's intent against the actual current codebase.
+4. **Rename all `_t7` suffixed dict keys**: `avg_return_t7` → `avg_return`, `accuracy_t7` → `accuracy`, etc. across all query functions and their consumers (including tests).
 
 ---
 

--- a/shit_tests/shitty_ui/test_cards.py
+++ b/shit_tests/shitty_ui/test_cards.py
@@ -1052,11 +1052,11 @@ class TestNanResilience:
         assert "nan" not in text.lower()
 
     def test_related_asset_link_nan_return(self):
-        """Related asset link handles NaN avg_return_t7."""
+        """Related asset link handles NaN avg_return."""
         card = create_related_asset_link({
             "related_symbol": "TSLA",
             "co_occurrence_count": 3,
-            "avg_return_t7": float("nan"),
+            "avg_return": float("nan"),
         })
         text = _extract_text(card)
         assert "nan" not in text.lower()

--- a/shit_tests/shitty_ui/test_data.py
+++ b/shit_tests/shitty_ui/test_data.py
@@ -189,11 +189,11 @@ class TestGetPerformanceMetrics:
             [(100, 60, 40, 100, 2.5, 2500.0, 0.72)],
             [
                 "total_outcomes",
-                "correct_t7",
-                "incorrect_t7",
-                "evaluated_t7",
-                "avg_return_t7",
-                "total_pnl_t7",
+                "correct",
+                "incorrect",
+                "evaluated",
+                "avg_return",
+                "total_pnl",
                 "avg_confidence",
             ],
         )
@@ -203,9 +203,9 @@ class TestGetPerformanceMetrics:
         assert isinstance(result, dict)
         assert result["total_outcomes"] == 100
         assert result["correct_predictions"] == 60
-        assert result["accuracy_t7"] == 60.0
-        assert result["avg_return_t7"] == 2.5
-        assert result["total_pnl_t7"] == 2500.0
+        assert result["accuracy"] == 60.0
+        assert result["avg_return"] == 2.5
+        assert result["total_pnl"] == 2500.0
 
     @patch("data.base.execute_query")
     def test_calculates_accuracy_correctly(self, mock_execute):
@@ -216,18 +216,18 @@ class TestGetPerformanceMetrics:
             [(50, 35, 15, 50, 1.5, 1500.0, 0.65)],
             [
                 "total_outcomes",
-                "correct_t7",
-                "incorrect_t7",
-                "evaluated_t7",
-                "avg_return_t7",
-                "total_pnl_t7",
+                "correct",
+                "incorrect",
+                "evaluated",
+                "avg_return",
+                "total_pnl",
                 "avg_confidence",
             ],
         )
 
         result = get_performance_metrics()
 
-        assert result["accuracy_t7"] == 70.0  # 35/50 = 70%
+        assert result["accuracy"] == 70.0  # 35/50 = 70%
 
     @patch("data.base.execute_query")
     def test_handles_zero_evaluated(self, mock_execute):
@@ -238,18 +238,18 @@ class TestGetPerformanceMetrics:
             [(0, 0, 0, 0, None, 0.0, None)],
             [
                 "total_outcomes",
-                "correct_t7",
-                "incorrect_t7",
-                "evaluated_t7",
-                "avg_return_t7",
-                "total_pnl_t7",
+                "correct",
+                "incorrect",
+                "evaluated",
+                "avg_return",
+                "total_pnl",
                 "avg_confidence",
             ],
         )
 
         result = get_performance_metrics()
 
-        assert result["accuracy_t7"] == 0.0
+        assert result["accuracy"] == 0.0
 
     @patch("data.base.execute_query")
     def test_returns_defaults_on_error(self, mock_execute):
@@ -261,7 +261,7 @@ class TestGetPerformanceMetrics:
         result = get_performance_metrics()
 
         assert result["total_outcomes"] == 0
-        assert result["accuracy_t7"] == 0.0
+        assert result["accuracy"] == 0.0
 
 
 class TestGetDashboardKpis:
@@ -274,7 +274,7 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(80, 48, 2.15, 1720.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
@@ -283,7 +283,7 @@ class TestGetDashboardKpis:
         assert isinstance(result, dict)
         assert result["total_signals"] == 80
         assert result["accuracy_pct"] == 60.0  # 48/80 = 60%
-        assert result["avg_return_t7"] == 2.15
+        assert result["avg_return"] == 2.15
         assert result["total_pnl"] == 1720.0
 
     @patch("data.base.execute_query")
@@ -293,7 +293,7 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(200, 130, 1.8, 3200.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
@@ -308,7 +308,7 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(0, 0, None, 0.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
@@ -316,7 +316,7 @@ class TestGetDashboardKpis:
 
         assert result["total_signals"] == 0
         assert result["accuracy_pct"] == 0.0
-        assert result["avg_return_t7"] == 0.0
+        assert result["avg_return"] == 0.0
         assert result["total_pnl"] == 0.0
 
     @patch("data.base.execute_query")
@@ -331,7 +331,7 @@ class TestGetDashboardKpis:
 
         assert result["total_signals"] == 0
         assert result["accuracy_pct"] == 0.0
-        assert result["avg_return_t7"] == 0.0
+        assert result["avg_return"] == 0.0
         assert result["total_pnl"] == 0.0
 
     @patch("data.base.execute_query")
@@ -341,7 +341,7 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(10, 6, 1.5, 600.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
@@ -359,7 +359,7 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(500, 300, 2.0, 15000.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
@@ -377,14 +377,14 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(50, 20, -1.5, -750.0)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
         result = get_dashboard_kpis()
 
         assert result["total_pnl"] == -750.0
-        assert result["avg_return_t7"] == -1.5
+        assert result["avg_return"] == -1.5
         assert result["accuracy_pct"] == 40.0  # 20/50 = 40%
 
     @patch("data.base.execute_query")
@@ -394,13 +394,13 @@ class TestGetDashboardKpis:
 
         mock_execute.return_value = (
             [(0, 0, None, None)],
-            ["total_signals", "correct_count", "avg_return_t7", "total_pnl"],
+            ["total_signals", "correct_count", "avg_return", "total_pnl"],
         )
 
         get_dashboard_kpis.clear_cache()
         result = get_dashboard_kpis()
 
-        assert result["avg_return_t7"] == 0.0
+        assert result["avg_return"] == 0.0
         assert result["total_pnl"] == 0.0
 
 
@@ -818,11 +818,11 @@ class TestTimePeriodFiltering:
             [(50, 30, 20, 50, 2.5, 2500.0, 0.72)],
             [
                 "total_outcomes",
-                "correct_t7",
-                "incorrect_t7",
-                "evaluated_t7",
-                "avg_return_t7",
-                "total_pnl_t7",
+                "correct",
+                "incorrect",
+                "evaluated",
+                "avg_return",
+                "total_pnl",
                 "avg_confidence",
             ],
         )
@@ -842,11 +842,11 @@ class TestTimePeriodFiltering:
             [(100, 60, 40, 100, 2.5, 2500.0, 0.72)],
             [
                 "total_outcomes",
-                "correct_t7",
-                "incorrect_t7",
-                "evaluated_t7",
-                "avg_return_t7",
-                "total_pnl_t7",
+                "correct",
+                "incorrect",
+                "evaluated",
+                "avg_return",
+                "total_pnl",
                 "avg_confidence",
             ],
         )
@@ -1655,12 +1655,12 @@ class TestGetAssetStats:
         assert isinstance(result, dict)
         assert result["total_predictions"] == 20
         assert result["correct_predictions"] == 14
-        assert result["accuracy_t7"] == 70.0  # 14/20 = 70%
+        assert result["accuracy"] == 70.0  # 14/20 = 70%
         assert result["bullish_count"] == 12
         assert result["bearish_count"] == 6
-        assert result["best_return_t7"] == 8.5
-        assert result["worst_return_t7"] == -3.2
-        assert result["overall_accuracy_t7"] == 60.0  # 600/1000 = 60%
+        assert result["best_return"] == 8.5
+        assert result["worst_return"] == -3.2
+        assert result["overall_accuracy"] == 60.0  # 600/1000 = 60%
 
     @patch("data.base.execute_query")
     def test_handles_zero_evaluated(self, mock_execute):
@@ -1709,8 +1709,8 @@ class TestGetAssetStats:
         get_asset_stats.clear_cache()
         result = get_asset_stats("UNKNOWN")
 
-        assert result["accuracy_t7"] == 0.0
-        assert result["best_return_t7"] is None
+        assert result["accuracy"] == 0.0
+        assert result["best_return"] is None
 
     @patch("data.base.execute_query")
     def test_returns_defaults_on_error(self, mock_execute):
@@ -1723,8 +1723,8 @@ class TestGetAssetStats:
         result = get_asset_stats("AAPL")
 
         assert result["total_predictions"] == 0
-        assert result["accuracy_t7"] == 0.0
-        assert result["overall_accuracy_t7"] == 0.0
+        assert result["accuracy"] == 0.0
+        assert result["overall_accuracy"] == 0.0
 
 
 class TestGetRelatedAssets:
@@ -1741,7 +1741,7 @@ class TestGetRelatedAssets:
                 ("MSFT", 12, 1.8),
                 ("AMZN", 8, -0.5),
             ],
-            ["related_symbol", "co_occurrence_count", "avg_return_t7"],
+            ["related_symbol", "co_occurrence_count", "avg_return"],
         )
 
         result = get_related_assets("AAPL", limit=10)
@@ -3034,14 +3034,14 @@ class TestGetDashboardKpisWithFallback:
         mock_kpis.return_value = {
             "total_signals": 10,
             "accuracy_pct": 60.0,
-            "avg_return_t7": 1.5,
+            "avg_return": 1.5,
             "total_pnl": 500.0,
         }
         result = get_dashboard_kpis_with_fallback(days=7)
         assert result["total_signals"] == 10
         assert result["is_fallback"] is False
         assert result["fallback_label"] == ""
-        mock_kpis.assert_called_once_with(days=7)
+        mock_kpis.assert_called_once_with(days=7, timeframe="t7")
 
     @patch("data.performance_queries.get_dashboard_kpis")
     def test_falls_back_to_alltime_when_period_empty(self, mock_kpis):
@@ -3049,16 +3049,16 @@ class TestGetDashboardKpisWithFallback:
         from data import get_dashboard_kpis_with_fallback
 
         mock_kpis.side_effect = [
-            {"total_signals": 0, "accuracy_pct": 0.0, "avg_return_t7": 0.0, "total_pnl": 0.0},
-            {"total_signals": 80, "accuracy_pct": 55.0, "avg_return_t7": 1.2, "total_pnl": 1000.0},
+            {"total_signals": 0, "accuracy_pct": 0.0, "avg_return": 0.0, "total_pnl": 0.0},
+            {"total_signals": 80, "accuracy_pct": 55.0, "avg_return": 1.2, "total_pnl": 1000.0},
         ]
         result = get_dashboard_kpis_with_fallback(days=7)
         assert result["total_signals"] == 80
         assert result["is_fallback"] is True
         assert result["fallback_label"] == "Showing all-time data"
         assert mock_kpis.call_count == 2
-        mock_kpis.assert_any_call(days=7)
-        mock_kpis.assert_any_call(days=None)
+        mock_kpis.assert_any_call(days=7, timeframe="t7")
+        mock_kpis.assert_any_call(days=None, timeframe="t7")
 
     @patch("data.performance_queries.get_dashboard_kpis")
     def test_no_fallback_when_days_is_none(self, mock_kpis):
@@ -3068,12 +3068,12 @@ class TestGetDashboardKpisWithFallback:
         mock_kpis.return_value = {
             "total_signals": 0,
             "accuracy_pct": 0.0,
-            "avg_return_t7": 0.0,
+            "avg_return": 0.0,
             "total_pnl": 0.0,
         }
         result = get_dashboard_kpis_with_fallback(days=None)
         assert result["is_fallback"] is False
-        mock_kpis.assert_called_once_with(days=None)
+        mock_kpis.assert_called_once_with(days=None, timeframe="t7")
 
     @patch("data.performance_queries.get_dashboard_kpis")
     def test_preserves_all_original_keys(self, mock_kpis):
@@ -3083,13 +3083,13 @@ class TestGetDashboardKpisWithFallback:
         mock_kpis.return_value = {
             "total_signals": 5,
             "accuracy_pct": 70.0,
-            "avg_return_t7": 2.0,
+            "avg_return": 2.0,
             "total_pnl": 300.0,
         }
         result = get_dashboard_kpis_with_fallback(days=30)
         assert "total_signals" in result
         assert "accuracy_pct" in result
-        assert "avg_return_t7" in result
+        assert "avg_return" in result
         assert "total_pnl" in result
         assert "is_fallback" in result
         assert "fallback_label" in result

--- a/shit_tests/shitty_ui/test_data_screener.py
+++ b/shit_tests/shitty_ui/test_data_screener.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock
 
 from data import get_asset_screener_data, get_screener_sparkline_prices
-from data.base import _timeframe_for_period
 
 
 @pytest.fixture(autouse=True)
@@ -186,30 +185,8 @@ class TestGetScreenerSparklinePrices:
         assert len(df) == 3
 
 
-class TestTimeframeForPeriod:
-    """Tests for _timeframe_for_period helper."""
-
-    def test_7d_returns_t1(self):
-        assert _timeframe_for_period(7) == "t1"
-
-    def test_30d_returns_t3(self):
-        assert _timeframe_for_period(30) == "t3"
-
-    def test_90d_returns_t7(self):
-        assert _timeframe_for_period(90) == "t7"
-
-    def test_none_returns_t7(self):
-        assert _timeframe_for_period(None) == "t7"
-
-    def test_1d_returns_t1(self):
-        assert _timeframe_for_period(1) == "t1"
-
-    def test_14d_returns_t3(self):
-        assert _timeframe_for_period(14) == "t3"
-
-
-class TestAdaptiveTimeframeScreener:
-    """Tests for adaptive timeframe in get_asset_screener_data."""
+class TestExplicitTimeframeScreener:
+    """Tests for explicit timeframe parameter in get_asset_screener_data."""
 
     @pytest.fixture(autouse=True)
     def _clear(self):
@@ -218,26 +195,26 @@ class TestAdaptiveTimeframeScreener:
         get_asset_screener_data.clear_cache()
 
     @patch("data.base.execute_query")
-    def test_7d_uses_t1_columns(self, mock_query):
+    def test_t1_uses_t1_columns(self, mock_query):
         mock_query.return_value = ([], [])
-        get_asset_screener_data(days=7)
+        get_asset_screener_data(timeframe="t1")
         query_text = str(mock_query.call_args[0][0])
         assert "correct_t1" in query_text
         assert "return_t1" in query_text
         assert "pnl_t1" in query_text
 
     @patch("data.base.execute_query")
-    def test_30d_uses_t3_columns(self, mock_query):
+    def test_t3_uses_t3_columns(self, mock_query):
         mock_query.return_value = ([], [])
-        get_asset_screener_data(days=30)
+        get_asset_screener_data(timeframe="t3")
         query_text = str(mock_query.call_args[0][0])
         assert "correct_t3" in query_text
         assert "return_t3" in query_text
 
     @patch("data.base.execute_query")
-    def test_alltime_uses_t7_columns(self, mock_query):
+    def test_default_uses_t7_columns(self, mock_query):
         mock_query.return_value = ([], [])
-        get_asset_screener_data(days=None)
+        get_asset_screener_data()
         query_text = str(mock_query.call_args[0][0])
         assert "correct_t7" in query_text
 
@@ -256,6 +233,6 @@ class TestAdaptiveTimeframeScreener:
                 "latest_sentiment",
             ],
         )
-        df = get_asset_screener_data(days=7)
+        df = get_asset_screener_data(timeframe="t1")
         assert "timeframe" in df.columns
         assert df.iloc[0]["timeframe"] == "t1"

--- a/shit_tests/shitty_ui/test_layout.py
+++ b/shit_tests/shitty_ui/test_layout.py
@@ -186,9 +186,9 @@ class TestCreateApp:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -232,9 +232,9 @@ class TestCreateApp:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -550,9 +550,9 @@ class TestRegisterCallbacks:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -844,9 +844,9 @@ class TestLoadingStates:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -894,9 +894,9 @@ class TestTimePeriodSelector:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -944,9 +944,9 @@ class TestRefreshIndicator:
             "evaluated_predictions": 0,
             "correct_predictions": 0,
             "incorrect_predictions": 0,
-            "accuracy_t7": 0.0,
-            "avg_return_t7": 0.0,
-            "total_pnl_t7": 0.0,
+            "accuracy": 0.0,
+            "avg_return": 0.0,
+            "total_pnl": 0.0,
             "avg_confidence": 0.0,
         }
         mock_conf_acc.return_value = pd.DataFrame()
@@ -1677,8 +1677,8 @@ class TestClientSideRoutes:
     }
     _mock_perf = {
         "total_outcomes": 0, "evaluated_predictions": 0, "correct_predictions": 0,
-        "incorrect_predictions": 0, "accuracy_t7": 0.0, "avg_return_t7": 0.0,
-        "total_pnl_t7": 0.0, "avg_confidence": 0.0,
+        "incorrect_predictions": 0, "accuracy": 0.0, "avg_return": 0.0,
+        "total_pnl": 0.0, "avg_confidence": 0.0,
     }
 
     @patch("data.get_prediction_stats")
@@ -1894,7 +1894,7 @@ class TestCSSExternalFile:
     ):
         """Test that index_string no longer has an embedded <style> block."""
         mock_stats.return_value = {"total_posts": 0, "analyzed_posts": 0, "completed_analyses": 0, "bypassed_posts": 0, "avg_confidence": 0.0, "high_confidence_predictions": 0}
-        mock_perf.return_value = {"total_outcomes": 0, "evaluated_predictions": 0, "correct_predictions": 0, "incorrect_predictions": 0, "accuracy_t7": 0.0, "avg_return_t7": 0.0, "total_pnl_t7": 0.0, "avg_confidence": 0.0}
+        mock_perf.return_value = {"total_outcomes": 0, "evaluated_predictions": 0, "correct_predictions": 0, "incorrect_predictions": 0, "accuracy": 0.0, "avg_return": 0.0, "total_pnl": 0.0, "avg_confidence": 0.0}
         mock_conf_acc.return_value = pd.DataFrame()
         mock_asset_acc.return_value = pd.DataFrame()
         mock_signals.return_value = pd.DataFrame()
@@ -1919,7 +1919,7 @@ class TestViewportMetaTag:
     ):
         """Test that app index_string contains viewport meta tag for mobile."""
         mock_stats.return_value = {"total_posts": 0, "analyzed_posts": 0, "completed_analyses": 0, "bypassed_posts": 0, "avg_confidence": 0.0, "high_confidence_predictions": 0}
-        mock_perf.return_value = {"total_outcomes": 0, "evaluated_predictions": 0, "correct_predictions": 0, "incorrect_predictions": 0, "accuracy_t7": 0.0, "avg_return_t7": 0.0, "total_pnl_t7": 0.0, "avg_confidence": 0.0}
+        mock_perf.return_value = {"total_outcomes": 0, "evaluated_predictions": 0, "correct_predictions": 0, "incorrect_predictions": 0, "accuracy": 0.0, "avg_return": 0.0, "total_pnl": 0.0, "avg_confidence": 0.0}
         mock_conf_acc.return_value = pd.DataFrame()
         mock_asset_acc.return_value = pd.DataFrame()
         mock_signals.return_value = pd.DataFrame()

--- a/shit_tests/shitty_ui/test_timeframe.py
+++ b/shit_tests/shitty_ui/test_timeframe.py
@@ -1,0 +1,103 @@
+"""Tests for the timeframe column mapping helper module."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+import pytest
+
+from data.timeframe import (
+    get_tf_columns,
+    TIMEFRAME_OPTIONS,
+    VALID_TIMEFRAMES,
+    DEFAULT_TIMEFRAME,
+)
+
+
+class TestTimeframeConstants:
+    """Tests for module-level constants."""
+
+    def test_valid_timeframes_tuple(self):
+        """VALID_TIMEFRAMES is a tuple of all timeframe keys."""
+        assert isinstance(VALID_TIMEFRAMES, tuple)
+        assert set(VALID_TIMEFRAMES) == {"t1", "t3", "t7", "t30"}
+
+    def test_default_timeframe_is_t7(self):
+        """Default timeframe is t7."""
+        assert DEFAULT_TIMEFRAME == "t7"
+
+    def test_default_timeframe_in_valid(self):
+        """Default timeframe is in the valid set."""
+        assert DEFAULT_TIMEFRAME in VALID_TIMEFRAMES
+
+    def test_timeframe_options_has_all_keys(self):
+        """TIMEFRAME_OPTIONS has entries for all valid timeframes."""
+        for tf in VALID_TIMEFRAMES:
+            assert tf in TIMEFRAME_OPTIONS
+
+    def test_each_option_has_required_keys(self):
+        """Each timeframe option has all required column mapping keys."""
+        required = {
+            "correct_col",
+            "return_col",
+            "pnl_col",
+            "price_col",
+            "label_short",
+            "label_long",
+            "label_days",
+        }
+        for tf, mapping in TIMEFRAME_OPTIONS.items():
+            assert set(mapping.keys()) == required, f"{tf} missing keys"
+
+
+class TestGetTfColumns:
+    """Tests for get_tf_columns()."""
+
+    def test_default_returns_t7(self):
+        """Calling with no argument returns t7 columns."""
+        result = get_tf_columns()
+        assert result["correct_col"] == "correct_t7"
+        assert result["return_col"] == "return_t7"
+        assert result["pnl_col"] == "pnl_t7"
+        assert result["price_col"] == "price_t7"
+
+    def test_t1_columns(self):
+        """T+1 timeframe returns correct column names."""
+        result = get_tf_columns("t1")
+        assert result["correct_col"] == "correct_t1"
+        assert result["return_col"] == "return_t1"
+        assert result["pnl_col"] == "pnl_t1"
+        assert result["price_col"] == "price_t1"
+        assert result["label_short"] == "1D"
+        assert result["label_long"] == "1-Day"
+
+    def test_t3_columns(self):
+        """T+3 timeframe returns correct column names."""
+        result = get_tf_columns("t3")
+        assert result["correct_col"] == "correct_t3"
+        assert result["return_col"] == "return_t3"
+
+    def test_t30_columns(self):
+        """T+30 timeframe returns correct column names."""
+        result = get_tf_columns("t30")
+        assert result["correct_col"] == "correct_t30"
+        assert result["return_col"] == "return_t30"
+        assert result["pnl_col"] == "pnl_t30"
+        assert result["label_short"] == "30D"
+
+    def test_invalid_timeframe_raises(self):
+        """Invalid timeframe key raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid timeframe"):
+            get_tf_columns("t99")
+
+    def test_empty_string_raises(self):
+        """Empty string raises ValueError."""
+        with pytest.raises(ValueError):
+            get_tf_columns("")
+
+    def test_returns_copy_not_reference(self):
+        """get_tf_columns returns a new dict, not a reference to the global."""
+        result = get_tf_columns("t7")
+        result["correct_col"] = "mutated"
+        assert TIMEFRAME_OPTIONS["t7"]["correct_col"] == "correct_t7"

--- a/shitty_ui/components/cards/metrics.py
+++ b/shitty_ui/components/cards/metrics.py
@@ -131,16 +131,16 @@ def create_performance_summary(stats: Dict[str, Any]) -> html.Div:
     Returns:
         html.Div with comparison metrics
     """
-    asset_accuracy = stats.get("accuracy_t7", 0)
-    overall_accuracy = stats.get("overall_accuracy_t7", 0)
+    asset_accuracy = stats.get("accuracy", 0)
+    overall_accuracy = stats.get("overall_accuracy", 0)
     accuracy_diff = asset_accuracy - overall_accuracy
 
-    asset_return = stats.get("avg_return_t7", 0)
-    overall_return = stats.get("overall_avg_return_t7", 0)
+    asset_return = stats.get("avg_return", 0)
+    overall_return = stats.get("overall_avg_return", 0)
     return_diff = asset_return - overall_return
 
-    best = stats.get("best_return_t7")
-    worst = stats.get("worst_return_t7")
+    best = stats.get("best_return")
+    worst = stats.get("worst_return")
 
     return html.Div(
         [

--- a/shitty_ui/components/cards/timeline.py
+++ b/shitty_ui/components/cards/timeline.py
@@ -228,14 +228,14 @@ def create_related_asset_link(row: dict) -> html.Div:
     Create a clickable link for a related asset.
 
     Args:
-        row: Dictionary with keys: related_symbol, co_occurrence_count, avg_return_t7
+        row: Dictionary with keys: related_symbol, co_occurrence_count, avg_return
 
     Returns:
         html.Div component
     """
     symbol = safe_get(row, "related_symbol", "???")
     count = safe_get(row, "co_occurrence_count", 0)
-    avg_return = safe_get(row, "avg_return_t7")
+    avg_return = safe_get(row, "avg_return")
 
     return_color = COLORS["text_muted"]
     return_str = "--"

--- a/shitty_ui/data/__init__.py
+++ b/shitty_ui/data/__init__.py
@@ -10,7 +10,16 @@ Internal structure:
     data/performance_queries.py -- KPIs, accuracy, P&L, streaks
     data/asset_queries.py     -- Screener, sparklines, asset stats
     data/insight_queries.py   -- Dynamic insight cards
+    data/timeframe.py         -- Timeframe column mapping helper
 """
+
+# --- Timeframe helpers ---
+from data.timeframe import (  # noqa: F401
+    get_tf_columns,
+    TIMEFRAME_OPTIONS,
+    VALID_TIMEFRAMES,
+    DEFAULT_TIMEFRAME,
+)
 
 # --- Base infrastructure ---
 from data.base import (  # noqa: F401
@@ -114,6 +123,11 @@ def clear_all_caches() -> None:
 
 
 __all__ = [
+    # Timeframe
+    "get_tf_columns",
+    "TIMEFRAME_OPTIONS",
+    "VALID_TIMEFRAMES",
+    "DEFAULT_TIMEFRAME",
     # Base
     "execute_query",
     "ttl_cache",

--- a/shitty_ui/data/asset_queries.py
+++ b/shitty_ui/data/asset_queries.py
@@ -33,7 +33,8 @@ def get_asset_screener_data(
         incorrect, avg_return, total_pnl, accuracy, latest_sentiment,
         avg_confidence, timeframe. Sorted by total_predictions descending.
     """
-    tf_cols = get_tf_columns(timeframe)
+    # Validate timeframe key; use raw key for column interpolation
+    get_tf_columns(timeframe)
     tf = timeframe
 
     date_filter = ""

--- a/shitty_ui/data/asset_queries.py
+++ b/shitty_ui/data/asset_queries.py
@@ -154,7 +154,10 @@ def get_screener_sparkline_prices(symbols: tuple) -> Dict[str, pd.DataFrame]:
 
 
 def get_similar_predictions(
-    asset: str = None, limit: int = 10, days: int = None
+    asset: str = None,
+    limit: int = 10,
+    days: int = None,
+    timeframe: str = DEFAULT_TIMEFRAME,
 ) -> pd.DataFrame:
     """
     Get predictions for a specific asset with their outcomes.
@@ -164,9 +167,16 @@ def get_similar_predictions(
         asset: Asset symbol to filter by
         limit: Maximum number of predictions to return
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
     """
     if not asset:
         return pd.DataFrame()
+
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+    price_col = tf["price_col"]
 
     # Build date filter
     date_filter = ""
@@ -187,16 +197,16 @@ def get_similar_predictions(
             po.prediction_sentiment,
             po.return_t1,
             po.return_t3,
-            po.return_t7,
-            po.correct_t7,
-            po.pnl_t7,
+            po.{return_col},
+            po.{correct_col},
+            po.{pnl_col},
             po.price_at_prediction,
-            po.price_t7
+            po.{price_col}
         FROM prediction_outcomes po
         INNER JOIN predictions p ON po.prediction_id = p.id
         INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
         WHERE po.symbol = :asset
-            AND po.correct_t7 IS NOT NULL
+            AND po.{correct_col} IS NOT NULL
             {date_filter}
         ORDER BY tss.timestamp DESC
         LIMIT :limit
@@ -494,55 +504,51 @@ def get_asset_predictions(symbol: str, limit: int = 50) -> pd.DataFrame:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_asset_stats(symbol: str) -> Dict[str, Any]:
+def get_asset_stats(
+    symbol: str, timeframe: str = DEFAULT_TIMEFRAME
+) -> Dict[str, Any]:
     """
     Get aggregate performance statistics for a specific asset,
     alongside overall system averages for comparison.
 
     Args:
         symbol: Ticker symbol (e.g., 'AAPL')
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
-        Dictionary with keys:
-          - total_predictions (int)
-          - correct_predictions (int)
-          - incorrect_predictions (int)
-          - accuracy_t7 (float, percentage)
-          - avg_return_t7 (float, percentage)
-          - total_pnl_t7 (float, dollar amount)
-          - avg_confidence (float, 0-1)
-          - bullish_count (int)
-          - bearish_count (int)
-          - neutral_count (int)
-          - best_return_t7 (float or None)
-          - worst_return_t7 (float or None)
-          - overall_accuracy_t7 (float, percentage, system-wide)
-          - overall_avg_return_t7 (float, percentage, system-wide)
+        Dictionary with generic keys (no _t7 suffix):
+          accuracy, avg_return, total_pnl, best_return, worst_return,
+          overall_accuracy, overall_avg_return, etc.
         Returns zeroed dict on error.
     """
-    query = text("""
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
+    query = text(f"""
         WITH asset_stats AS (
             SELECT
                 COUNT(*) AS total_predictions,
-                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS correct,
-                COUNT(CASE WHEN correct_t7 = false THEN 1 END) AS incorrect,
-                COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS evaluated,
-                AVG(CASE WHEN correct_t7 IS NOT NULL THEN return_t7 END) AS avg_return,
-                SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) AS total_pnl,
+                COUNT(CASE WHEN {correct_col} = true THEN 1 END) AS correct,
+                COUNT(CASE WHEN {correct_col} = false THEN 1 END) AS incorrect,
+                COUNT(CASE WHEN {correct_col} IS NOT NULL THEN 1 END) AS evaluated,
+                AVG(CASE WHEN {correct_col} IS NOT NULL THEN {return_col} END) AS avg_return,
+                SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END) AS total_pnl,
                 AVG(prediction_confidence) AS avg_confidence,
                 COUNT(CASE WHEN prediction_sentiment = 'bullish' THEN 1 END) AS bullish_count,
                 COUNT(CASE WHEN prediction_sentiment = 'bearish' THEN 1 END) AS bearish_count,
                 COUNT(CASE WHEN prediction_sentiment = 'neutral' THEN 1 END) AS neutral_count,
-                MAX(return_t7) AS best_return,
-                MIN(return_t7) AS worst_return
+                MAX({return_col}) AS best_return,
+                MIN({return_col}) AS worst_return
             FROM prediction_outcomes
             WHERE symbol = :symbol
         ),
         overall_stats AS (
             SELECT
-                COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS overall_evaluated,
-                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS overall_correct,
-                AVG(CASE WHEN correct_t7 IS NOT NULL THEN return_t7 END) AS overall_avg_return
+                COUNT(CASE WHEN {correct_col} IS NOT NULL THEN 1 END) AS overall_evaluated,
+                COUNT(CASE WHEN {correct_col} = true THEN 1 END) AS overall_correct,
+                AVG(CASE WHEN {correct_col} IS NOT NULL THEN {return_col} END) AS overall_avg_return
             FROM prediction_outcomes
         )
         SELECT
@@ -584,17 +590,17 @@ def get_asset_stats(symbol: str) -> Dict[str, Any]:
                 "total_predictions": row[0] or 0,
                 "correct_predictions": correct,
                 "incorrect_predictions": row[2] or 0,
-                "accuracy_t7": round(accuracy, 1),
-                "avg_return_t7": round(float(row[4]), 2) if row[4] else 0.0,
-                "total_pnl_t7": round(float(row[5]), 2) if row[5] else 0.0,
+                "accuracy": round(accuracy, 1),
+                "avg_return": round(float(row[4]), 2) if row[4] else 0.0,
+                "total_pnl": round(float(row[5]), 2) if row[5] else 0.0,
                 "avg_confidence": round(float(row[6]), 2) if row[6] else 0.0,
                 "bullish_count": row[7] or 0,
                 "bearish_count": row[8] or 0,
                 "neutral_count": row[9] or 0,
-                "best_return_t7": round(float(row[10]), 2) if row[10] else None,
-                "worst_return_t7": round(float(row[11]), 2) if row[11] else None,
-                "overall_accuracy_t7": round(overall_accuracy, 1),
-                "overall_avg_return_t7": (round(float(row[14]), 2) if row[14] else 0.0),
+                "best_return": round(float(row[10]), 2) if row[10] else None,
+                "worst_return": round(float(row[11]), 2) if row[11] else None,
+                "overall_accuracy": round(overall_accuracy, 1),
+                "overall_avg_return": (round(float(row[14]), 2) if row[14] else 0.0),
             }
     except Exception as e:
         logger.error(f"Error loading asset stats for {symbol}: {e}")
@@ -603,21 +609,23 @@ def get_asset_stats(symbol: str) -> Dict[str, Any]:
         "total_predictions": 0,
         "correct_predictions": 0,
         "incorrect_predictions": 0,
-        "accuracy_t7": 0.0,
-        "avg_return_t7": 0.0,
-        "total_pnl_t7": 0.0,
+        "accuracy": 0.0,
+        "avg_return": 0.0,
+        "total_pnl": 0.0,
         "avg_confidence": 0.0,
         "bullish_count": 0,
         "bearish_count": 0,
         "neutral_count": 0,
-        "best_return_t7": None,
-        "worst_return_t7": None,
-        "overall_accuracy_t7": 0.0,
-        "overall_avg_return_t7": 0.0,
+        "best_return": None,
+        "worst_return": None,
+        "overall_accuracy": 0.0,
+        "overall_avg_return": 0.0,
     }
 
 
-def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
+def get_related_assets(
+    symbol: str, limit: int = 8, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get assets that frequently appear in the same predictions as the given symbol.
 
@@ -629,11 +637,14 @@ def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
         limit: Maximum number of related assets to return
 
     Returns:
-        DataFrame with columns: related_symbol, co_occurrence_count, avg_return_t7
+        DataFrame with columns: related_symbol, co_occurrence_count, avg_return
         Sorted by co_occurrence_count descending.
         Returns empty DataFrame on error.
     """
-    query = text("""
+    tf = get_tf_columns(timeframe)
+    return_col = tf["return_col"]
+
+    query = text(f"""
         WITH target_predictions AS (
             -- Find all prediction IDs that mention this symbol
             SELECT p.id AS prediction_id
@@ -646,7 +657,7 @@ def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
             SELECT
                 po.symbol AS related_symbol,
                 COUNT(DISTINCT po.prediction_id) AS co_occurrence_count,
-                AVG(po.return_t7) AS avg_return_t7
+                AVG(po.{return_col}) AS avg_return
             FROM prediction_outcomes po
             INNER JOIN target_predictions tp
                 ON po.prediction_id = tp.prediction_id
@@ -657,7 +668,7 @@ def get_related_assets(symbol: str, limit: int = 8) -> pd.DataFrame:
         SELECT
             related_symbol,
             co_occurrence_count,
-            ROUND(avg_return_t7::numeric, 2) AS avg_return_t7
+            ROUND(avg_return::numeric, 2) AS avg_return
         FROM co_occurring_assets
         ORDER BY co_occurrence_count DESC
         LIMIT :limit

--- a/shitty_ui/data/asset_queries.py
+++ b/shitty_ui/data/asset_queries.py
@@ -11,26 +11,30 @@ from sqlalchemy import text
 from typing import Dict, Any, Optional
 
 import data.base as _base
-from data.base import ttl_cache, logger, _timeframe_for_period
+from data.base import ttl_cache, logger
+from data.timeframe import get_tf_columns, DEFAULT_TIMEFRAME
 
 
 @ttl_cache(ttl_seconds=300)
-def get_asset_screener_data(days: int = None) -> pd.DataFrame:
+def get_asset_screener_data(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """Get combined asset screener data for the dashboard table.
 
     Joins per-asset accuracy metrics with the latest prediction sentiment
-    for each asset, plus average confidence. Uses adaptive timeframe
-    columns based on the selected period to avoid structurally empty results.
+    for each asset, plus average confidence.
 
     Args:
         days: Number of days to look back (None = all time).
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with columns: symbol, total_predictions, correct,
         incorrect, avg_return, total_pnl, accuracy, latest_sentiment,
         avg_confidence, timeframe. Sorted by total_predictions descending.
     """
-    tf = _timeframe_for_period(days)
+    tf_cols = get_tf_columns(timeframe)
+    tf = timeframe
 
     date_filter = ""
     params: Dict[str, Any] = {}

--- a/shitty_ui/data/base.py
+++ b/shitty_ui/data/base.py
@@ -58,24 +58,6 @@ def ttl_cache(ttl_seconds: int = 300):
     return decorator
 
 
-def _timeframe_for_period(days: int | None) -> str:
-    """Return the outcome timeframe suffix appropriate for the given period.
-
-    Shorter periods use faster-maturing outcomes to avoid structurally
-    empty results (e.g., 7D period can't show T+7 outcomes).
-
-    Args:
-        days: Number of days in the selected period (None = all time).
-
-    Returns:
-        Suffix string: "t1", "t3", or "t7".
-    """
-    if days is not None and days <= 7:
-        return "t1"
-    elif days is not None and days <= 30:
-        return "t3"
-    return "t7"
-
 
 def execute_query(query, params=None):
     """Execute query using appropriate session type."""

--- a/shitty_ui/data/insight_queries.py
+++ b/shitty_ui/data/insight_queries.py
@@ -11,10 +11,13 @@ from typing import List, Dict, Any
 
 import data.base as _base
 from data.base import ttl_cache, logger
+from data.timeframe import get_tf_columns, DEFAULT_TIMEFRAME
 
 
 @ttl_cache(ttl_seconds=300)
-def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
+def get_dynamic_insights(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> List[Dict[str, Any]]:
     """Generate a pool of dynamic insight candidates for the dashboard.
 
     Queries for multiple insight types and returns them as structured dicts.
@@ -31,11 +34,17 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
 
     Args:
         days: Number of days to look back (None = all time).
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         List of insight dicts, unranked (caller sorts by priority + recency).
         Returns empty list if no data available.
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+    tf_label = tf["label_long"].lower()
     insights: List[Dict[str, Any]] = []
 
     date_filter = ""
@@ -50,16 +59,16 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
             SELECT
                 po.symbol,
                 po.prediction_sentiment,
-                po.return_t7,
-                po.correct_t7,
-                po.pnl_t7,
+                po.{return_col},
+                po.{correct_col},
+                po.{pnl_col},
                 po.prediction_date,
                 po.prediction_confidence,
                 tss.timestamp AS post_timestamp
             FROM prediction_outcomes po
             INNER JOIN predictions p ON po.prediction_id = p.id
             INNER JOIN truth_social_shitposts tss ON p.shitpost_id = tss.shitpost_id
-            WHERE po.correct_t7 IS NOT NULL
+            WHERE po.{correct_col} IS NOT NULL
                 {date_filter}
             ORDER BY po.prediction_date DESC
             LIMIT 1
@@ -68,27 +77,31 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
         if rows and rows[0]:
             r = rows[0]
             symbol = r[0]
-            return_t7 = float(r[2]) if r[2] is not None else None
+            ret_val = float(r[2]) if r[2] is not None else None
             correct = r[3]
             post_ts = r[7]
 
-            if return_t7 is not None:
-                ret_str = f"{return_t7:+.2f}%"
+            if ret_val is not None:
+                ret_str = f"{ret_val:+.2f}%"
                 if correct:
-                    headline = f"Trump mentioned {symbol} -- it's {ret_str} in 7 days."
+                    headline = (
+                        f"Trump mentioned {symbol}"
+                        f" -- it's {ret_str} in {tf_label}."
+                    )
                     body = (
                         f"Predicted correctly with {ret_str} return."
-                        if return_t7 > 2
+                        if ret_val > 2
                         else f"Called it. {ret_str} return."
                     )
                     ins_sentiment = "positive"
                 else:
                     headline = (
-                        f"Trump mentioned {symbol} -- it went {ret_str} in 7 days."
+                        f"Trump mentioned {symbol}"
+                        f" -- it went {ret_str} in {tf_label}."
                     )
                     body = (
                         "Missed by a wide margin."
-                        if return_t7 < -2
+                        if ret_val < -2
                         else "Close to the threshold."
                     )
                     ins_sentiment = "negative"
@@ -115,20 +128,20 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
 
         best_worst_query = text(f"""
             (
-                SELECT symbol, return_t7, correct_t7, prediction_date, 'best' AS rank_type
+                SELECT symbol, {return_col}, {correct_col}, prediction_date, 'best' AS rank_type
                 FROM prediction_outcomes
-                WHERE correct_t7 IS NOT NULL AND return_t7 IS NOT NULL
+                WHERE {correct_col} IS NOT NULL AND {return_col} IS NOT NULL
                     {date_filter_bare}
-                ORDER BY return_t7 DESC
+                ORDER BY {return_col} DESC
                 LIMIT 1
             )
             UNION ALL
             (
-                SELECT symbol, return_t7, correct_t7, prediction_date, 'worst' AS rank_type
+                SELECT symbol, {return_col}, {correct_col}, prediction_date, 'worst' AS rank_type
                 FROM prediction_outcomes
-                WHERE correct_t7 IS NOT NULL AND return_t7 IS NOT NULL
+                WHERE {correct_col} IS NOT NULL AND {return_col} IS NOT NULL
                     {date_filter_bare}
-                ORDER BY return_t7 ASC
+                ORDER BY {return_col} ASC
                 LIMIT 1
             )
         """)
@@ -167,9 +180,9 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
         accuracy_query = text(f"""
             SELECT
                 COUNT(*) AS total,
-                COUNT(CASE WHEN correct_t7 = true THEN 1 END) AS correct
+                COUNT(CASE WHEN {correct_col} = true THEN 1 END) AS correct
             FROM prediction_outcomes
-            WHERE correct_t7 IS NOT NULL
+            WHERE {correct_col} IS NOT NULL
                 {date_filter_bare}
         """)
         rows, columns = _base.execute_query(accuracy_query, params)
@@ -217,9 +230,9 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
             SELECT
                 symbol,
                 COUNT(*) AS pred_count,
-                ROUND(AVG(return_t7)::numeric, 2) AS avg_return
+                ROUND(AVG({return_col})::numeric, 2) AS avg_return
             FROM prediction_outcomes
-            WHERE correct_t7 IS NOT NULL
+            WHERE {correct_col} IS NOT NULL
                 {date_filter_bare}
             GROUP BY symbol
             HAVING COUNT(*) >= 3
@@ -264,13 +277,13 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
 
     # ---- Insight 5: Recent high-confidence signal ----
     try:
-        hot_signal_query = text("""
+        hot_signal_query = text(f"""
             SELECT
                 po.symbol,
                 po.prediction_sentiment,
                 po.prediction_confidence,
-                po.correct_t7,
-                po.return_t7,
+                po.{correct_col},
+                po.{return_col},
                 tss.timestamp AS post_timestamp
             FROM prediction_outcomes po
             INNER JOIN predictions p ON po.prediction_id = p.id
@@ -285,22 +298,23 @@ def get_dynamic_insights(days: int = None) -> List[Dict[str, Any]]:
             sentiment = (rows[0][1] or "neutral").lower()
             confidence = float(rows[0][2]) if rows[0][2] is not None else 0.0
             correct = rows[0][3]
-            return_t7 = float(rows[0][4]) if rows[0][4] is not None else None
+            ret_val = float(rows[0][4]) if rows[0][4] is not None else None
             post_ts = rows[0][5]
 
             conf_pct = f"{confidence:.0%}"
+            tf_short = tf["label_short"]
             if correct is None:
                 headline = f"High-confidence call: {sentiment.upper()} on {symbol} ({conf_pct}). Awaiting results."
                 body = "Outcome pending -- check back after maturation."
                 ins_sentiment = "neutral"
             elif correct:
-                ret_str = f"{return_t7:+.2f}%" if return_t7 is not None else "N/A"
-                headline = f"High-confidence call on {symbol} ({conf_pct}) was RIGHT. {ret_str} in 7d."
+                ret_str = f"{ret_val:+.2f}%" if ret_val is not None else "N/A"
+                headline = f"High-confidence call on {symbol} ({conf_pct}) was RIGHT. {ret_str} in {tf_short}."
                 body = "High-confidence signal validated."
                 ins_sentiment = "positive"
             else:
-                ret_str = f"{return_t7:+.2f}%" if return_t7 is not None else "N/A"
-                headline = f"High-confidence call on {symbol} ({conf_pct}) was WRONG. {ret_str} in 7d."
+                ret_str = f"{ret_val:+.2f}%" if ret_val is not None else "N/A"
+                headline = f"High-confidence call on {symbol} ({conf_pct}) was WRONG. {ret_str} in {tf_short}."
                 body = "High confidence did not translate to accuracy here."
                 ins_sentiment = "negative"
 

--- a/shitty_ui/data/performance_queries.py
+++ b/shitty_ui/data/performance_queries.py
@@ -114,14 +114,21 @@ def get_prediction_stats() -> Dict[str, Any]:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_performance_metrics(days: int = None) -> Dict[str, Any]:
+def get_performance_metrics(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> Dict[str, Any]:
     """
     Get overall prediction performance metrics from prediction_outcomes table.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
     """
-    # Build date filter
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -132,11 +139,11 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
     query = text(f"""
         SELECT
             COUNT(*) as total_outcomes,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_t7,
-            COUNT(CASE WHEN correct_t7 = false THEN 1 END) as incorrect_t7,
-            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_t7,
-            AVG(CASE WHEN correct_t7 IS NOT NULL THEN return_t7 END) as avg_return_t7,
-            SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) as total_pnl_t7,
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct_count,
+            COUNT(CASE WHEN {correct_col} = false THEN 1 END) as incorrect_count,
+            COUNT(CASE WHEN {correct_col} IS NOT NULL THEN 1 END) as evaluated_count,
+            AVG(CASE WHEN {correct_col} IS NOT NULL THEN {return_col} END) as avg_return,
+            SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END) as total_pnl,
             AVG(prediction_confidence) as avg_confidence
         FROM prediction_outcomes
         {date_filter}
@@ -146,7 +153,7 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
         rows, columns = _base.execute_query(query, params)
         if rows and rows[0]:
             row = rows[0]
-            total = row[3] or 0  # evaluated_t7
+            total = row[3] or 0
             correct = row[1] or 0
             accuracy = (correct / total * 100) if total > 0 else 0
 
@@ -155,9 +162,9 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
                 "evaluated_predictions": total,
                 "correct_predictions": correct,
                 "incorrect_predictions": row[2] or 0,
-                "accuracy_t7": round(accuracy, 1),
-                "avg_return_t7": round(float(row[4]), 2) if row[4] else 0.0,
-                "total_pnl_t7": round(float(row[5]), 2) if row[5] else 0.0,
+                "accuracy": round(accuracy, 1),
+                "avg_return": round(float(row[4]), 2) if row[4] else 0.0,
+                "total_pnl": round(float(row[5]), 2) if row[5] else 0.0,
                 "avg_confidence": round(float(row[6]), 2) if row[6] else 0.0,
             }
     except Exception as e:
@@ -168,9 +175,9 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
         "evaluated_predictions": 0,
         "correct_predictions": 0,
         "incorrect_predictions": 0,
-        "accuracy_t7": 0.0,
-        "avg_return_t7": 0.0,
-        "total_pnl_t7": 0.0,
+        "accuracy": 0.0,
+        "avg_return": 0.0,
+        "total_pnl": 0.0,
         "avg_confidence": 0.0,
     }
 
@@ -282,14 +289,21 @@ def get_dashboard_kpis_with_fallback(
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_accuracy_by_confidence(days: int = None) -> pd.DataFrame:
+def get_accuracy_by_confidence(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get prediction accuracy broken down by confidence level.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
     """
-    # Build date filter
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -305,12 +319,12 @@ def get_accuracy_by_confidence(days: int = None) -> pd.DataFrame:
                 ELSE 'High (>75%)'
             END as confidence_level,
             COUNT(*) as total,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
-            COUNT(CASE WHEN correct_t7 = false THEN 1 END) as incorrect,
-            ROUND(AVG(CASE WHEN return_t7 IS NOT NULL THEN return_t7 END)::numeric, 2) as avg_return,
-            ROUND(SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END)::numeric, 2) as total_pnl
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} = false THEN 1 END) as incorrect,
+            ROUND(AVG(CASE WHEN {return_col} IS NOT NULL THEN {return_col} END)::numeric, 2) as avg_return,
+            ROUND(SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END)::numeric, 2) as total_pnl
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         {date_filter}
         GROUP BY
             CASE
@@ -338,15 +352,22 @@ def get_accuracy_by_confidence(days: int = None) -> pd.DataFrame:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_accuracy_by_asset(limit: int = 15, days: int = None) -> pd.DataFrame:
+def get_accuracy_by_asset(
+    limit: int = 15, days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get prediction accuracy broken down by asset.
 
     Args:
         limit: Maximum number of assets to return
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
     """
-    # Build date filter
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {"limit": limit}
 
@@ -358,12 +379,12 @@ def get_accuracy_by_asset(limit: int = 15, days: int = None) -> pd.DataFrame:
         SELECT
             symbol,
             COUNT(*) as total_predictions,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
-            COUNT(CASE WHEN correct_t7 = false THEN 1 END) as incorrect,
-            ROUND(AVG(CASE WHEN return_t7 IS NOT NULL THEN return_t7 END)::numeric, 2) as avg_return,
-            ROUND(SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END)::numeric, 2) as total_pnl
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} = false THEN 1 END) as incorrect,
+            ROUND(AVG(CASE WHEN {return_col} IS NOT NULL THEN {return_col} END)::numeric, 2) as avg_return,
+            ROUND(SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END)::numeric, 2) as total_pnl
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         {date_filter}
         GROUP BY symbol
         HAVING COUNT(*) >= 2
@@ -470,17 +491,23 @@ def get_top_predicted_asset() -> Optional[str]:
         return None
 
 
-def get_cumulative_pnl(days: int = None) -> pd.DataFrame:
+def get_cumulative_pnl(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get cumulative P&L over time for equity curve visualization.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with columns: prediction_date, daily_pnl, predictions_count, cumulative_pnl
     """
-    # Build date filter
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -491,10 +518,10 @@ def get_cumulative_pnl(days: int = None) -> pd.DataFrame:
     query = text(f"""
         SELECT
             prediction_date,
-            SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) as daily_pnl,
+            SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END) as daily_pnl,
             COUNT(*) as predictions_count
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         {date_filter}
         GROUP BY prediction_date
         ORDER BY prediction_date ASC
@@ -511,18 +538,23 @@ def get_cumulative_pnl(days: int = None) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def get_rolling_accuracy(window: int = 30, days: int = None) -> pd.DataFrame:
+def get_rolling_accuracy(
+    window: int = 30, days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get rolling accuracy over time.
 
     Args:
         window: Rolling window size in days
         days: Total days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with: prediction_date, correct, total, rolling_accuracy
     """
-    # Build date filter
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -533,10 +565,10 @@ def get_rolling_accuracy(window: int = 30, days: int = None) -> pd.DataFrame:
     query = text(f"""
         SELECT
             prediction_date,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
-            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as total
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} IS NOT NULL THEN 1 END) as total
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         {date_filter}
         GROUP BY prediction_date
         ORDER BY prediction_date ASC
@@ -561,9 +593,12 @@ def get_rolling_accuracy(window: int = 30, days: int = None) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def get_win_loss_streaks() -> Dict[str, int]:
+def get_win_loss_streaks(timeframe: str = DEFAULT_TIMEFRAME) -> Dict[str, int]:
     """
     Calculate current and max win/loss streaks.
+
+    Args:
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with:
@@ -571,12 +606,15 @@ def get_win_loss_streaks() -> Dict[str, int]:
             max_win_streak: longest consecutive correct predictions
             max_loss_streak: longest consecutive incorrect predictions
     """
-    query = text("""
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
+    query = text(f"""
         SELECT
             prediction_date,
-            correct_t7
+            {correct_col}
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         ORDER BY prediction_date ASC, created_at ASC
     """)
 
@@ -616,7 +654,9 @@ def get_win_loss_streaks() -> Dict[str, int]:
         return {"current_streak": 0, "max_win_streak": 0, "max_loss_streak": 0}
 
 
-def get_confidence_calibration(buckets: int = 10) -> pd.DataFrame:
+def get_confidence_calibration(
+    buckets: int = 10, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get confidence calibration data (predicted confidence vs actual accuracy).
 
@@ -626,21 +666,25 @@ def get_confidence_calibration(buckets: int = 10) -> pd.DataFrame:
 
     Args:
         buckets: Number of confidence buckets (default 10 = 0-10%, 10-20%, etc.)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with: bucket_start, total, correct, avg_confidence,
                         actual_accuracy, predicted_confidence, bucket_label
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
     bucket_size = 1.0 / buckets
 
-    query = text("""
+    query = text(f"""
         SELECT
             FLOOR(prediction_confidence / :bucket_size) * :bucket_size as bucket_start,
             COUNT(*) as total,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
             AVG(prediction_confidence) as avg_confidence
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
             AND prediction_confidence IS NOT NULL
         GROUP BY FLOOR(prediction_confidence / :bucket_size)
         ORDER BY bucket_start ASC
@@ -661,27 +705,35 @@ def get_confidence_calibration(buckets: int = 10) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def get_monthly_performance(months: int = 12) -> pd.DataFrame:
+def get_monthly_performance(
+    months: int = 12, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get monthly performance summary.
 
     Args:
         months: Number of months to look back
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with: month, total_predictions, correct, incorrect,
                         avg_return, total_pnl, accuracy
     """
-    query = text("""
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
+    query = text(f"""
         SELECT
             DATE_TRUNC('month', prediction_date) as month,
             COUNT(*) as total_predictions,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
-            COUNT(CASE WHEN correct_t7 = false THEN 1 END) as incorrect,
-            ROUND(AVG(return_t7)::numeric, 2) as avg_return,
-            ROUND(SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END)::numeric, 2) as total_pnl
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} = false THEN 1 END) as incorrect,
+            ROUND(AVG({return_col})::numeric, 2) as avg_return,
+            ROUND(SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END)::numeric, 2) as total_pnl
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
         GROUP BY DATE_TRUNC('month', prediction_date)
         ORDER BY month DESC
         LIMIT :months
@@ -700,16 +752,22 @@ def get_monthly_performance(months: int = 12) -> pd.DataFrame:
 
 
 @ttl_cache(ttl_seconds=300)
-def get_high_confidence_metrics(days: int = None) -> Dict[str, Any]:
+def get_high_confidence_metrics(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> Dict[str, Any]:
     """
     Get win rate and count for high-confidence predictions (>=0.75).
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with win_rate, total, correct, incorrect
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -720,11 +778,11 @@ def get_high_confidence_metrics(days: int = None) -> Dict[str, Any]:
     query = text(f"""
         SELECT
             COUNT(*) as total,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct,
-            COUNT(CASE WHEN correct_t7 = false THEN 1 END) as incorrect
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN {correct_col} = false THEN 1 END) as incorrect
         FROM prediction_outcomes
         WHERE prediction_confidence >= 0.75
-            AND correct_t7 IS NOT NULL
+            AND {correct_col} IS NOT NULL
             {date_filter}
     """)
 
@@ -747,11 +805,14 @@ def get_high_confidence_metrics(days: int = None) -> Dict[str, Any]:
 
 
 @ttl_cache(ttl_seconds=300)
-def get_empty_state_context() -> Dict[str, Any]:
+def get_empty_state_context(timeframe: str = DEFAULT_TIMEFRAME) -> Dict[str, Any]:
     """Get contextual counts for smart empty state messages.
 
     Returns lightweight aggregate counts used by empty-state components
     to guide users toward timeframes and pages that have data.
+
+    Args:
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with keys:
@@ -759,11 +820,14 @@ def get_empty_state_context() -> Dict[str, Any]:
             total_pending: int -- outcomes awaiting maturation
             total_high_confidence: int -- all-time high-confidence signals (>=0.75)
     """
-    query = text("""
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
+    query = text(f"""
         SELECT
-            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) AS total_evaluated,
-            COUNT(CASE WHEN correct_t7 IS NULL THEN 1 END) AS total_pending,
-            COUNT(CASE WHEN prediction_confidence >= 0.75 AND correct_t7 IS NOT NULL THEN 1 END) AS total_high_confidence
+            COUNT(CASE WHEN {correct_col} IS NOT NULL THEN 1 END) AS total_evaluated,
+            COUNT(CASE WHEN {correct_col} IS NULL THEN 1 END) AS total_pending,
+            COUNT(CASE WHEN prediction_confidence >= 0.75 AND {correct_col} IS NOT NULL THEN 1 END) AS total_high_confidence
         FROM prediction_outcomes
     """)
 
@@ -786,16 +850,23 @@ def get_empty_state_context() -> Dict[str, Any]:
 
 
 @ttl_cache(ttl_seconds=300)
-def get_best_performing_asset(days: int = None) -> Dict[str, Any]:
+def get_best_performing_asset(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> Dict[str, Any]:
     """
     Get the best performing asset by total P&L.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with symbol, total_pnl, accuracy, prediction_count
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -806,15 +877,15 @@ def get_best_performing_asset(days: int = None) -> Dict[str, Any]:
     query = text(f"""
         SELECT
             symbol,
-            ROUND(SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END)::numeric, 2) as total_pnl,
+            ROUND(SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END)::numeric, 2) as total_pnl,
             COUNT(*) as prediction_count,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
             {date_filter}
         GROUP BY symbol
         HAVING COUNT(*) >= 2
-        ORDER BY SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) DESC
+        ORDER BY SUM(CASE WHEN {pnl_col} IS NOT NULL THEN {pnl_col} ELSE 0 END) DESC
         LIMIT 1
     """)
 
@@ -835,16 +906,22 @@ def get_best_performing_asset(days: int = None) -> Dict[str, Any]:
     return {"symbol": "N/A", "total_pnl": 0.0, "prediction_count": 0, "accuracy": 0.0}
 
 
-def get_accuracy_over_time(days: int = None) -> pd.DataFrame:
+def get_accuracy_over_time(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get prediction accuracy aggregated by week for line chart.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with columns: week, total, correct, accuracy
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -856,9 +933,9 @@ def get_accuracy_over_time(days: int = None) -> pd.DataFrame:
         SELECT
             DATE_TRUNC('week', prediction_date) as week,
             COUNT(*) as total,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct
         FROM prediction_outcomes
-        WHERE correct_t7 IS NOT NULL
+        WHERE {correct_col} IS NOT NULL
             {date_filter}
         GROUP BY DATE_TRUNC('week', prediction_date)
         HAVING COUNT(*) >= 1
@@ -882,6 +959,7 @@ def get_backtest_simulation(
     initial_capital: float = 10000,
     min_confidence: float = 0.75,
     days: int = 90,
+    timeframe: str = DEFAULT_TIMEFRAME,
 ) -> Dict[str, Any]:
     """
     Simulate P&L if following high-confidence signals with a given capital.
@@ -892,10 +970,16 @@ def get_backtest_simulation(
         initial_capital: Starting capital
         min_confidence: Minimum confidence threshold for trades
         days: Number of days to look back
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with final_value, total_return_pct, trade_count, wins, losses, win_rate
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+    return_col = tf["return_col"]
+    pnl_col = tf["pnl_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {"min_confidence": min_confidence}
 
@@ -905,13 +989,13 @@ def get_backtest_simulation(
 
     query = text(f"""
         SELECT
-            return_t7,
-            correct_t7,
-            pnl_t7
+            {return_col},
+            {correct_col},
+            {pnl_col}
         FROM prediction_outcomes
         WHERE prediction_confidence >= :min_confidence
-            AND correct_t7 IS NOT NULL
-            AND return_t7 IS NOT NULL
+            AND {correct_col} IS NOT NULL
+            AND {return_col} IS NOT NULL
             {date_filter}
         ORDER BY prediction_date ASC
     """)
@@ -964,16 +1048,22 @@ def get_backtest_simulation(
         }
 
 
-def get_sentiment_accuracy(days: int = None) -> pd.DataFrame:
+def get_sentiment_accuracy(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> pd.DataFrame:
     """
     Get accuracy breakdown by sentiment type with counts.
 
     Args:
         days: Number of days to look back (None = all time)
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         DataFrame with columns: sentiment, total, correct, accuracy
     """
+    tf = get_tf_columns(timeframe)
+    correct_col = tf["correct_col"]
+
     date_filter = ""
     params: Dict[str, Any] = {}
 
@@ -985,10 +1075,10 @@ def get_sentiment_accuracy(days: int = None) -> pd.DataFrame:
         SELECT
             prediction_sentiment as sentiment,
             COUNT(*) as total,
-            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct
+            COUNT(CASE WHEN {correct_col} = true THEN 1 END) as correct
         FROM prediction_outcomes
         WHERE prediction_sentiment IS NOT NULL
-            AND correct_t7 IS NOT NULL
+            AND {correct_col} IS NOT NULL
             {date_filter}
         GROUP BY prediction_sentiment
         ORDER BY COUNT(*) DESC

--- a/shitty_ui/data/performance_queries.py
+++ b/shitty_ui/data/performance_queries.py
@@ -12,7 +12,8 @@ from sqlalchemy import text
 from typing import List, Dict, Any, Optional
 
 import data.base as _base
-from data.base import ttl_cache, logger, DATABASE_URL, _timeframe_for_period
+from data.base import ttl_cache, logger, DATABASE_URL
+from data.timeframe import get_tf_columns, DEFAULT_TIMEFRAME
 
 
 @ttl_cache(ttl_seconds=600)  # Cache for 10 minutes
@@ -175,25 +176,28 @@ def get_performance_metrics(days: int = None) -> Dict[str, Any]:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_dashboard_kpis(days: int = None) -> Dict[str, Any]:
+def get_dashboard_kpis(
+    days: int = None, timeframe: str = DEFAULT_TIMEFRAME
+) -> Dict[str, Any]:
     """Get the four key metrics for the main dashboard KPI cards.
 
-    Returns only evaluated predictions (where the appropriate timeframe
-    outcome is not NULL). Uses adaptive timeframe: T+1 for 7D, T+3 for
-    30D, T+7 for 90D and all-time.
+    Returns only evaluated predictions (where the selected timeframe
+    outcome is not NULL).
 
     Args:
         days: Number of days to look back (None = all time).
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with keys:
             total_signals: int - count of evaluated prediction-outcome rows
             accuracy_pct: float - percentage correct at chosen timeframe
-            avg_return_t7: float - mean return at chosen timeframe (percentage)
+            avg_return: float - mean return at chosen timeframe (percentage)
             total_pnl: float - sum of P&L at chosen timeframe (dollar amount)
-            timeframe: str - which timeframe was used ("t1", "t3", or "t7")
+            timeframe: str - which timeframe was used
     """
-    tf = _timeframe_for_period(days)
+    tf = timeframe
+    get_tf_columns(tf)  # validate
 
     date_filter = ""
     params: Dict[str, Any] = {}
@@ -225,7 +229,7 @@ def get_dashboard_kpis(days: int = None) -> Dict[str, Any]:
             return {
                 "total_signals": total,
                 "accuracy_pct": round(accuracy, 1),
-                "avg_return_t7": round(float(row[2]), 2) if row[2] else 0.0,
+                "avg_return": round(float(row[2]), 2) if row[2] else 0.0,
                 "total_pnl": round(float(row[3]), 2) if row[3] else 0.0,
                 "timeframe": tf,
             }
@@ -235,13 +239,15 @@ def get_dashboard_kpis(days: int = None) -> Dict[str, Any]:
     return {
         "total_signals": 0,
         "accuracy_pct": 0.0,
-        "avg_return_t7": 0.0,
+        "avg_return": 0.0,
         "total_pnl": 0.0,
         "timeframe": tf,
     }
 
 
-def get_dashboard_kpis_with_fallback(days: int | None = 90) -> dict:
+def get_dashboard_kpis_with_fallback(
+    days: int | None = 90, timeframe: str = DEFAULT_TIMEFRAME
+) -> dict:
     """Get dashboard KPIs with automatic fallback to all-time data.
 
     When the selected time period has no evaluated predictions (total_signals == 0),
@@ -249,6 +255,7 @@ def get_dashboard_kpis_with_fallback(days: int | None = 90) -> dict:
 
     Args:
         days: Number of days to filter. None = all time.
+        timeframe: Outcome timeframe key ("t1", "t3", "t7", "t30").
 
     Returns:
         Dict with KPI values plus:
@@ -256,11 +263,9 @@ def get_dashboard_kpis_with_fallback(days: int | None = 90) -> dict:
             fallback_label: str - Display label (empty if not fallback)
             timeframe_label: str - Human-readable label for the active timeframe
     """
-    kpis = get_dashboard_kpis(days=days)
-    tf = kpis.get("timeframe", "t7")
-
-    tf_labels = {"t1": "1-day", "t3": "3-day", "t7": "7-day"}
-    kpis["timeframe_label"] = tf_labels.get(tf, "7-day")
+    tf_info = get_tf_columns(timeframe)
+    kpis = get_dashboard_kpis(days=days, timeframe=timeframe)
+    kpis["timeframe_label"] = tf_info["label_long"].lower()
 
     # If period has evaluated signals, return as-is
     if kpis["total_signals"] > 0 or days is None:
@@ -269,9 +274,8 @@ def get_dashboard_kpis_with_fallback(days: int | None = 90) -> dict:
         return kpis
 
     # Fall back to all-time
-    kpis = get_dashboard_kpis(days=None)
-    tf = kpis.get("timeframe", "t7")
-    kpis["timeframe_label"] = tf_labels.get(tf, "7-day")
+    kpis = get_dashboard_kpis(days=None, timeframe=timeframe)
+    kpis["timeframe_label"] = tf_info["label_long"].lower()
     kpis["is_fallback"] = True
     kpis["fallback_label"] = "Showing all-time data"
     return kpis

--- a/shitty_ui/data/timeframe.py
+++ b/shitty_ui/data/timeframe.py
@@ -71,4 +71,4 @@ def get_tf_columns(timeframe: str = "t7") -> Dict[str, str]:
             f"Invalid timeframe '{timeframe}'. "
             f"Valid options: {VALID_TIMEFRAMES}"
         )
-    return TIMEFRAME_OPTIONS[timeframe]
+    return dict(TIMEFRAME_OPTIONS[timeframe])

--- a/shitty_ui/data/timeframe.py
+++ b/shitty_ui/data/timeframe.py
@@ -1,0 +1,74 @@
+"""Timeframe column mapping for multi-timeframe queries.
+
+Provides a helper that maps a timeframe key (e.g., "t7") to the
+corresponding database column names in the prediction_outcomes table.
+
+Valid timeframe keys: "t1", "t3", "t7", "t30".
+"""
+
+from typing import Dict, Literal
+
+TimeframeKey = Literal["t1", "t3", "t7", "t30"]
+
+TIMEFRAME_OPTIONS: Dict[str, Dict[str, str]] = {
+    "t1": {
+        "correct_col": "correct_t1",
+        "return_col": "return_t1",
+        "pnl_col": "pnl_t1",
+        "price_col": "price_t1",
+        "label_short": "1D",
+        "label_long": "1-Day",
+        "label_days": "1",
+    },
+    "t3": {
+        "correct_col": "correct_t3",
+        "return_col": "return_t3",
+        "pnl_col": "pnl_t3",
+        "price_col": "price_t3",
+        "label_short": "3D",
+        "label_long": "3-Day",
+        "label_days": "3",
+    },
+    "t7": {
+        "correct_col": "correct_t7",
+        "return_col": "return_t7",
+        "pnl_col": "pnl_t7",
+        "price_col": "price_t7",
+        "label_short": "7D",
+        "label_long": "7-Day",
+        "label_days": "7",
+    },
+    "t30": {
+        "correct_col": "correct_t30",
+        "return_col": "return_t30",
+        "pnl_col": "pnl_t30",
+        "price_col": "price_t30",
+        "label_short": "30D",
+        "label_long": "30-Day",
+        "label_days": "30",
+    },
+}
+
+VALID_TIMEFRAMES = tuple(TIMEFRAME_OPTIONS.keys())
+DEFAULT_TIMEFRAME: TimeframeKey = "t7"
+
+
+def get_tf_columns(timeframe: str = "t7") -> Dict[str, str]:
+    """Get column names and labels for a given timeframe key.
+
+    Args:
+        timeframe: One of "t1", "t3", "t7", "t30". Defaults to "t7".
+
+    Returns:
+        Dict with keys: correct_col, return_col, pnl_col, price_col,
+        label_short, label_long, label_days.
+
+    Raises:
+        ValueError: If timeframe is not a valid key.
+    """
+    if timeframe not in TIMEFRAME_OPTIONS:
+        raise ValueError(
+            f"Invalid timeframe '{timeframe}'. "
+            f"Valid options: {VALID_TIMEFRAMES}"
+        )
+    return TIMEFRAME_OPTIONS[timeframe]

--- a/shitty_ui/layout.py
+++ b/shitty_ui/layout.py
@@ -108,6 +108,8 @@ def create_app() -> Dash:
             dcc.Store(id="selected-asset", data=None),
             # Store for selected time period (default: 90d)
             dcc.Store(id="selected-period", data="90d"),
+            # Store for selected outcome timeframe (default: t7)
+            dcc.Store(id="selected-timeframe", data="t7"),
             # Store for last update timestamp
             dcc.Store(id="last-update-timestamp", data=None),
             # Alert system stores

--- a/shitty_ui/pages/assets.py
+++ b/shitty_ui/pages/assets.py
@@ -318,12 +318,12 @@ def register_asset_callbacks(app: Dash):
                     dbc.Col(
                         create_metric_card(
                             "Prediction Accuracy",
-                            f"{stats['accuracy_t7']:.1f}%",
+                            f"{stats['accuracy']:.1f}%",
                             f"{stats['correct_predictions']}/{stats['total_predictions']} correct",
                             "bullseye",
                             (
                                 COLORS["success"]
-                                if stats["accuracy_t7"] > 60
+                                if stats["accuracy"] > 60
                                 else COLORS["danger"]
                             ),
                         ),
@@ -343,13 +343,13 @@ def register_asset_callbacks(app: Dash):
                     ),
                     dbc.Col(
                         create_metric_card(
-                            "Total P&L (7-day)",
-                            safe_format_dollar(stats["total_pnl_t7"], fmt=",.0f"),
+                            "Total P&L",
+                            safe_format_dollar(stats["total_pnl"], fmt=",.0f"),
                             "Based on $1,000 positions",
                             "dollar-sign",
                             (
                                 COLORS["success"]
-                                if (stats["total_pnl_t7"] or 0) > 0
+                                if (stats["total_pnl"] or 0) > 0
                                 else COLORS["danger"]
                             ),
                         ),
@@ -358,13 +358,13 @@ def register_asset_callbacks(app: Dash):
                     ),
                     dbc.Col(
                         create_metric_card(
-                            "Avg 7-Day Return",
-                            safe_format_pct(stats["avg_return_t7"]),
+                            "Avg Return",
+                            safe_format_pct(stats["avg_return"]),
                             f"Confidence: {stats['avg_confidence']:.0%}",
                             "chart-line",
                             (
                                 COLORS["success"]
-                                if (stats["avg_return_t7"] or 0) > 0
+                                if (stats["avg_return"] or 0) > 0
                                 else COLORS["danger"]
                             ),
                         ),

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -18,48 +18,106 @@ def create_dashboard_page() -> html.Div:
             # Main content container
             html.Div(
                 [
-                    # Time Period Selector Row
+                    # Time Period & Timeframe Selector Row
                     html.Div(
                         [
-                            html.Span(
-                                "Time Period: ",
-                                style={
-                                    "color": COLORS["text_muted"],
-                                    "marginRight": "10px",
-                                    "fontSize": "0.9rem",
-                                },
-                            ),
-                            dbc.ButtonGroup(
+                            # Outcome Timeframe selector (left)
+                            html.Div(
                                 [
-                                    dbc.Button(
-                                        "7D",
-                                        id="period-7d",
-                                        color="secondary",
-                                        outline=True,
-                                        size="sm",
+                                    html.Span(
+                                        "Outcome Window: ",
+                                        style={
+                                            "color": COLORS["text_muted"],
+                                            "marginRight": "10px",
+                                            "fontSize": "0.9rem",
+                                        },
                                     ),
-                                    dbc.Button(
-                                        "30D",
-                                        id="period-30d",
-                                        color="secondary",
-                                        outline=True,
-                                        size="sm",
-                                    ),
-                                    dbc.Button(
-                                        "90D",
-                                        id="period-90d",
-                                        color="primary",
-                                        size="sm",
-                                    ),
-                                    dbc.Button(
-                                        "All",
-                                        id="period-all",
-                                        color="secondary",
-                                        outline=True,
+                                    dbc.ButtonGroup(
+                                        [
+                                            dbc.Button(
+                                                "T+1",
+                                                id="tf-t1",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "T+3",
+                                                id="tf-t3",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "T+7",
+                                                id="tf-t7",
+                                                color="primary",
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "T+30",
+                                                id="tf-t30",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                        ],
                                         size="sm",
                                     ),
                                 ],
-                                size="sm",
+                                style={
+                                    "display": "flex",
+                                    "alignItems": "center",
+                                },
+                            ),
+                            # Time Period selector (right)
+                            html.Div(
+                                [
+                                    html.Span(
+                                        "Time Period: ",
+                                        style={
+                                            "color": COLORS["text_muted"],
+                                            "marginRight": "10px",
+                                            "fontSize": "0.9rem",
+                                        },
+                                    ),
+                                    dbc.ButtonGroup(
+                                        [
+                                            dbc.Button(
+                                                "7D",
+                                                id="period-7d",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "30D",
+                                                id="period-30d",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "90D",
+                                                id="period-90d",
+                                                color="primary",
+                                                size="sm",
+                                            ),
+                                            dbc.Button(
+                                                "All",
+                                                id="period-all",
+                                                color="secondary",
+                                                outline=True,
+                                                size="sm",
+                                            ),
+                                        ],
+                                        size="sm",
+                                    ),
+                                ],
+                                style={
+                                    "display": "flex",
+                                    "alignItems": "center",
+                                },
                             ),
                         ],
                         className="period-selector",
@@ -67,7 +125,9 @@ def create_dashboard_page() -> html.Div:
                             "marginBottom": "20px",
                             "display": "flex",
                             "alignItems": "center",
-                            "justifyContent": "flex-end",
+                            "justifyContent": "space-between",
+                            "flexWrap": "wrap",
+                            "gap": "12px",
                         },
                     ),
                     # Dynamic Insight Cards (above KPIs, answer "so what right now?")

--- a/shitty_ui/pages/dashboard_callbacks/content.py
+++ b/shitty_ui/pages/dashboard_callbacks/content.py
@@ -24,6 +24,7 @@ from data import (
     load_recent_posts,
     get_dashboard_kpis_with_fallback,
     get_dynamic_insights,
+    get_tf_columns,
 )
 from components.screener import build_screener_table
 from components.insights import create_insight_cards
@@ -46,11 +47,13 @@ def register_content_callbacks(app: Dash) -> None:
         [
             Input("refresh-interval", "n_intervals"),
             Input("selected-period", "data"),
+            Input("selected-timeframe", "data"),
         ],
     )
-    def update_dashboard(n_intervals, period):
+    def update_dashboard(n_intervals, period, timeframe):
         """Update main dashboard components with error boundaries."""
         errors = []
+        timeframe = timeframe or "t7"
 
         # Convert period to days
         days_map = {"7d": 7, "30d": 30, "90d": 90, "all": None}
@@ -59,9 +62,13 @@ def register_content_callbacks(app: Dash) -> None:
         # Current timestamp for refresh indicator
         current_time = datetime.now().isoformat()
 
+        # Resolve timeframe display label
+        tf = get_tf_columns(timeframe)
+        tf_label_short = tf["label_short"]
+
         # ===== Dynamic Insight Cards =====
         try:
-            insight_pool = get_dynamic_insights(days=days)
+            insight_pool = get_dynamic_insights(days=days, timeframe=timeframe)
             insight_cards = create_insight_cards(insight_pool, max_cards=3)
         except Exception as e:
             errors.append(f"Insight cards: {e}")
@@ -70,24 +77,20 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Asset Screener Table =====
         try:
-            screener_df = get_asset_screener_data(days=days)
+            screener_df = get_asset_screener_data(
+                days=days, timeframe=timeframe
+            )
             sparkline_data = {}
             if not screener_df.empty:
                 symbols = tuple(screener_df["symbol"].tolist())
                 sparkline_data = get_screener_sparkline_prices(symbols=symbols)
-
-            # Determine display label for timeframe column
-            tf_map = {"t1": "1d", "t3": "3d", "t7": "7d"}
-            screener_tf = "7d"
-            if not screener_df.empty and "timeframe" in screener_df.columns:
-                screener_tf = tf_map.get(screener_df["timeframe"].iloc[0], "7d")
 
             screener_table = build_screener_table(
                 screener_df=screener_df,
                 sparkline_data=sparkline_data,
                 sort_column="total_predictions",
                 sort_ascending=False,
-                timeframe_label=screener_tf,
+                timeframe_label=tf_label_short,
             )
         except Exception as e:
             errors.append(f"Asset screener: {e}")
@@ -96,9 +99,11 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Performance Metrics with error handling =====
         try:
-            kpis = get_dashboard_kpis_with_fallback(days=days)
+            kpis = get_dashboard_kpis_with_fallback(
+                days=days, timeframe=timeframe
+            )
             fallback_note = kpis["fallback_label"] if kpis["is_fallback"] else ""
-            tf_label = kpis.get("timeframe_label", "7-day")
+            tf_label = kpis.get("timeframe_label", tf["label_long"])
 
             # Create KPI metrics row
             metrics_row = dbc.Row(
@@ -136,11 +141,11 @@ def register_content_callbacks(app: Dash) -> None:
                     dbc.Col(
                         create_metric_card(
                             COPY["kpi_avg_return_title"],
-                            safe_format_pct(kpis["avg_return_t7"]),
+                            safe_format_pct(kpis["avg_return"]),
                             COPY["kpi_avg_return_subtitle"].format(tf_label=tf_label),
                             "chart-line",
                             COLORS["success"]
-                            if (kpis["avg_return_t7"] or 0) > 0
+                            if (kpis["avg_return"] or 0) > 0
                             else COLORS["danger"],
                             note=fallback_note,
                         ),

--- a/shitty_ui/pages/dashboard_callbacks/period.py
+++ b/shitty_ui/pages/dashboard_callbacks/period.py
@@ -1,12 +1,30 @@
-"""Time period selection and refresh countdown callbacks."""
+"""Time period selection, timeframe selection, and refresh countdown callbacks."""
 
 from dash import Dash, Input, Output, State, callback_context
 
 from components.controls import get_period_button_styles
 
 
+def _get_timeframe_button_styles(selected: str):
+    """Return (color, outline) tuples for each timeframe button.
+
+    Args:
+        selected: The currently selected timeframe key ("t1", "t3", "t7", "t30").
+
+    Returns:
+        Flat tuple of 8 values: (color, outline) x 4 buttons in order t1, t3, t7, t30.
+    """
+    result = []
+    for tf in ("t1", "t3", "t7", "t30"):
+        if tf == selected:
+            result.extend(["primary", False])
+        else:
+            result.extend(["secondary", True])
+    return tuple(result)
+
+
 def register_period_callbacks(app: Dash) -> None:
-    """Register period selection and countdown callbacks.
+    """Register period selection, timeframe selection, and countdown callbacks.
 
     Args:
         app: The Dash application instance.
@@ -47,6 +65,42 @@ def register_period_callbacks(app: Dash) -> None:
         }
         selected = period_map.get(button_id, "90d")
         return selected, *get_period_button_styles(selected)
+
+    @app.callback(
+        [
+            Output("selected-timeframe", "data"),
+            Output("tf-t1", "color"),
+            Output("tf-t1", "outline"),
+            Output("tf-t3", "color"),
+            Output("tf-t3", "outline"),
+            Output("tf-t7", "color"),
+            Output("tf-t7", "outline"),
+            Output("tf-t30", "color"),
+            Output("tf-t30", "outline"),
+        ],
+        [
+            Input("tf-t1", "n_clicks"),
+            Input("tf-t3", "n_clicks"),
+            Input("tf-t7", "n_clicks"),
+            Input("tf-t30", "n_clicks"),
+        ],
+        prevent_initial_call=True,
+    )
+    def update_timeframe_selection(n1, n3, n7, n30):
+        """Update selected outcome timeframe based on button clicks."""
+        ctx = callback_context
+        if not ctx.triggered:
+            return "t7", *_get_timeframe_button_styles("t7")
+
+        button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+        tf_map = {
+            "tf-t1": "t1",
+            "tf-t3": "t3",
+            "tf-t7": "t7",
+            "tf-t30": "t30",
+        }
+        selected = tf_map.get(button_id, "t7")
+        return selected, *_get_timeframe_button_styles(selected)
 
     # Refresh countdown clientside callback
     app.clientside_callback(


### PR DESCRIPTION
## Summary
- **New timeframe selector** — "Outcome Window" toggle (T+1, T+3, T+7, T+30) on the dashboard homepage lets users view KPIs, screener, and insights across any prediction timeframe
- **New `data/timeframe.py` module** — Single source of truth for timeframe→column mapping (`get_tf_columns()`, `TIMEFRAME_OPTIONS`, `VALID_TIMEFRAMES`, `DEFAULT_TIMEFRAME`)
- **20+ query functions parameterized** — All functions in `performance_queries.py`, `asset_queries.py`, and `insight_queries.py` accept explicit `timeframe` parameter with backward-compatible default of "t7"
- **Generic dict keys** — Return dicts use `accuracy`, `avg_return`, `total_pnl` instead of `_t7` suffixed names; all UI components and tests updated
- **Removed `_timeframe_for_period()`** — Replaced Phase 03's auto-selection logic with explicit user-controlled timeframe selection

## Test plan
- [x] 12 new tests in `test_timeframe.py` covering constants and `get_tf_columns()`
- [x] Updated `test_data.py`, `test_layout.py`, `test_cards.py`, `test_data_screener.py` for renamed dict keys
- [x] 858 tests pass (3 pre-existing telegram mapper failures)
- [x] Lint clean (`ruff check`)

Phase 04 of alpha-quality_2026-03-04 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)