### PR TITLE
feat: add analytics charts section with equity curve, rolling accuracy, calibration, and backtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Analytics Charts Section** - New collapsible "Show Me The Money" section on the dashboard
+  - Cumulative P&L equity curve chart showing running total P&L over time
+  - Rolling accuracy chart showing 30-day rolling prediction accuracy trend
+  - Confidence calibration chart comparing predicted confidence vs actual accuracy
+  - Interactive backtest simulator with configurable starting capital and confidence threshold
+  - All charts respect the global Time Period selector
+  - Backtest tab shows summary stats (final value, return %, trades, win rate)
 - **Multi-timeframe dashboard** — New "Outcome Window" toggle (T+1, T+3, T+7, T+30) on the dashboard lets users view KPIs, screener, and insights across any prediction timeframe instead of only T+7
 - **Timeframe column mapping module** — `data/timeframe.py` provides `get_tf_columns()`, `TIMEFRAME_OPTIONS`, `VALID_TIMEFRAMES`, and `DEFAULT_TIMEFRAME` as single source of truth for timeframe→column mapping
 - 12 new tests for timeframe module (`test_timeframe.py`)

--- a/shit_tests/shitty_ui/test_analytics_charts.py
+++ b/shit_tests/shitty_ui/test_analytics_charts.py
@@ -1,0 +1,288 @@
+"""Tests for analytics chart builders and analytics callbacks."""
+
+import sys
+import os
+
+# Add shitty_ui to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "shitty_ui"))
+
+import pytest
+import pandas as pd
+import plotly.graph_objects as go
+from datetime import datetime, date
+
+from components.charts import (
+    build_cumulative_pnl_chart,
+    build_rolling_accuracy_chart,
+    build_confidence_calibration_chart,
+    build_backtest_equity_chart,
+    build_empty_signal_chart,
+)
+from constants import ANALYTICS_COLORS, COLORS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_pnl_df():
+    """Sample cumulative P&L data."""
+    return pd.DataFrame(
+        {
+            "prediction_date": pd.to_datetime(
+                [
+                    "2025-06-01",
+                    "2025-06-02",
+                    "2025-06-03",
+                    "2025-06-04",
+                    "2025-06-05",
+                ]
+            ),
+            "daily_pnl": [50.0, -20.0, 80.0, -10.0, 30.0],
+            "predictions_count": [2, 1, 3, 1, 2],
+            "cumulative_pnl": [50.0, 30.0, 110.0, 100.0, 130.0],
+        }
+    )
+
+
+def _make_rolling_accuracy_df():
+    """Sample rolling accuracy data."""
+    return pd.DataFrame(
+        {
+            "prediction_date": pd.to_datetime(
+                [
+                    "2025-06-01",
+                    "2025-06-02",
+                    "2025-06-03",
+                    "2025-06-04",
+                ]
+            ),
+            "correct": [1, 2, 1, 3],
+            "total": [2, 3, 2, 4],
+            "rolling_accuracy": [50.0, 57.1, 55.0, 63.6],
+        }
+    )
+
+
+def _make_calibration_df():
+    """Sample confidence calibration data."""
+    return pd.DataFrame(
+        {
+            "bucket_start": [0.5, 0.6, 0.7, 0.8],
+            "total": [10, 15, 20, 8],
+            "correct": [4, 9, 15, 7],
+            "avg_confidence": [0.55, 0.67, 0.74, 0.85],
+            "actual_accuracy": [40.0, 60.0, 75.0, 87.5],
+            "predicted_confidence": [55.0, 67.0, 74.0, 85.0],
+            "bucket_label": ["50-60%", "60-70%", "70-80%", "80-90%"],
+        }
+    )
+
+
+def _make_backtest_df(initial_capital=10000):
+    """Sample backtest equity curve data."""
+    return pd.DataFrame(
+        {
+            "prediction_date": pd.to_datetime(
+                [
+                    "2025-06-01",
+                    "2025-06-02",
+                    "2025-06-03",
+                    "2025-06-04",
+                ]
+            ),
+            "daily_pnl": [100.0, -50.0, 200.0, 75.0],
+            "trade_count": [1, 1, 2, 1],
+            "cumulative_pnl": [100.0, 50.0, 250.0, 325.0],
+            "equity": [10100.0, 10050.0, 10250.0, 10325.0],
+        }
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cumulative P&L Chart
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildCumulativePnlChart:
+    """Tests for build_cumulative_pnl_chart."""
+
+    def test_returns_figure_with_data(self):
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        assert isinstance(fig, go.Figure)
+
+    def test_empty_df_returns_empty_chart(self):
+        fig = build_cumulative_pnl_chart(pd.DataFrame())
+        assert isinstance(fig, go.Figure)
+        assert len(fig.layout.annotations) == 1
+
+    def test_has_line_trace(self):
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter)]
+        assert len(scatter_traces) >= 1
+        assert scatter_traces[0].mode == "lines"
+
+    def test_line_uses_equity_color(self):
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        line_trace = [t for t in fig.data if isinstance(t, go.Scatter)][0]
+        assert line_trace.line.color == ANALYTICS_COLORS["equity_line"]
+
+    def test_has_fill_to_zero(self):
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        line_trace = [t for t in fig.data if isinstance(t, go.Scatter)][0]
+        assert line_trace.fill == "tozeroy"
+
+    def test_yaxis_has_dollar_prefix(self):
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        assert fig.layout.yaxis.tickprefix == "$"
+
+    def test_has_zero_reference_line(self):
+        """Chart should have an hline shape at y=0."""
+        fig = build_cumulative_pnl_chart(_make_pnl_df())
+        shapes = fig.layout.shapes
+        assert shapes is not None
+        assert len(shapes) >= 1
+        # hline at y=0
+        assert any(s.y0 == 0 and s.y1 == 0 for s in shapes)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Rolling Accuracy Chart
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildRollingAccuracyChart:
+    """Tests for build_rolling_accuracy_chart."""
+
+    def test_returns_figure_with_data(self):
+        fig = build_rolling_accuracy_chart(_make_rolling_accuracy_df())
+        assert isinstance(fig, go.Figure)
+
+    def test_empty_df_returns_empty_chart(self):
+        fig = build_rolling_accuracy_chart(pd.DataFrame())
+        assert isinstance(fig, go.Figure)
+        assert len(fig.layout.annotations) >= 1
+
+    def test_has_accuracy_line(self):
+        fig = build_rolling_accuracy_chart(_make_rolling_accuracy_df())
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter)]
+        assert len(scatter_traces) >= 1
+
+    def test_line_uses_rolling_color(self):
+        fig = build_rolling_accuracy_chart(_make_rolling_accuracy_df())
+        line_trace = [t for t in fig.data if isinstance(t, go.Scatter)][0]
+        assert line_trace.line.color == ANALYTICS_COLORS["rolling_line"]
+
+    def test_yaxis_range_is_0_to_105(self):
+        fig = build_rolling_accuracy_chart(_make_rolling_accuracy_df())
+        assert tuple(fig.layout.yaxis.range) == (0, 105)
+
+    def test_has_50_percent_baseline(self):
+        """Should have a reference line at 50%."""
+        fig = build_rolling_accuracy_chart(_make_rolling_accuracy_df())
+        shapes = fig.layout.shapes
+        assert shapes is not None
+        assert any(s.y0 == 50 and s.y1 == 50 for s in shapes)
+
+    def test_missing_rolling_accuracy_column(self):
+        """DataFrame without rolling_accuracy column returns empty chart."""
+        df = pd.DataFrame({"prediction_date": ["2025-06-01"], "correct": [1]})
+        fig = build_rolling_accuracy_chart(df)
+        assert len(fig.layout.annotations) >= 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Confidence Calibration Chart
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildConfidenceCalibrationChart:
+    """Tests for build_confidence_calibration_chart."""
+
+    def test_returns_figure_with_data(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        assert isinstance(fig, go.Figure)
+
+    def test_empty_df_returns_empty_chart(self):
+        fig = build_confidence_calibration_chart(pd.DataFrame())
+        assert isinstance(fig, go.Figure)
+        assert len(fig.layout.annotations) >= 1
+
+    def test_has_two_bar_traces(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        bar_traces = [t for t in fig.data if isinstance(t, go.Bar)]
+        assert len(bar_traces) == 2
+
+    def test_predicted_bar_uses_correct_color(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        bar_traces = [t for t in fig.data if isinstance(t, go.Bar)]
+        assert bar_traces[0].marker.color == ANALYTICS_COLORS["calibration_predicted"]
+
+    def test_actual_bar_uses_correct_color(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        bar_traces = [t for t in fig.data if isinstance(t, go.Bar)]
+        assert bar_traces[1].marker.color == ANALYTICS_COLORS["calibration_actual"]
+
+    def test_has_grouped_barmode(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        assert fig.layout.barmode == "group"
+
+    def test_legend_shown(self):
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        assert fig.layout.showlegend is True
+
+    def test_has_reference_line_trace(self):
+        """Should have a dotted reference line for perfect calibration."""
+        fig = build_confidence_calibration_chart(_make_calibration_df())
+        line_traces = [
+            t for t in fig.data if isinstance(t, go.Scatter) and t.line.dash == "dot"
+        ]
+        assert len(line_traces) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Backtest Equity Chart
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestBuildBacktestEquityChart:
+    """Tests for build_backtest_equity_chart."""
+
+    def test_returns_figure_with_data(self):
+        fig = build_backtest_equity_chart(_make_backtest_df())
+        assert isinstance(fig, go.Figure)
+
+    def test_empty_df_returns_empty_chart(self):
+        fig = build_backtest_equity_chart(pd.DataFrame())
+        assert isinstance(fig, go.Figure)
+        assert len(fig.layout.annotations) >= 1
+
+    def test_has_equity_line_trace(self):
+        fig = build_backtest_equity_chart(_make_backtest_df())
+        scatter_traces = [t for t in fig.data if isinstance(t, go.Scatter)]
+        assert len(scatter_traces) >= 1
+
+    def test_line_uses_backtest_color(self):
+        fig = build_backtest_equity_chart(_make_backtest_df())
+        line_trace = [t for t in fig.data if isinstance(t, go.Scatter)][0]
+        assert line_trace.line.color == ANALYTICS_COLORS["backtest_line"]
+
+    def test_has_starting_capital_reference(self):
+        """Should have a reference line at initial capital."""
+        fig = build_backtest_equity_chart(_make_backtest_df(), initial_capital=10000)
+        shapes = fig.layout.shapes
+        assert shapes is not None
+        assert any(s.y0 == 10000 for s in shapes)
+
+    def test_custom_initial_capital(self):
+        """Reference line adapts to custom initial_capital."""
+        fig = build_backtest_equity_chart(
+            _make_backtest_df(25000), initial_capital=25000
+        )
+        shapes = fig.layout.shapes
+        assert any(s.y0 == 25000 for s in shapes)
+
+    def test_yaxis_has_dollar_prefix(self):
+        fig = build_backtest_equity_chart(_make_backtest_df())
+        assert fig.layout.yaxis.tickprefix == "$"

--- a/shitty_ui/app.py
+++ b/shitty_ui/app.py
@@ -72,10 +72,24 @@ def register_webhook_route(app):
         return jsonify(health), status_code
 
 
-_STATIC_EXTENSIONS = frozenset((
-    ".css", ".js", ".json", ".png", ".jpg", ".jpeg", ".gif",
-    ".ico", ".svg", ".woff", ".woff2", ".ttf", ".map", ".gz",
-))
+_STATIC_EXTENSIONS = frozenset(
+    (
+        ".css",
+        ".js",
+        ".json",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".ico",
+        ".svg",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".map",
+        ".gz",
+    )
+)
 
 
 def register_client_routes(app):

--- a/shitty_ui/brand_copy.py
+++ b/shitty_ui/brand_copy.py
@@ -33,6 +33,18 @@ COPY = {
     "tab_accuracy": "Accuracy Over Time",
     "tab_confidence": "By Confidence Level",
     "tab_asset": "By Asset (click to drill down)",
+    # ===== Dashboard: Analytics Charts Section =====
+    "analytics_section_subtitle": "equity curves, accuracy trends, and backtesting (the real stuff)",
+    "analytics_pnl_tab": "Equity Curve",
+    "analytics_rolling_tab": "Rolling Accuracy",
+    "analytics_calibration_tab": "Calibration",
+    "analytics_backtest_tab": "Backtest Simulator",
+    "analytics_empty_pnl": "No P&L data yet. Predictions need 7+ trading days to mature.",
+    "analytics_empty_rolling": "Not enough data points for rolling accuracy.",
+    "analytics_empty_calibration": "No calibration data. Need evaluated predictions first.",
+    "analytics_empty_backtest": "No backtest data for these settings.",
+    "analytics_backtest_capital_label": "Starting Capital ($)",
+    "analytics_backtest_confidence_label": "Min Confidence",
     # ===== Dashboard: Posts + Feed Columns =====
     "latest_posts_header": "Latest Shitposts",
     "latest_posts_subtitle": "fresh off Truth Social, with our AI's hot take on your portfolio",

--- a/shitty_ui/components/charts.py
+++ b/shitty_ui/components/charts.py
@@ -12,6 +12,7 @@ from constants import (
     TIMEFRAME_COLORS,
     CHART_LAYOUT,
     CHART_COLORS,
+    ANALYTICS_COLORS,
 )
 
 
@@ -453,3 +454,305 @@ def _add_annotation_legend(fig: go.Figure) -> None:
             font=dict(color=COLORS["text_muted"], size=11),
         ),
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Analytics chart builders (Phase 05)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_cumulative_pnl_chart(
+    df: pd.DataFrame,
+    chart_height: int = 350,
+) -> go.Figure:
+    """Build a cumulative P&L equity curve line chart.
+
+    Shows running total P&L over time with a horizontal $0 reference line.
+    Green fill above zero, red below.
+
+    Args:
+        df: DataFrame from get_cumulative_pnl() with columns:
+            prediction_date, daily_pnl, predictions_count, cumulative_pnl.
+        chart_height: Height in pixels.
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph.
+    """
+    if df.empty:
+        return build_empty_signal_chart("No P&L data available")
+
+    fig = go.Figure()
+
+    # --- $0 reference line ---
+    fig.add_hline(
+        y=0,
+        line_dash="dash",
+        line_color=ANALYTICS_COLORS["zero_line"],
+        line_width=1,
+    )
+
+    # --- Main equity curve ---
+    fig.add_trace(
+        go.Scatter(
+            x=df["prediction_date"],
+            y=df["cumulative_pnl"],
+            mode="lines",
+            line=dict(
+                color=ANALYTICS_COLORS["equity_line"],
+                width=2,
+            ),
+            fill="tozeroy",
+            fillcolor=ANALYTICS_COLORS["equity_fill"],
+            name="Cumulative P&L",
+            showlegend=False,
+            hovertemplate=(
+                "<b>%{x|%b %d, %Y}</b><br>"
+                "Cumulative P&L: <b>$%{y:+,.0f}</b>"
+                "<extra></extra>"
+            ),
+        )
+    )
+
+    # --- Layout ---
+    apply_chart_layout(
+        fig,
+        height=chart_height,
+        show_legend=False,
+        hovermode="x unified",
+        margin={"l": 55, "r": 20, "t": 10, "b": 40},
+        yaxis={"title": "Cumulative P&L ($)", "tickprefix": "$"},
+    )
+
+    return fig
+
+
+def build_rolling_accuracy_chart(
+    df: pd.DataFrame,
+    chart_height: int = 350,
+) -> go.Figure:
+    """Build a rolling accuracy percentage line chart.
+
+    Shows rolling-window accuracy over time so the user can see if
+    the system is improving or degrading.
+
+    Args:
+        df: DataFrame from get_rolling_accuracy() with columns:
+            prediction_date, correct, total, rolling_accuracy.
+        chart_height: Height in pixels.
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph.
+    """
+    if df.empty or "rolling_accuracy" not in df.columns:
+        return build_empty_signal_chart("Not enough data for rolling accuracy")
+
+    fig = go.Figure()
+
+    # --- 50% reference line (coin flip baseline) ---
+    fig.add_hline(
+        y=50,
+        line_dash="dash",
+        line_color=ANALYTICS_COLORS["zero_line"],
+        line_width=1,
+        annotation_text="50% (coin flip)",
+        annotation_position="bottom right",
+        annotation_font_color=COLORS["text_muted"],
+        annotation_font_size=10,
+    )
+
+    # --- Rolling accuracy line ---
+    fig.add_trace(
+        go.Scatter(
+            x=df["prediction_date"],
+            y=df["rolling_accuracy"],
+            mode="lines",
+            line=dict(
+                color=ANALYTICS_COLORS["rolling_line"],
+                width=2,
+            ),
+            fill="tozeroy",
+            fillcolor=ANALYTICS_COLORS["rolling_fill"],
+            name="Rolling Accuracy",
+            showlegend=False,
+            hovertemplate=(
+                "<b>%{x|%b %d, %Y}</b><br>"
+                "Rolling Accuracy: <b>%{y:.1f}%</b>"
+                "<extra></extra>"
+            ),
+        )
+    )
+
+    # --- Layout ---
+    apply_chart_layout(
+        fig,
+        height=chart_height,
+        show_legend=False,
+        hovermode="x unified",
+        margin={"l": 50, "r": 20, "t": 10, "b": 40},
+        yaxis={"title": "Accuracy (%)", "range": [0, 105], "ticksuffix": "%"},
+    )
+
+    return fig
+
+
+def build_confidence_calibration_chart(
+    df: pd.DataFrame,
+    chart_height: int = 350,
+) -> go.Figure:
+    """Build a confidence calibration grouped bar chart.
+
+    Compares predicted confidence levels vs actual accuracy per bucket.
+    A well-calibrated model has bars at roughly equal heights.
+    Includes a diagonal "perfect calibration" reference line.
+
+    Args:
+        df: DataFrame from get_confidence_calibration() with columns:
+            bucket_start, total, correct, avg_confidence,
+            actual_accuracy, predicted_confidence, bucket_label.
+        chart_height: Height in pixels.
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph.
+    """
+    if df.empty:
+        return build_empty_signal_chart("No calibration data available")
+
+    fig = go.Figure()
+
+    # --- Predicted confidence bars ---
+    fig.add_trace(
+        go.Bar(
+            x=df["bucket_label"],
+            y=df["predicted_confidence"],
+            name="Predicted Confidence",
+            marker_color=ANALYTICS_COLORS["calibration_predicted"],
+            opacity=0.7,
+            hovertemplate=("<b>%{x}</b><br>Predicted: <b>%{y:.1f}%</b><extra></extra>"),
+        )
+    )
+
+    # --- Actual accuracy bars ---
+    fig.add_trace(
+        go.Bar(
+            x=df["bucket_label"],
+            y=df["actual_accuracy"],
+            name="Actual Accuracy",
+            marker_color=ANALYTICS_COLORS["calibration_actual"],
+            opacity=0.7,
+            hovertemplate=(
+                "<b>%{x}</b><br>"
+                "Actual: <b>%{y:.1f}%</b><br>"
+                "Predictions: <b>%{customdata}</b>"
+                "<extra></extra>"
+            ),
+            customdata=df["total"],
+        )
+    )
+
+    # --- Perfect calibration reference line ---
+    # Draw a diagonal from bottom-left to top-right using bucket midpoints
+    if len(df) >= 2:
+        fig.add_trace(
+            go.Scatter(
+                x=df["bucket_label"],
+                y=df["predicted_confidence"],
+                mode="lines",
+                line=dict(
+                    color=ANALYTICS_COLORS["calibration_perfect"],
+                    width=1.5,
+                    dash="dot",
+                ),
+                name="Perfect Calibration",
+                showlegend=True,
+                hoverinfo="skip",
+            )
+        )
+
+    # --- Layout ---
+    apply_chart_layout(
+        fig,
+        height=chart_height,
+        show_legend=True,
+        barmode="group",
+        margin={"l": 50, "r": 20, "t": 10, "b": 40},
+        yaxis={"title": "Percentage (%)", "range": [0, 105], "ticksuffix": "%"},
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+            font=dict(color=COLORS["text_muted"], size=11),
+        ),
+    )
+
+    return fig
+
+
+def build_backtest_equity_chart(
+    df: pd.DataFrame,
+    initial_capital: float = 10000,
+    chart_height: int = 350,
+) -> go.Figure:
+    """Build a backtest simulation equity curve chart.
+
+    Shows the hypothetical equity growth over time if following the
+    system's high-confidence recommendations.
+
+    Args:
+        df: DataFrame from get_backtest_equity_curve() with columns:
+            prediction_date, daily_pnl, trade_count, cumulative_pnl, equity.
+        initial_capital: Starting capital for the horizontal reference line.
+        chart_height: Height in pixels.
+
+    Returns:
+        go.Figure ready to be rendered by dcc.Graph.
+    """
+    if df.empty:
+        return build_empty_signal_chart("No backtest data for these settings")
+
+    fig = go.Figure()
+
+    # --- Starting capital reference line ---
+    fig.add_hline(
+        y=initial_capital,
+        line_dash="dash",
+        line_color=ANALYTICS_COLORS["backtest_start"],
+        line_width=1,
+        annotation_text=f"Start: ${initial_capital:,.0f}",
+        annotation_position="top left",
+        annotation_font_color=ANALYTICS_COLORS["backtest_start"],
+        annotation_font_size=10,
+    )
+
+    # --- Equity curve ---
+    fig.add_trace(
+        go.Scatter(
+            x=df["prediction_date"],
+            y=df["equity"],
+            mode="lines",
+            line=dict(
+                color=ANALYTICS_COLORS["backtest_line"],
+                width=2,
+            ),
+            fill="tozeroy",
+            fillcolor=ANALYTICS_COLORS["backtest_fill"],
+            name="Portfolio Value",
+            showlegend=False,
+            hovertemplate=(
+                "<b>%{x|%b %d, %Y}</b><br>Portfolio: <b>$%{y:,.0f}</b><extra></extra>"
+            ),
+        )
+    )
+
+    # --- Layout ---
+    apply_chart_layout(
+        fig,
+        height=chart_height,
+        show_legend=False,
+        hovermode="x unified",
+        margin={"l": 60, "r": 20, "t": 10, "b": 40},
+        yaxis={"title": "Portfolio Value ($)", "tickprefix": "$"},
+    )
+
+    return fig

--- a/shitty_ui/components/controls.py
+++ b/shitty_ui/components/controls.py
@@ -72,4 +72,3 @@ def create_filter_controls():
         ],
         className="g-3",
     )
-

--- a/shitty_ui/components/header.py
+++ b/shitty_ui/components/header.py
@@ -19,8 +19,14 @@ def create_header():
                             dcc.Link(
                                 html.H1(
                                     [
-                                        html.Span("$hitpost ", style={"color": COLORS["accent"]}),
-                                        html.Span("Alpha", style={"color": COLORS["accent_gold"]}),
+                                        html.Span(
+                                            "$hitpost ",
+                                            style={"color": COLORS["accent"]},
+                                        ),
+                                        html.Span(
+                                            "Alpha",
+                                            style={"color": COLORS["accent_gold"]},
+                                        ),
                                     ],
                                     style={
                                         "fontSize": "1.75rem",
@@ -161,7 +167,10 @@ def create_footer():
             html.P(
                 [
                     html.A(
-                        [html.I(className="fab fa-github me-1"), COPY["footer_source_link"]],
+                        [
+                            html.I(className="fab fa-github me-1"),
+                            COPY["footer_source_link"],
+                        ],
                         href="https://github.com/chrisrogers37/shitpost-alpha",
                         target="_blank",
                         style={"color": COLORS["accent"], "textDecoration": "none"},
@@ -171,4 +180,3 @@ def create_footer():
             ),
         ]
     )
-

--- a/shitty_ui/constants.py
+++ b/shitty_ui/constants.py
@@ -19,25 +19,25 @@ COLORS = {
 
 # Sentiment-specific color mapping for chart overlays
 SENTIMENT_COLORS = {
-    "bullish": "#85BB65",   # Dollar bill green (same as COLORS["success"])
-    "bearish": "#B22234",   # Old Glory red (same as COLORS["danger"])
-    "neutral": "#8B9A7E",   # Sage muted green (same as COLORS["text_muted"])
+    "bullish": "#85BB65",  # Dollar bill green (same as COLORS["success"])
+    "bearish": "#B22234",  # Old Glory red (same as COLORS["danger"])
+    "neutral": "#8B9A7E",  # Sage muted green (same as COLORS["text_muted"])
 }
 
 # Pre-computed sentiment badge background colors (hex + alpha suffix)
 # Used by card components for consistent badge and border styling
 SENTIMENT_BG_COLORS = {
-    "bullish": "#85BB6526",   # Dollar bill green at ~15% opacity
-    "bearish": "#B2223426",   # Old Glory red at ~15% opacity
-    "neutral": "#8B9A7E26",   # Sage muted green at ~15% opacity
+    "bullish": "#85BB6526",  # Dollar bill green at ~15% opacity
+    "bearish": "#B2223426",  # Old Glory red at ~15% opacity
+    "neutral": "#8B9A7E26",  # Sage muted green at ~15% opacity
 }
 
 # Marker configuration for signal overlays
 MARKER_CONFIG = {
-    "min_size": 8,          # Minimum marker size (pixels)
-    "max_size": 22,         # Maximum marker size (pixels)
-    "opacity": 0.85,        # Default marker opacity
-    "border_width": 1.5,    # Marker border width
+    "min_size": 8,  # Minimum marker size (pixels)
+    "max_size": 22,  # Maximum marker size (pixels)
+    "opacity": 0.85,  # Default marker opacity
+    "border_width": 1.5,  # Marker border width
     "symbols": {
         "bullish": "triangle-up",
         "bearish": "triangle-down",
@@ -49,38 +49,38 @@ MARKER_CONFIG = {
 TIMEFRAME_COLORS = {
     "t1": "rgba(133, 187, 101, 0.06)",  # Dollar bill green, very light
     "t3": "rgba(133, 187, 101, 0.04)",
-    "t7": "rgba(255, 215, 0, 0.04)",    # Gold, very light
+    "t7": "rgba(255, 215, 0, 0.04)",  # Gold, very light
     "t30": "rgba(255, 215, 0, 0.02)",
 }
 
 # Typography scale - consistent font sizes across all UI components
 # Based on a 1.25 ratio (Major Third) scale with 1rem = 16px base
 FONT_SIZES = {
-    "page_title": "1.75rem",   # 28px - Top-level page headers (H1)
+    "page_title": "1.75rem",  # 28px - Top-level page headers (H1)
     "section_header": "1.15rem",  # ~18px - Section headers within pages (H2/H3)
-    "card_title": "0.95rem",   # ~15px - Card header titles
-    "body": "0.9rem",          # ~14px - Standard body text
-    "label": "0.8rem",         # ~13px - Form labels, metadata labels
-    "meta": "0.75rem",         # 12px - Timestamps, badges, footnotes
-    "small": "0.7rem",         # ~11px - Fine print, subordinate labels
+    "card_title": "0.95rem",  # ~15px - Card header titles
+    "body": "0.9rem",  # ~14px - Standard body text
+    "label": "0.8rem",  # ~13px - Form labels, metadata labels
+    "meta": "0.75rem",  # 12px - Timestamps, badges, footnotes
+    "small": "0.7rem",  # ~11px - Fine print, subordinate labels
 }
 
 # Font weights - semantic weight names for consistent emphasis
 FONT_WEIGHTS = {
-    "bold": "700",       # Page titles, hero elements
-    "semibold": "600",   # Section headers, card titles, emphasis
-    "medium": "500",     # Navigation links, active elements
-    "normal": "400",     # Body text, descriptions
+    "bold": "700",  # Page titles, hero elements
+    "semibold": "600",  # Section headers, card titles, emphasis
+    "medium": "500",  # Navigation links, active elements
+    "normal": "400",  # Body text, descriptions
 }
 
 # Spacing tokens - consistent padding and margins (in px)
 # Named xs through xl for predictable rhythm
 SPACING = {
-    "xs": "4px",    # Tight gaps (between icon and label)
-    "sm": "8px",    # Small gaps (between inline elements)
-    "md": "16px",   # Standard padding (card bodies, section gaps)
-    "lg": "24px",   # Larger gaps (between major sections)
-    "xl": "32px",   # Page-level padding (top/bottom of page content)
+    "xs": "4px",  # Tight gaps (between icon and label)
+    "sm": "8px",  # Small gaps (between inline elements)
+    "md": "16px",  # Standard padding (card bodies, section gaps)
+    "lg": "24px",  # Larger gaps (between major sections)
+    "xl": "32px",  # Page-level padding (top/bottom of page content)
     "xxl": "48px",  # Major visual breaks (before footer)
 }
 
@@ -119,17 +119,17 @@ HIERARCHY = {
 
 # Sparkline configuration for inline price charts on signal cards
 SPARKLINE_CONFIG = {
-    "width": 120,             # px -- chart width
-    "height": 36,             # px -- chart height
-    "line_width": 1.5,        # px -- line stroke width
-    "days_before": 3,         # trading days before prediction to show
-    "days_after": 10,         # trading days after prediction to show
-    "color_up": COLORS["success"],   # Line color when price ended higher
+    "width": 120,  # px -- chart width
+    "height": 36,  # px -- chart height
+    "line_width": 1.5,  # px -- line stroke width
+    "days_before": 3,  # trading days before prediction to show
+    "days_after": 10,  # trading days after prediction to show
+    "color_up": COLORS["success"],  # Line color when price ended higher
     "color_down": COLORS["danger"],  # Line color when price ended lower
     "color_flat": COLORS["text_muted"],  # Line color when negligible change
-    "fill_opacity": 0.08,     # Fill-under-line opacity
+    "fill_opacity": 0.08,  # Fill-under-line opacity
     "marker_color": COLORS["warning"],  # Color of the prediction-date marker
-    "marker_size": 5,         # px -- prediction-date dot size
+    "marker_size": 5,  # px -- prediction-date dot size
 }
 
 # ============================================================
@@ -180,15 +180,15 @@ CHART_CONFIG = {
 
 # Extended candlestick-specific colors (override Plotly defaults)
 CHART_COLORS = {
-    "candle_up": "#85BB65",       # Dollar bill green — matches COLORS["success"]
-    "candle_down": "#B22234",     # Old Glory red — matches COLORS["danger"]
+    "candle_up": "#85BB65",  # Dollar bill green — matches COLORS["success"]
+    "candle_down": "#B22234",  # Old Glory red — matches COLORS["danger"]
     "candle_up_fill": "#85BB65",  # Solid fill for up candles
     "candle_down_fill": "#B22234",
-    "volume_up": "rgba(133, 187, 101, 0.3)",   # Dollar bill green at 30%
-    "volume_down": "rgba(178, 34, 52, 0.3)",   # Old Glory red at 30%
-    "line_accent": "#85BB65",     # Dollar bill green — COLORS["accent"]
+    "volume_up": "rgba(133, 187, 101, 0.3)",  # Dollar bill green at 30%
+    "volume_down": "rgba(178, 34, 52, 0.3)",  # Old Glory red at 30%
+    "line_accent": "#85BB65",  # Dollar bill green — COLORS["accent"]
     "line_accent_fill": "rgba(133, 187, 101, 0.08)",  # Subtler area fill
-    "bar_palette": [              # Money-themed palette for multi-bar charts
+    "bar_palette": [  # Money-themed palette for multi-bar charts
         "#85BB65",  # Dollar bill green
         "#FFD700",  # Gold
         "#B22234",  # Old Glory red
@@ -197,4 +197,19 @@ CHART_COLORS = {
         "#5C8A4D",  # Darker money green
     ],
     "reference_line": "rgba(139, 154, 126, 0.3)",  # Sage muted green at 30%
+}
+
+# Analytics chart-specific colors
+ANALYTICS_COLORS = {
+    "equity_line": "#85BB65",  # Dollar bill green -- main equity curve
+    "equity_fill": "rgba(133, 187, 101, 0.12)",  # Subtle green fill
+    "zero_line": "rgba(139, 154, 126, 0.4)",  # Sage muted -- $0 reference
+    "rolling_line": "#FFD700",  # Gold -- rolling accuracy
+    "rolling_fill": "rgba(255, 215, 0, 0.08)",  # Subtle gold fill
+    "calibration_predicted": "#85BB65",  # Dollar green -- predicted confidence bar
+    "calibration_actual": "#FFD700",  # Gold -- actual accuracy bar
+    "calibration_perfect": "rgba(139, 154, 126, 0.3)",  # Sage -- diagonal reference
+    "backtest_line": "#85BB65",  # Dollar green -- equity curve
+    "backtest_fill": "rgba(133, 187, 101, 0.10)",
+    "backtest_start": "#FFD700",  # Gold -- starting capital marker
 }

--- a/shitty_ui/data/__init__.py
+++ b/shitty_ui/data/__init__.py
@@ -90,6 +90,11 @@ from data.insight_queries import (  # noqa: F401
     get_dynamic_insights,
 )
 
+# --- Backtest queries ---
+from data.backtest_queries import (  # noqa: F401
+    get_backtest_equity_curve,
+)
+
 
 def clear_all_caches() -> None:
     """Clear all data layer caches. Call when forcing a full refresh.
@@ -120,6 +125,9 @@ def clear_all_caches() -> None:
 
     # Insight queries (1 cached function)
     get_dynamic_insights.clear_cache()  # type: ignore
+
+    # Backtest queries (1 cached function)
+    get_backtest_equity_curve.clear_cache()  # type: ignore
 
 
 __all__ = [
@@ -183,4 +191,6 @@ __all__ = [
     "get_related_assets",
     # Insight queries
     "get_dynamic_insights",
+    # Backtest queries
+    "get_backtest_equity_curve",
 ]

--- a/shitty_ui/data/asset_queries.py
+++ b/shitty_ui/data/asset_queries.py
@@ -505,9 +505,7 @@ def get_asset_predictions(symbol: str, limit: int = 50) -> pd.DataFrame:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_asset_stats(
-    symbol: str, timeframe: str = DEFAULT_TIMEFRAME
-) -> Dict[str, Any]:
+def get_asset_stats(symbol: str, timeframe: str = DEFAULT_TIMEFRAME) -> Dict[str, Any]:
     """
     Get aggregate performance statistics for a specific asset,
     alongside overall system averages for comparison.

--- a/shitty_ui/data/backtest_queries.py
+++ b/shitty_ui/data/backtest_queries.py
@@ -1,0 +1,69 @@
+"""Backtest simulation queries returning time-series data for charts.
+
+Supplements the summary-only get_backtest_simulation() in performance_queries
+with a date-ordered DataFrame suitable for plotting equity curves.
+"""
+
+import pandas as pd
+from datetime import datetime, timedelta
+from typing import Dict, Any
+
+from sqlalchemy import text
+
+import data.base as _base
+from data.base import ttl_cache, logger
+
+
+@ttl_cache(ttl_seconds=300)
+def get_backtest_equity_curve(
+    initial_capital: float = 10000,
+    min_confidence: float = 0.75,
+    days: int = None,
+) -> pd.DataFrame:
+    """Get date-ordered equity curve for backtest simulation chart.
+
+    Returns the same trade-by-trade P&L data as get_backtest_simulation()
+    but includes prediction_date so it can be plotted as a time series.
+
+    Args:
+        initial_capital: Starting capital in dollars.
+        min_confidence: Minimum prediction confidence threshold to include.
+        days: Number of days to look back (None = all time).
+
+    Returns:
+        DataFrame with columns:
+            prediction_date, daily_pnl, trade_count, cumulative_pnl, equity
+        Where equity = initial_capital + cumulative_pnl.
+        Empty DataFrame if no data.
+    """
+    date_filter = ""
+    params: Dict[str, Any] = {"min_confidence": min_confidence}
+
+    if days is not None:
+        date_filter = "AND prediction_date >= :start_date"
+        params["start_date"] = (datetime.now() - timedelta(days=days)).date()
+
+    query = text(f"""
+        SELECT
+            prediction_date,
+            SUM(CASE WHEN pnl_t7 IS NOT NULL THEN pnl_t7 ELSE 0 END) as daily_pnl,
+            COUNT(*) as trade_count
+        FROM prediction_outcomes
+        WHERE prediction_confidence >= :min_confidence
+            AND correct_t7 IS NOT NULL
+            AND return_t7 IS NOT NULL
+            {date_filter}
+        GROUP BY prediction_date
+        ORDER BY prediction_date ASC
+    """)
+
+    try:
+        rows, columns = _base.execute_query(query, params)
+        df = pd.DataFrame(rows, columns=columns)
+        if not df.empty:
+            df["cumulative_pnl"] = df["daily_pnl"].cumsum()
+            df["equity"] = initial_capital + df["cumulative_pnl"]
+        return df
+    except Exception as e:
+        logger.error(f"Error loading backtest equity curve: {e}")
+        return pd.DataFrame()

--- a/shitty_ui/data/base.py
+++ b/shitty_ui/data/base.py
@@ -58,7 +58,6 @@ def ttl_cache(ttl_seconds: int = 300):
     return decorator
 
 
-
 def execute_query(query, params=None):
     """Execute query using appropriate session type."""
     try:

--- a/shitty_ui/data/insight_queries.py
+++ b/shitty_ui/data/insight_queries.py
@@ -85,8 +85,7 @@ def get_dynamic_insights(
                 ret_str = f"{ret_val:+.2f}%"
                 if correct:
                     headline = (
-                        f"Trump mentioned {symbol}"
-                        f" -- it's {ret_str} in {tf_label}."
+                        f"Trump mentioned {symbol} -- it's {ret_str} in {tf_label}."
                     )
                     body = (
                         f"Predicted correctly with {ret_str} return."
@@ -96,8 +95,7 @@ def get_dynamic_insights(
                     ins_sentiment = "positive"
                 else:
                     headline = (
-                        f"Trump mentioned {symbol}"
-                        f" -- it went {ret_str} in {tf_label}."
+                        f"Trump mentioned {symbol} -- it went {ret_str} in {tf_label}."
                     )
                     body = (
                         "Missed by a wide margin."

--- a/shitty_ui/data/timeframe.py
+++ b/shitty_ui/data/timeframe.py
@@ -68,7 +68,6 @@ def get_tf_columns(timeframe: str = "t7") -> Dict[str, str]:
     """
     if timeframe not in TIMEFRAME_OPTIONS:
         raise ValueError(
-            f"Invalid timeframe '{timeframe}'. "
-            f"Valid options: {VALID_TIMEFRAMES}"
+            f"Invalid timeframe '{timeframe}'. Valid options: {VALID_TIMEFRAMES}"
         )
     return dict(TIMEFRAME_OPTIONS[timeframe])

--- a/shitty_ui/pages/dashboard.py
+++ b/shitty_ui/pages/dashboard.py
@@ -3,7 +3,7 @@
 from dash import Dash, html, dcc
 import dash_bootstrap_components as dbc
 
-from constants import COLORS, HIERARCHY
+from constants import COLORS, HIERARCHY, CHART_CONFIG
 from components.controls import create_filter_controls
 from components.header import create_header, create_footer
 from brand_copy import COPY
@@ -198,6 +198,199 @@ def create_dashboard_page() -> html.Div:
                             "boxShadow": HIERARCHY["secondary"]["shadow"],
                         },
                     ),
+                    # ========== Analytics Charts (Secondary tier, collapsible) ==========
+                    dbc.Card(
+                        [
+                            dbc.CardHeader(
+                                [
+                                    dbc.Button(
+                                        [
+                                            html.I(
+                                                className="fas fa-chevron-right me-2 collapse-chevron",
+                                                id="collapse-analytics-chevron",
+                                            ),
+                                            html.I(className="fas fa-chart-area me-2"),
+                                            COPY["analytics_header"],
+                                            html.Small(
+                                                f" - {COPY['analytics_section_subtitle']}",
+                                                style={
+                                                    "color": COLORS["text_muted"],
+                                                    "fontWeight": "normal",
+                                                },
+                                            ),
+                                        ],
+                                        id="collapse-analytics-button",
+                                        color="link",
+                                        className="text-white fw-bold p-0 collapse-toggle-btn",
+                                    ),
+                                ],
+                                className="fw-bold",
+                                style={
+                                    "backgroundColor": HIERARCHY["secondary"][
+                                        "background"
+                                    ]
+                                },
+                            ),
+                            dbc.Collapse(
+                                dbc.CardBody(
+                                    [
+                                        # Tab navigation for chart types
+                                        dbc.Tabs(
+                                            [
+                                                dbc.Tab(
+                                                    label=COPY["analytics_pnl_tab"],
+                                                    tab_id="tab-pnl",
+                                                ),
+                                                dbc.Tab(
+                                                    label=COPY["analytics_rolling_tab"],
+                                                    tab_id="tab-rolling",
+                                                ),
+                                                dbc.Tab(
+                                                    label=COPY[
+                                                        "analytics_calibration_tab"
+                                                    ],
+                                                    tab_id="tab-calibration",
+                                                ),
+                                                dbc.Tab(
+                                                    label=COPY[
+                                                        "analytics_backtest_tab"
+                                                    ],
+                                                    tab_id="tab-backtest",
+                                                ),
+                                            ],
+                                            id="analytics-tabs",
+                                            active_tab="tab-pnl",
+                                            className="mb-3",
+                                        ),
+                                        # Backtest controls (visible only on backtest tab)
+                                        html.Div(
+                                            [
+                                                dbc.Row(
+                                                    [
+                                                        dbc.Col(
+                                                            [
+                                                                html.Label(
+                                                                    COPY[
+                                                                        "analytics_backtest_capital_label"
+                                                                    ],
+                                                                    style={
+                                                                        "color": COLORS[
+                                                                            "text_muted"
+                                                                        ],
+                                                                        "fontSize": "0.8rem",
+                                                                        "marginBottom": "4px",
+                                                                    },
+                                                                ),
+                                                                dbc.Input(
+                                                                    id="backtest-capital-input",
+                                                                    type="number",
+                                                                    value=10000,
+                                                                    min=1000,
+                                                                    max=1000000,
+                                                                    step=1000,
+                                                                    style={
+                                                                        "backgroundColor": COLORS[
+                                                                            "bg"
+                                                                        ],
+                                                                        "color": COLORS[
+                                                                            "text"
+                                                                        ],
+                                                                        "border": f"1px solid {COLORS['border']}",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            md=4,
+                                                            xs=6,
+                                                        ),
+                                                        dbc.Col(
+                                                            [
+                                                                html.Label(
+                                                                    COPY[
+                                                                        "analytics_backtest_confidence_label"
+                                                                    ],
+                                                                    style={
+                                                                        "color": COLORS[
+                                                                            "text_muted"
+                                                                        ],
+                                                                        "fontSize": "0.8rem",
+                                                                        "marginBottom": "4px",
+                                                                    },
+                                                                ),
+                                                                dcc.Slider(
+                                                                    id="backtest-confidence-slider",
+                                                                    min=0.5,
+                                                                    max=0.95,
+                                                                    step=0.05,
+                                                                    value=0.75,
+                                                                    marks={
+                                                                        0.5: "50%",
+                                                                        0.6: "60%",
+                                                                        0.7: "70%",
+                                                                        0.75: "75%",
+                                                                        0.8: "80%",
+                                                                        0.9: "90%",
+                                                                        0.95: "95%",
+                                                                    },
+                                                                    tooltip={
+                                                                        "placement": "bottom",
+                                                                        "always_visible": False,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            md=6,
+                                                            xs=12,
+                                                        ),
+                                                    ],
+                                                    className="g-3 align-items-end",
+                                                ),
+                                                # "Run Backtest" button instead of live slider updates
+                                                dbc.Button(
+                                                    "Run Backtest",
+                                                    id="backtest-run-btn",
+                                                    color="primary",
+                                                    size="sm",
+                                                    className="mt-2",
+                                                ),
+                                            ],
+                                            id="backtest-controls-container",
+                                            style={
+                                                "display": "none",
+                                                "marginBottom": "16px",
+                                            },
+                                        ),
+                                        # Chart container
+                                        dcc.Loading(
+                                            type="circle",
+                                            color=COLORS["accent"],
+                                            children=dcc.Graph(
+                                                id="analytics-chart",
+                                                config=CHART_CONFIG,
+                                            ),
+                                        ),
+                                        # Backtest summary stats (below chart, only on backtest tab)
+                                        html.Div(
+                                            id="backtest-summary-container",
+                                            style={"display": "none"},
+                                        ),
+                                    ],
+                                    style={
+                                        "backgroundColor": HIERARCHY["secondary"][
+                                            "background"
+                                        ],
+                                        "padding": "12px",
+                                    },
+                                ),
+                                id="collapse-analytics",
+                                is_open=False,
+                            ),
+                        ],
+                        className="mb-4",
+                        style={
+                            "backgroundColor": HIERARCHY["secondary"]["background"],
+                            "borderTop": HIERARCHY["secondary"]["accent_top"],
+                            "boxShadow": HIERARCHY["secondary"]["shadow"],
+                        },
+                    ),
                     # ========== Latest Posts (Tertiary tier) ==========
                     dbc.Card(
                         [
@@ -304,8 +497,10 @@ def register_dashboard_callbacks(app: Dash):
         register_period_callbacks,
         register_content_callbacks,
         register_table_callbacks,
+        register_analytics_callbacks,
     )
 
     register_period_callbacks(app)
     register_content_callbacks(app)
     register_table_callbacks(app)
+    register_analytics_callbacks(app)

--- a/shitty_ui/pages/dashboard_callbacks/__init__.py
+++ b/shitty_ui/pages/dashboard_callbacks/__init__.py
@@ -4,14 +4,17 @@ Each module registers a focused group of callbacks:
 - period: Time period selection and countdown
 - content: Main dashboard content (KPIs, screener, insights, post feed)
 - table: Data table management (collapse, filtering, row clicks, thesis expand)
+- analytics: Analytics charts (P&L, accuracy, calibration, backtest)
 """
 
 from pages.dashboard_callbacks.period import register_period_callbacks
 from pages.dashboard_callbacks.content import register_content_callbacks
 from pages.dashboard_callbacks.table import register_table_callbacks
+from pages.dashboard_callbacks.analytics import register_analytics_callbacks
 
 __all__ = [
     "register_period_callbacks",
     "register_content_callbacks",
     "register_table_callbacks",
+    "register_analytics_callbacks",
 ]

--- a/shitty_ui/pages/dashboard_callbacks/analytics.py
+++ b/shitty_ui/pages/dashboard_callbacks/analytics.py
@@ -1,0 +1,256 @@
+"""Analytics chart callbacks.
+
+Handles the analytics section: tab switching, chart rendering,
+backtest controls visibility, and backtest summary display.
+"""
+
+import traceback
+
+from dash import Dash, html, Input, Output, State
+import dash_bootstrap_components as dbc
+
+from constants import COLORS
+from brand_copy import COPY
+from components.charts import (
+    build_cumulative_pnl_chart,
+    build_rolling_accuracy_chart,
+    build_confidence_calibration_chart,
+    build_backtest_equity_chart,
+    build_empty_signal_chart,
+)
+from data import (
+    get_cumulative_pnl,
+    get_rolling_accuracy,
+    get_confidence_calibration,
+    get_backtest_simulation,
+    get_backtest_equity_curve,
+)
+
+
+def register_analytics_callbacks(app: Dash) -> None:
+    """Register analytics chart callbacks.
+
+    Args:
+        app: The Dash application instance.
+    """
+
+    # ========== Collapse toggle ==========
+    @app.callback(
+        Output("collapse-analytics", "is_open"),
+        [Input("collapse-analytics-button", "n_clicks")],
+        [State("collapse-analytics", "is_open")],
+    )
+    def toggle_analytics_collapse(n_clicks, is_open):
+        """Toggle the analytics section collapse."""
+        if n_clicks:
+            return not is_open
+        return is_open
+
+    # Chevron rotation (clientside)
+    app.clientside_callback(
+        """
+        function(isOpen) {
+            if (isOpen) {
+                return 'fas fa-chevron-right me-2 collapse-chevron rotated';
+            }
+            return 'fas fa-chevron-right me-2 collapse-chevron';
+        }
+        """,
+        Output("collapse-analytics-chevron", "className"),
+        [Input("collapse-analytics", "is_open")],
+    )
+
+    # ========== Show/hide backtest controls based on active tab ==========
+    @app.callback(
+        [
+            Output("backtest-controls-container", "style"),
+            Output("backtest-summary-container", "style"),
+        ],
+        [Input("analytics-tabs", "active_tab")],
+    )
+    def toggle_backtest_controls(active_tab):
+        """Show backtest controls only when backtest tab is active."""
+        if active_tab == "tab-backtest":
+            return (
+                {"display": "block", "marginBottom": "16px"},
+                {"display": "block"},
+            )
+        return (
+            {"display": "none"},
+            {"display": "none"},
+        )
+
+    # ========== Main chart rendering callback ==========
+    @app.callback(
+        [
+            Output("analytics-chart", "figure"),
+            Output("backtest-summary-container", "children"),
+        ],
+        [
+            Input("analytics-tabs", "active_tab"),
+            Input("selected-period", "data"),
+            Input("collapse-analytics", "is_open"),
+            Input("backtest-run-btn", "n_clicks"),
+        ],
+        [
+            State("backtest-capital-input", "value"),
+            State("backtest-confidence-slider", "value"),
+        ],
+    )
+    def update_analytics_chart(
+        active_tab, period, is_open, n_clicks, backtest_capital, backtest_confidence
+    ):
+        """Render the appropriate analytics chart based on active tab.
+
+        Only fetches data when the analytics section is open to avoid
+        unnecessary database queries.
+        """
+        # Don't fetch data if section is collapsed
+        if not is_open:
+            return build_empty_signal_chart("Expand to view analytics"), html.Div()
+
+        # Convert period to days
+        days_map = {"7d": 7, "30d": 30, "90d": 90, "all": None}
+        days = days_map.get(period, 90)
+
+        backtest_summary = html.Div()  # Default empty
+
+        try:
+            if active_tab == "tab-pnl":
+                df = get_cumulative_pnl(days=days)
+                if df.empty:
+                    fig = build_empty_signal_chart(COPY["analytics_empty_pnl"])
+                else:
+                    fig = build_cumulative_pnl_chart(df)
+
+            elif active_tab == "tab-rolling":
+                df = get_rolling_accuracy(window=30, days=days)
+                if df.empty:
+                    fig = build_empty_signal_chart(COPY["analytics_empty_rolling"])
+                else:
+                    fig = build_rolling_accuracy_chart(df)
+
+            elif active_tab == "tab-calibration":
+                df = get_confidence_calibration(buckets=10)
+                if df.empty:
+                    fig = build_empty_signal_chart(COPY["analytics_empty_calibration"])
+                else:
+                    fig = build_confidence_calibration_chart(df)
+
+            elif active_tab == "tab-backtest":
+                capital = float(backtest_capital or 10000)
+                confidence = float(backtest_confidence or 0.75)
+
+                df = get_backtest_equity_curve(
+                    initial_capital=capital,
+                    min_confidence=confidence,
+                    days=days,
+                )
+                if df.empty:
+                    fig = build_empty_signal_chart(COPY["analytics_empty_backtest"])
+                else:
+                    fig = build_backtest_equity_chart(df, initial_capital=capital)
+
+                # Also fetch the summary stats for the info panel
+                summary = get_backtest_simulation(
+                    initial_capital=capital,
+                    min_confidence=confidence,
+                    days=days if days is not None else 90,
+                )
+                backtest_summary = _build_backtest_summary(summary)
+
+            else:
+                fig = build_empty_signal_chart("Select a tab")
+
+        except Exception as e:
+            print(f"Error loading analytics chart: {traceback.format_exc()}")
+            fig = build_empty_signal_chart(f"Error loading chart: {str(e)[:60]}")
+
+        return fig, backtest_summary
+
+
+def _build_backtest_summary(summary: dict) -> html.Div:
+    """Build the backtest summary stats panel below the chart.
+
+    Args:
+        summary: Dict from get_backtest_simulation() with keys:
+            initial_capital, final_value, total_return_pct,
+            trade_count, wins, losses, win_rate.
+
+    Returns:
+        html.Div with a row of summary stats.
+    """
+    if summary["trade_count"] == 0:
+        return html.Div()
+
+    pnl = summary["final_value"] - summary["initial_capital"]
+    pnl_color = COLORS["success"] if pnl >= 0 else COLORS["danger"]
+
+    return dbc.Row(
+        [
+            _backtest_stat(
+                f"${summary['final_value']:,.0f}",
+                "Final Value",
+                pnl_color,
+            ),
+            _backtest_stat(
+                f"{summary['total_return_pct']:+.1f}%",
+                "Total Return",
+                pnl_color,
+            ),
+            _backtest_stat(
+                f"{summary['trade_count']}",
+                "Total Trades",
+                COLORS["accent"],
+            ),
+            _backtest_stat(
+                f"{summary['win_rate']:.1f}%",
+                f"Win Rate ({summary['wins']}W / {summary['losses']}L)",
+                COLORS["success"] if summary["win_rate"] > 50 else COLORS["danger"],
+            ),
+        ],
+        className="g-2 mt-2",
+    )
+
+
+def _backtest_stat(value: str, label: str, color: str) -> dbc.Col:
+    """Build a single backtest summary stat card.
+
+    Args:
+        value: Prominent display value.
+        label: Description below the value.
+        color: CSS color for the value.
+
+    Returns:
+        dbc.Col containing the stat card.
+    """
+    return dbc.Col(
+        html.Div(
+            [
+                html.Div(
+                    value,
+                    style={
+                        "fontSize": "1rem",
+                        "fontWeight": "bold",
+                        "color": color,
+                    },
+                ),
+                html.Div(
+                    label,
+                    style={
+                        "fontSize": "0.7rem",
+                        "color": COLORS["text_muted"],
+                    },
+                ),
+            ],
+            style={
+                "textAlign": "center",
+                "padding": "8px",
+                "backgroundColor": COLORS["bg"],
+                "borderRadius": "8px",
+                "border": f"1px solid {COLORS['border']}",
+            },
+        ),
+        xs=6,
+        md=3,
+    )

--- a/shitty_ui/pages/dashboard_callbacks/content.py
+++ b/shitty_ui/pages/dashboard_callbacks/content.py
@@ -77,9 +77,7 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Asset Screener Table =====
         try:
-            screener_df = get_asset_screener_data(
-                days=days, timeframe=timeframe
-            )
+            screener_df = get_asset_screener_data(days=days, timeframe=timeframe)
             sparkline_data = {}
             if not screener_df.empty:
                 symbols = tuple(screener_df["symbol"].tolist())
@@ -99,9 +97,7 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Performance Metrics with error handling =====
         try:
-            kpis = get_dashboard_kpis_with_fallback(
-                days=days, timeframe=timeframe
-            )
+            kpis = get_dashboard_kpis_with_fallback(days=days, timeframe=timeframe)
             fallback_note = kpis["fallback_label"] if kpis["is_fallback"] else ""
             tf_label = kpis.get("timeframe_label", tf["label_long"])
 


### PR DESCRIPTION
## Summary
- Add collapsible "Show Me The Money" analytics section to the main dashboard with four tabbed chart views: cumulative P&L equity curve, rolling 30-day accuracy trend, confidence calibration grouped bar chart, and interactive backtest simulator
- New `backtest_queries.py` provides time-series equity curve data for the backtest chart (supplements existing summary-only `get_backtest_simulation()`)
- Backtest simulator uses a "Run Backtest" button with configurable starting capital ($1K-$1M) and minimum confidence threshold (50%-95%), respecting the global Time Period selector
- 29 new tests covering all four chart builders with empty data, colors, traces, reference lines, and axis formatting

## Test plan
- [x] `pytest shit_tests/shitty_ui/test_analytics_charts.py -v` -- 29/29 pass
- [x] `pytest shit_tests/shitty_ui/test_charts.py -v` -- 50/50 pass (existing unchanged)
- [x] `pytest shit_tests/shitty_ui/test_data_init.py -v` -- 7/7 pass (exports verified)
- [x] `pytest shit_tests/shitty_ui/ -v` -- 887/890 pass (3 pre-existing telegram failures)
- [x] `ruff check shitty_ui/` -- no new lint errors
- [x] `ruff format --check shitty_ui/` -- formatting clean
- [ ] Manual: Dashboard loads, analytics section collapses/expands, all four tabs render

Generated with [Claude Code](https://claude.com/claude-code)