### PR TITLE
feat: add company fundamentals fetching, storage, and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Company Fundamentals & Asset Profiles** — Automatic yfinance-powered company data population for all tracked tickers
+  - New `FundamentalsProvider` service fetches sector, industry, market cap, P/E, beta, dividend yield, and description from yfinance
+  - 10 new columns on `ticker_registry`: `company_name`, `sector`, `industry`, `market_cap`, `pe_ratio`, `forward_pe`, `dividend_yield`, `beta`, `description`, `fundamentals_updated_at`
+  - Fundamentals auto-populate on ticker registration (best-effort, non-blocking)
+  - Staleness-based caching: re-fetches if data is older than 24 hours
+  - Asset detail page now shows company subtitle, sector badge, and full profile card with key metrics
+  - Screener table gains a Sector column with 4-char abbreviated sector badges
+  - 35 new tests covering FundamentalsProvider, ticker registry hook, sector badges, and screener integration
+
 - **Multi-timeframe dashboard** — New "Outcome Window" toggle (T+1, T+3, T+7, T+30) on the dashboard lets users view KPIs, screener, and insights across any prediction timeframe instead of only T+7
 - **Timeframe column mapping module** — `data/timeframe.py` provides `get_tf_columns()`, `TIMEFRAME_OPTIONS`, `VALID_TIMEFRAMES`, and `DEFAULT_TIMEFRAME` as single source of truth for timeframe→column mapping
 - 12 new tests for timeframe module (`test_timeframe.py`)

--- a/shit/market_data/__init__.py
+++ b/shit/market_data/__init__.py
@@ -1,14 +1,20 @@
 """
 Market Data Module
-Fetches stock prices and calculates prediction outcomes.
+Fetches stock prices, company fundamentals, and calculates prediction outcomes.
 """
 
 from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
 from shit.market_data.client import MarketDataClient
 from shit.market_data.outcome_calculator import OutcomeCalculator
-from shit.market_data.price_provider import PriceProvider, ProviderChain, RawPriceRecord, ProviderError
+from shit.market_data.price_provider import (
+    PriceProvider,
+    ProviderChain,
+    RawPriceRecord,
+    ProviderError,
+)
 from shit.market_data.yfinance_provider import YFinanceProvider
 from shit.market_data.alphavantage_provider import AlphaVantageProvider
+from shit.market_data.fundamentals_provider import FundamentalsProvider
 from shit.market_data.health import run_health_check, HealthReport
 
 __all__ = [
@@ -23,6 +29,7 @@ __all__ = [
     "ProviderError",
     "YFinanceProvider",
     "AlphaVantageProvider",
+    "FundamentalsProvider",
     "run_health_check",
     "HealthReport",
 ]

--- a/shit/market_data/fundamentals_provider.py
+++ b/shit/market_data/fundamentals_provider.py
@@ -1,0 +1,273 @@
+"""
+Fundamentals Provider
+Fetches company fundamental data from yfinance and stores it in the TickerRegistry.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Any
+
+import yfinance as yf
+
+from shit.market_data.models import TickerRegistry
+from shit.db.sync_session import get_session
+from shit.logging import get_service_logger
+
+logger = get_service_logger("fundamentals_provider")
+
+# Mapping from yfinance .info keys to TickerRegistry column names
+_INFO_FIELD_MAP: Dict[str, str] = {
+    "longName": "company_name",
+    "shortName": "company_name",  # fallback if longName missing
+    "sector": "sector",
+    "industry": "industry",
+    "marketCap": "market_cap",
+    "trailingPE": "pe_ratio",
+    "forwardPE": "forward_pe",
+    "dividendYield": "dividend_yield",
+    "beta": "beta",
+    "exchange": "exchange",
+    "quoteType": "asset_type",
+    "longBusinessSummary": "description",
+    "shortBusinessSummary": "description",  # fallback
+}
+
+# yfinance quoteType -> our asset_type mapping
+_QUOTE_TYPE_MAP: Dict[str, str] = {
+    "EQUITY": "stock",
+    "ETF": "etf",
+    "MUTUALFUND": "etf",
+    "CRYPTOCURRENCY": "crypto",
+    "CURRENCY": "crypto",
+    "FUTURE": "commodity",
+    "INDEX": "index",
+}
+
+# Maximum description length to store (avoid bloating the DB)
+_MAX_DESCRIPTION_LENGTH = 500
+
+# Default staleness threshold: re-fetch if older than this
+DEFAULT_STALENESS_HOURS = 24
+
+
+class FundamentalsProvider:
+    """Fetches and stores company fundamental data from yfinance.
+
+    Usage:
+        provider = FundamentalsProvider()
+        provider.update_fundamentals("AAPL")  # Single ticker
+        provider.update_all_fundamentals()      # All active tickers
+    """
+
+    def __init__(self, staleness_hours: int = DEFAULT_STALENESS_HOURS):
+        """Initialize the provider.
+
+        Args:
+            staleness_hours: Hours after which fundamentals are considered stale
+                and should be re-fetched. Default 24 hours.
+        """
+        self.staleness_hours = staleness_hours
+
+    def fetch_info(self, symbol: str) -> Dict[str, Any]:
+        """Fetch raw .info dict from yfinance for a single symbol.
+
+        Args:
+            symbol: Ticker symbol (e.g. "AAPL", "BTC-USD").
+
+        Returns:
+            Dict of yfinance info fields. Empty dict on failure.
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info
+            if not info or info.get("regularMarketPrice") is None:
+                # yfinance returns a dict with trailingPegRatio=None for invalid tickers
+                # Check for a reliable sentinel field
+                if not info.get("shortName") and not info.get("longName"):
+                    logger.warning(
+                        f"yfinance returned no usable info for {symbol}",
+                        extra={"symbol": symbol},
+                    )
+                    return {}
+            return info or {}
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch info for {symbol}: {e}",
+                extra={"symbol": symbol, "error": str(e)},
+            )
+            return {}
+
+    def _extract_fundamentals(self, info: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract and normalize fundamental fields from yfinance info dict.
+
+        Args:
+            info: Raw yfinance .info dict.
+
+        Returns:
+            Dict with TickerRegistry column names as keys.
+        """
+        result: Dict[str, Any] = {}
+
+        # Company name: prefer longName, fall back to shortName
+        result["company_name"] = info.get("longName") or info.get("shortName")
+
+        # Sector & Industry (only for equities; ETFs/crypto won't have these)
+        result["sector"] = info.get("sector")
+        result["industry"] = info.get("industry")
+
+        # Market cap
+        market_cap = info.get("marketCap")
+        if market_cap is not None:
+            try:
+                result["market_cap"] = int(market_cap)
+            except (ValueError, TypeError):
+                result["market_cap"] = None
+        else:
+            result["market_cap"] = None
+
+        # P/E ratios
+        pe = info.get("trailingPE")
+        result["pe_ratio"] = float(pe) if pe is not None else None
+
+        fpe = info.get("forwardPE")
+        result["forward_pe"] = float(fpe) if fpe is not None else None
+
+        # Dividend yield
+        div_yield = info.get("dividendYield")
+        result["dividend_yield"] = float(div_yield) if div_yield is not None else None
+
+        # Beta
+        beta = info.get("beta")
+        result["beta"] = float(beta) if beta is not None else None
+
+        # Exchange
+        result["exchange"] = info.get("exchange")
+
+        # Asset type from quoteType
+        quote_type = info.get("quoteType", "")
+        result["asset_type"] = _QUOTE_TYPE_MAP.get(quote_type, "stock")
+
+        # Description: truncate to avoid DB bloat
+        desc = info.get("longBusinessSummary") or info.get("shortBusinessSummary")
+        if desc and len(desc) > _MAX_DESCRIPTION_LENGTH:
+            desc = desc[: _MAX_DESCRIPTION_LENGTH - 3] + "..."
+        result["description"] = desc
+
+        return result
+
+    def _is_stale(self, entry: TickerRegistry) -> bool:
+        """Check whether a ticker's fundamentals need refreshing.
+
+        Args:
+            entry: TickerRegistry row.
+
+        Returns:
+            True if fundamentals_updated_at is None or older than staleness_hours.
+        """
+        if entry.fundamentals_updated_at is None:
+            return True
+        age = datetime.now(tz=timezone.utc) - entry.fundamentals_updated_at.replace(
+            tzinfo=timezone.utc
+        )
+        return age > timedelta(hours=self.staleness_hours)
+
+    def update_fundamentals(self, symbol: str, force: bool = False) -> bool:
+        """Fetch and store fundamentals for a single ticker.
+
+        Skips the fetch if data is fresh (< staleness_hours old) unless force=True.
+
+        Args:
+            symbol: Ticker symbol.
+            force: If True, fetch even if data is fresh.
+
+        Returns:
+            True if fundamentals were updated, False if skipped or failed.
+        """
+        symbol = symbol.strip().upper()
+
+        with get_session() as session:
+            entry = (
+                session.query(TickerRegistry)
+                .filter(TickerRegistry.symbol == symbol)
+                .first()
+            )
+
+            if not entry:
+                logger.warning(
+                    f"Ticker {symbol} not in registry, cannot update fundamentals",
+                    extra={"symbol": symbol},
+                )
+                return False
+
+            # Skip if fresh
+            if not force and not self._is_stale(entry):
+                logger.debug(
+                    f"Fundamentals for {symbol} are fresh, skipping",
+                    extra={"symbol": symbol},
+                )
+                return False
+
+            # Fetch from yfinance
+            info = self.fetch_info(symbol)
+            if not info:
+                logger.warning(
+                    f"No info returned for {symbol}, skipping update",
+                    extra={"symbol": symbol},
+                )
+                return False
+
+            # Extract and apply
+            fundamentals = self._extract_fundamentals(info)
+            for column, value in fundamentals.items():
+                if value is not None:
+                    setattr(entry, column, value)
+
+            entry.fundamentals_updated_at = datetime.now(tz=timezone.utc)
+            session.commit()
+
+            logger.info(
+                f"Updated fundamentals for {symbol}",
+                extra={
+                    "symbol": symbol,
+                    "company_name": fundamentals.get("company_name"),
+                    "sector": fundamentals.get("sector"),
+                },
+            )
+            return True
+
+    def update_all_fundamentals(
+        self, force: bool = False, status: str = "active"
+    ) -> Dict[str, Any]:
+        """Batch-update fundamentals for all registered tickers.
+
+        Args:
+            force: If True, re-fetch even fresh data.
+            status: Only update tickers with this status. Default "active".
+
+        Returns:
+            Stats dict with keys: total, updated, skipped, failed.
+        """
+        with get_session() as session:
+            query = session.query(TickerRegistry)
+            if status:
+                query = query.filter(TickerRegistry.status == status)
+            tickers = query.all()
+            symbols = [t.symbol for t in tickers]
+
+        stats = {"total": len(symbols), "updated": 0, "skipped": 0, "failed": 0}
+
+        for symbol in symbols:
+            try:
+                updated = self.update_fundamentals(symbol, force=force)
+                if updated:
+                    stats["updated"] += 1
+                else:
+                    stats["skipped"] += 1
+            except Exception as e:
+                logger.error(
+                    f"Failed to update fundamentals for {symbol}: {e}",
+                    extra={"symbol": symbol, "error": str(e)},
+                )
+                stats["failed"] += 1
+
+        logger.info("Batch fundamentals update complete", extra=stats)
+        return stats

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -5,7 +5,18 @@ SQLAlchemy models for tracking stock prices and prediction outcomes.
 
 from datetime import datetime, date
 from typing import Optional
-from sqlalchemy import Column, String, Date, DateTime, Float, BigInteger, ForeignKey, Integer, Boolean, Text
+from sqlalchemy import (
+    Column,
+    String,
+    Date,
+    DateTime,
+    Float,
+    BigInteger,
+    ForeignKey,
+    Integer,
+    Boolean,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from shit.db.data_models import Base, TimestampMixin, IDMixin
@@ -17,7 +28,9 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
     __tablename__ = "market_prices"
 
     # Asset identification
-    symbol = Column(String(20), nullable=False, index=True)  # Ticker symbol (AAPL, TSLA, BTC-USD, etc.)
+    symbol = Column(
+        String(20), nullable=False, index=True
+    )  # Ticker symbol (AAPL, TSLA, BTC-USD, etc.)
     date = Column(Date, nullable=False, index=True)  # Trading date
 
     # OHLCV data (Open, High, Low, Close, Volume)
@@ -32,7 +45,9 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
 
     # Data source tracking
     source = Column(String(50), default="yfinance")  # yfinance, alpha_vantage, etc.
-    last_updated = Column(DateTime, default=datetime.utcnow)  # When this data was fetched
+    last_updated = Column(
+        DateTime, default=datetime.utcnow
+    )  # When this data was fetched
 
     # Metadata
     is_market_open = Column(Boolean, default=True)  # Was market open this day?
@@ -43,9 +58,7 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
         return f"<MarketPrice(symbol='{self.symbol}', date={self.date}, close=${self.close})>"
 
     # Unique constraint on symbol + date (one price record per symbol per day)
-    __table_args__ = (
-        {'sqlite_autoincrement': True},
-    )
+    __table_args__ = ({"sqlite_autoincrement": True},)
 
 
 class PredictionOutcome(Base, IDMixin, TimestampMixin):
@@ -54,14 +67,20 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     __tablename__ = "prediction_outcomes"
 
     # Link to prediction
-    prediction_id = Column(Integer, ForeignKey("predictions.id"), nullable=False, index=True)
+    prediction_id = Column(
+        Integer, ForeignKey("predictions.id"), nullable=False, index=True
+    )
 
     # Asset being tracked
     symbol = Column(String(20), nullable=False, index=True)  # Ticker symbol
 
     # Prediction details (denormalized for easier querying)
-    prediction_date = Column(Date, nullable=False, index=True)  # When prediction was made
-    prediction_sentiment = Column(String(20), nullable=True)  # bullish, bearish, neutral
+    prediction_date = Column(
+        Date, nullable=False, index=True
+    )  # When prediction was made
+    prediction_sentiment = Column(
+        String(20), nullable=True
+    )  # bullish, bearish, neutral
     prediction_confidence = Column(Float, nullable=True)  # 0.0-1.0
     prediction_timeframe_days = Column(Integer, nullable=True)  # Expected timeframe
 
@@ -107,19 +126,25 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     def __repr__(self):
         return f"<PredictionOutcome(symbol='{self.symbol}', sentiment='{self.prediction_sentiment}', return_t7={self.return_t7}%)>"
 
-    def calculate_return(self, price_initial: float, price_final: Optional[float]) -> Optional[float]:
+    def calculate_return(
+        self, price_initial: float, price_final: Optional[float]
+    ) -> Optional[float]:
         """Calculate percentage return between two prices."""
         if price_initial is None or price_final is None or price_initial == 0:
             return None
         return ((price_final - price_initial) / price_initial) * 100
 
-    def calculate_pnl(self, return_pct: Optional[float], position_size: float = 1000.0) -> Optional[float]:
+    def calculate_pnl(
+        self, return_pct: Optional[float], position_size: float = 1000.0
+    ) -> Optional[float]:
         """Calculate P&L for a given return percentage and position size."""
         if return_pct is None:
             return None
         return (return_pct / 100) * position_size
 
-    def is_correct(self, sentiment: str, return_pct: Optional[float], threshold: float = 0.5) -> Optional[bool]:
+    def is_correct(
+        self, sentiment: str, return_pct: Optional[float], threshold: float = 0.5
+    ) -> Optional[bool]:
         """
         Determine if prediction was correct based on sentiment and actual return.
 
@@ -136,11 +161,11 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
 
         sentiment = sentiment.lower()
 
-        if sentiment == 'bullish':
+        if sentiment == "bullish":
             return return_pct > threshold
-        elif sentiment == 'bearish':
+        elif sentiment == "bearish":
             return return_pct < -threshold
-        elif sentiment == 'neutral':
+        elif sentiment == "neutral":
             return abs(return_pct) <= threshold
         else:
             return None
@@ -155,6 +180,7 @@ class TickerRegistry(Base, IDMixin, TimestampMixin):
     - Status tracking (active, inactive, invalid)
     - Audit trail of when each ticker was first seen
     - Source prediction linkage for debugging
+    - Company fundamental data from yfinance
     """
 
     __tablename__ = "ticker_registry"
@@ -176,20 +202,42 @@ class TickerRegistry(Base, IDMixin, TimestampMixin):
     price_data_end = Column(Date, nullable=True)
     total_price_records = Column(Integer, default=0)
 
-    # Metadata
-    asset_type = Column(String(20), nullable=True)  # stock, crypto, etf, commodity, index
+    # Metadata (existing)
+    asset_type = Column(
+        String(20), nullable=True
+    )  # stock, crypto, etf, commodity, index
     exchange = Column(String(20), nullable=True)  # NYSE, NASDAQ, etc.
 
+    # Company fundamentals (populated by FundamentalsProvider)
+    company_name = Column(String(255), nullable=True)  # e.g. "Apple Inc."
+    sector = Column(String(100), nullable=True)  # e.g. "Technology"
+    industry = Column(String(100), nullable=True)  # e.g. "Consumer Electronics"
+    market_cap = Column(BigInteger, nullable=True)  # Market capitalization in USD
+    pe_ratio = Column(Float, nullable=True)  # Trailing P/E ratio
+    forward_pe = Column(Float, nullable=True)  # Forward P/E ratio
+    dividend_yield = Column(Float, nullable=True)  # Dividend yield (0.0-1.0)
+    beta = Column(Float, nullable=True)  # Beta coefficient
+    description = Column(Text, nullable=True)  # Short business summary
+    fundamentals_updated_at = Column(
+        DateTime, nullable=True
+    )  # Last fundamentals refresh
+
     def __repr__(self):
-        return f"<TickerRegistry(symbol='{self.symbol}', status='{self.status}', first_seen={self.first_seen_date})>"
+        name_part = f" ({self.company_name})" if self.company_name else ""
+        return f"<TickerRegistry(symbol='{self.symbol}'{name_part}, status='{self.status}')>"
 
 
 # Indexes for efficient querying
 from sqlalchemy import Index
 
 # Create composite indexes for common queries
-Index('idx_market_price_symbol_date', MarketPrice.symbol, MarketPrice.date, unique=True)
-Index('idx_prediction_outcome_symbol_date', PredictionOutcome.symbol, PredictionOutcome.prediction_date)
-Index('idx_prediction_outcome_prediction_id', PredictionOutcome.prediction_id)
-Index('idx_ticker_registry_symbol', TickerRegistry.symbol, unique=True)
-Index('idx_ticker_registry_status', TickerRegistry.status)
+Index("idx_market_price_symbol_date", MarketPrice.symbol, MarketPrice.date, unique=True)
+Index(
+    "idx_prediction_outcome_symbol_date",
+    PredictionOutcome.symbol,
+    PredictionOutcome.prediction_date,
+)
+Index("idx_prediction_outcome_prediction_id", PredictionOutcome.prediction_id)
+Index("idx_ticker_registry_symbol", TickerRegistry.symbol, unique=True)
+Index("idx_ticker_registry_status", TickerRegistry.status)
+Index("idx_ticker_registry_sector", TickerRegistry.sector)

--- a/shit/market_data/ticker_registry.py
+++ b/shit/market_data/ticker_registry.py
@@ -62,7 +62,9 @@ class TickerRegistryService:
 
                 if existing:
                     already_known.append(symbol)
-                    logger.debug(f"Ticker {symbol} already registered (status={existing.status})")
+                    logger.debug(
+                        f"Ticker {symbol} already registered (status={existing.status})"
+                    )
                     continue
 
                 # Register new ticker
@@ -78,14 +80,36 @@ class TickerRegistryService:
                 newly_registered.append(symbol)
                 logger.info(
                     f"Registered new ticker: {symbol}",
-                    extra={"symbol": symbol, "source_prediction_id": source_prediction_id},
+                    extra={
+                        "symbol": symbol,
+                        "source_prediction_id": source_prediction_id,
+                    },
                 )
 
             try:
                 session.commit()
             except IntegrityError:
                 session.rollback()
-                logger.info("IntegrityError during ticker registration, handling concurrent insert")
+                logger.info(
+                    "IntegrityError during ticker registration, handling concurrent insert"
+                )
+
+        # Populate fundamentals for newly registered tickers (best-effort, non-blocking)
+        if newly_registered:
+            try:
+                from shit.market_data.fundamentals_provider import FundamentalsProvider
+
+                provider = FundamentalsProvider()
+                for symbol in newly_registered:
+                    try:
+                        provider.update_fundamentals(symbol, force=True)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to fetch fundamentals for new ticker {symbol}: {e}",
+                            extra={"symbol": symbol},
+                        )
+            except Exception as e:
+                logger.warning(f"Failed to initialize FundamentalsProvider: {e}")
 
         return (newly_registered, already_known)
 

--- a/shit_tests/shit/market_data/test_fundamentals_provider.py
+++ b/shit_tests/shit/market_data/test_fundamentals_provider.py
@@ -1,0 +1,477 @@
+"""Tests for FundamentalsProvider.
+
+Tests cover fetching, extraction, staleness checking, single-ticker updates,
+and batch updates. All tests mock get_session and yf.Ticker to avoid real
+API calls and database dependencies.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from shit.market_data.fundamentals_provider import (
+    FundamentalsProvider,
+    _QUOTE_TYPE_MAP,
+    _MAX_DESCRIPTION_LENGTH,
+)
+from shit.market_data.models import TickerRegistry
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+def _make_registry_entry(**overrides) -> MagicMock:
+    """Create a mock TickerRegistry row."""
+    entry = MagicMock(spec=TickerRegistry)
+    entry.symbol = overrides.get("symbol", "AAPL")
+    entry.status = overrides.get("status", "active")
+    entry.fundamentals_updated_at = overrides.get("fundamentals_updated_at", None)
+    entry.company_name = overrides.get("company_name", None)
+    entry.sector = overrides.get("sector", None)
+    entry.industry = overrides.get("industry", None)
+    entry.market_cap = overrides.get("market_cap", None)
+    entry.pe_ratio = overrides.get("pe_ratio", None)
+    entry.forward_pe = overrides.get("forward_pe", None)
+    entry.dividend_yield = overrides.get("dividend_yield", None)
+    entry.beta = overrides.get("beta", None)
+    entry.exchange = overrides.get("exchange", None)
+    entry.asset_type = overrides.get("asset_type", None)
+    entry.description = overrides.get("description", None)
+    return entry
+
+
+def _sample_info() -> dict:
+    """Return a sample yfinance .info dict for AAPL."""
+    return {
+        "longName": "Apple Inc.",
+        "shortName": "Apple",
+        "sector": "Technology",
+        "industry": "Consumer Electronics",
+        "marketCap": 3500000000000,
+        "trailingPE": 28.5,
+        "forwardPE": 25.2,
+        "dividendYield": 0.005,
+        "beta": 1.25,
+        "exchange": "NMS",
+        "quoteType": "EQUITY",
+        "longBusinessSummary": "Apple designs, manufactures, and markets smartphones.",
+        "regularMarketPrice": 175.50,
+    }
+
+
+# ── TestFetchInfo ────────────────────────────────────────────────────
+
+
+class TestFetchInfo:
+    """Tests for FundamentalsProvider.fetch_info()."""
+
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_returns_info_dict_for_valid_symbol(self, mock_ticker_cls):
+        """Valid symbol returns populated info dict."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = _sample_info()
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        result = provider.fetch_info("AAPL")
+
+        assert result["longName"] == "Apple Inc."
+        assert result["sector"] == "Technology"
+        mock_ticker_cls.assert_called_once_with("AAPL")
+
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_returns_empty_dict_for_invalid_symbol(self, mock_ticker_cls):
+        """Invalid symbol (no shortName/longName) returns empty dict."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"trailingPegRatio": None, "regularMarketPrice": None}
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        result = provider.fetch_info("INVALID123")
+
+        assert result == {}
+
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_returns_empty_dict_on_exception(self, mock_ticker_cls):
+        """Exception during fetch returns empty dict."""
+        mock_ticker_cls.side_effect = Exception("Network error")
+
+        provider = FundamentalsProvider()
+        result = provider.fetch_info("AAPL")
+
+        assert result == {}
+
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_logs_warning_for_invalid_symbol(self, mock_ticker_cls):
+        """Invalid symbol logs a warning."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"regularMarketPrice": None}
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        with patch("shit.market_data.fundamentals_provider.logger") as mock_logger:
+            provider.fetch_info("INVALID")
+            mock_logger.warning.assert_called_once()
+
+
+# ── TestExtractFundamentals ──────────────────────────────────────────
+
+
+class TestExtractFundamentals:
+    """Tests for FundamentalsProvider._extract_fundamentals()."""
+
+    def test_extracts_all_fields_from_complete_info(self):
+        """Complete info dict populates all fields."""
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(_sample_info())
+
+        assert result["company_name"] == "Apple Inc."
+        assert result["sector"] == "Technology"
+        assert result["industry"] == "Consumer Electronics"
+        assert result["market_cap"] == 3500000000000
+        assert result["pe_ratio"] == 28.5
+        assert result["forward_pe"] == 25.2
+        assert result["dividend_yield"] == 0.005
+        assert result["beta"] == 1.25
+        assert result["exchange"] == "NMS"
+        assert result["asset_type"] == "stock"
+        assert result["description"] is not None
+
+    def test_handles_missing_sector_for_etf(self):
+        """ETF without sector returns None for sector/industry."""
+        info = {
+            "shortName": "SPDR S&P 500 ETF Trust",
+            "quoteType": "ETF",
+            "regularMarketPrice": 450.0,
+        }
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert result["company_name"] == "SPDR S&P 500 ETF Trust"
+        assert result["sector"] is None
+        assert result["industry"] is None
+        assert result["asset_type"] == "etf"
+
+    def test_handles_missing_pe_for_commodity(self):
+        """Commodity without P/E ratios returns None."""
+        info = {
+            "shortName": "Gold Futures",
+            "quoteType": "FUTURE",
+            "regularMarketPrice": 2000.0,
+        }
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert result["pe_ratio"] is None
+        assert result["forward_pe"] is None
+        assert result["asset_type"] == "commodity"
+
+    def test_truncates_long_description(self):
+        """Description longer than _MAX_DESCRIPTION_LENGTH is truncated."""
+        long_desc = "A" * 1000
+        info = {
+            "longBusinessSummary": long_desc,
+            "shortName": "Test Corp",
+            "quoteType": "EQUITY",
+        }
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert len(result["description"]) == _MAX_DESCRIPTION_LENGTH
+        assert result["description"].endswith("...")
+
+    def test_maps_quote_type_to_asset_type(self):
+        """All known quoteType values map correctly."""
+        provider = FundamentalsProvider()
+        for yf_type, expected in _QUOTE_TYPE_MAP.items():
+            info = {"quoteType": yf_type, "shortName": "Test"}
+            result = provider._extract_fundamentals(info)
+            assert result["asset_type"] == expected
+
+    def test_prefers_longName_over_shortName(self):
+        """When both longName and shortName exist, longName is used."""
+        info = {
+            "longName": "Apple Inc.",
+            "shortName": "Apple",
+            "quoteType": "EQUITY",
+        }
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert result["company_name"] == "Apple Inc."
+
+    def test_handles_none_market_cap(self):
+        """None market cap is handled gracefully."""
+        info = {"shortName": "Test", "quoteType": "EQUITY"}
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert result["market_cap"] is None
+
+    def test_handles_non_numeric_market_cap(self):
+        """Non-numeric market cap is handled gracefully."""
+        info = {"shortName": "Test", "quoteType": "EQUITY", "marketCap": "invalid"}
+        provider = FundamentalsProvider()
+        result = provider._extract_fundamentals(info)
+
+        assert result["market_cap"] is None
+
+
+# ── TestIsStale ──────────────────────────────────────────────────────
+
+
+class TestIsStale:
+    """Tests for FundamentalsProvider._is_stale()."""
+
+    def test_returns_true_when_never_updated(self):
+        """Entry with no fundamentals_updated_at is stale."""
+        provider = FundamentalsProvider(staleness_hours=24)
+        entry = _make_registry_entry(fundamentals_updated_at=None)
+
+        assert provider._is_stale(entry) is True
+
+    def test_returns_true_when_older_than_threshold(self):
+        """Entry older than staleness threshold is stale."""
+        provider = FundamentalsProvider(staleness_hours=24)
+        old_time = datetime.now(tz=timezone.utc) - timedelta(hours=25)
+        entry = _make_registry_entry(fundamentals_updated_at=old_time)
+
+        assert provider._is_stale(entry) is True
+
+    def test_returns_false_when_fresh(self):
+        """Entry within staleness threshold is not stale."""
+        provider = FundamentalsProvider(staleness_hours=24)
+        recent_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        entry = _make_registry_entry(fundamentals_updated_at=recent_time)
+
+        assert provider._is_stale(entry) is False
+
+
+# ── TestUpdateFundamentals ───────────────────────────────────────────
+
+
+class TestUpdateFundamentals:
+    """Tests for FundamentalsProvider.update_fundamentals()."""
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_updates_single_ticker_successfully(
+        self, mock_ticker_cls, mock_get_session
+    ):
+        """Successful update returns True and sets attributes."""
+        entry = _make_registry_entry(fundamentals_updated_at=None)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = entry
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = _sample_info()
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        result = provider.update_fundamentals("AAPL", force=True)
+
+        assert result is True
+        mock_session.commit.assert_called_once()
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    def test_skips_fresh_ticker_without_force(self, mock_get_session):
+        """Fresh ticker without force=True returns False."""
+        recent_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        entry = _make_registry_entry(fundamentals_updated_at=recent_time)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = entry
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        provider = FundamentalsProvider(staleness_hours=24)
+        result = provider.update_fundamentals("AAPL", force=False)
+
+        assert result is False
+        mock_session.commit.assert_not_called()
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_updates_fresh_ticker_with_force(self, mock_ticker_cls, mock_get_session):
+        """Fresh ticker with force=True still updates."""
+        recent_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        entry = _make_registry_entry(fundamentals_updated_at=recent_time)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = entry
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = _sample_info()
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        result = provider.update_fundamentals("AAPL", force=True)
+
+        assert result is True
+        mock_session.commit.assert_called_once()
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    def test_returns_false_for_unregistered_ticker(self, mock_get_session):
+        """Ticker not in registry returns False."""
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        provider = FundamentalsProvider()
+        result = provider.update_fundamentals("UNKNOWN")
+
+        assert result is False
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_returns_false_when_no_info_returned(
+        self, mock_ticker_cls, mock_get_session
+    ):
+        """Empty info from yfinance returns False."""
+        entry = _make_registry_entry(fundamentals_updated_at=None)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = entry
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        result = provider.update_fundamentals("BADTICKER", force=True)
+
+        assert result is False
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch("shit.market_data.fundamentals_provider.yf.Ticker")
+    def test_sets_fundamentals_updated_at(self, mock_ticker_cls, mock_get_session):
+        """Successful update sets fundamentals_updated_at to now."""
+        entry = _make_registry_entry(fundamentals_updated_at=None)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = entry
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = _sample_info()
+        mock_ticker_cls.return_value = mock_ticker
+
+        provider = FundamentalsProvider()
+        before = datetime.now(tz=timezone.utc)
+        provider.update_fundamentals("AAPL", force=True)
+
+        # Check that fundamentals_updated_at was set to roughly now
+        assert entry.fundamentals_updated_at is not None
+        assert entry.fundamentals_updated_at >= before
+
+
+# ── TestUpdateAllFundamentals ────────────────────────────────────────
+
+
+class TestUpdateAllFundamentals:
+    """Tests for FundamentalsProvider.update_all_fundamentals()."""
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch.object(FundamentalsProvider, "update_fundamentals")
+    def test_processes_all_active_tickers(self, mock_update, mock_get_session):
+        """Batch mode calls update_fundamentals for each active ticker."""
+        tickers = [
+            _make_registry_entry(symbol="AAPL"),
+            _make_registry_entry(symbol="TSLA"),
+            _make_registry_entry(symbol="GOOG"),
+        ]
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = tickers
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_update.return_value = True
+
+        provider = FundamentalsProvider()
+        stats = provider.update_all_fundamentals()
+
+        assert stats["total"] == 3
+        assert stats["updated"] == 3
+        assert mock_update.call_count == 3
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch.object(FundamentalsProvider, "update_fundamentals")
+    def test_respects_status_filter(self, mock_update, mock_get_session):
+        """Batch mode filters by status."""
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        provider = FundamentalsProvider()
+        stats = provider.update_all_fundamentals(status="inactive")
+
+        assert stats["total"] == 0
+        # Verify filter was called (the query chain was invoked)
+        mock_session.query.return_value.filter.assert_called_once()
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch.object(FundamentalsProvider, "update_fundamentals")
+    def test_counts_updated_skipped_failed(self, mock_update, mock_get_session):
+        """Stats correctly count updated, skipped, and failed tickers."""
+        tickers = [
+            _make_registry_entry(symbol="AAPL"),
+            _make_registry_entry(symbol="TSLA"),
+            _make_registry_entry(symbol="BAD"),
+        ]
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = tickers
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # AAPL updated, TSLA skipped, BAD fails
+        mock_update.side_effect = [True, False, Exception("Network error")]
+
+        provider = FundamentalsProvider()
+        stats = provider.update_all_fundamentals()
+
+        assert stats["total"] == 3
+        assert stats["updated"] == 1
+        assert stats["skipped"] == 1
+        assert stats["failed"] == 1
+
+    @patch("shit.market_data.fundamentals_provider.get_session")
+    @patch.object(FundamentalsProvider, "update_fundamentals")
+    def test_continues_on_individual_failures(self, mock_update, mock_get_session):
+        """Batch mode continues processing after individual failures."""
+        tickers = [
+            _make_registry_entry(symbol="FAIL1"),
+            _make_registry_entry(symbol="PASS"),
+            _make_registry_entry(symbol="FAIL2"),
+        ]
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = tickers
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_update.side_effect = [
+            Exception("Error 1"),
+            True,
+            Exception("Error 2"),
+        ]
+
+        provider = FundamentalsProvider()
+        stats = provider.update_all_fundamentals()
+
+        # All three were attempted despite failures
+        assert mock_update.call_count == 3
+        assert stats["updated"] == 1
+        assert stats["failed"] == 2

--- a/shit_tests/shit/market_data/test_ticker_registry.py
+++ b/shit_tests/shit/market_data/test_ticker_registry.py
@@ -59,7 +59,10 @@ class TestRegisterTickers:
         ctx, session = _mock_session()
         existing = MagicMock(status="active")
         # First call returns None (new), second returns existing
-        session.query.return_value.filter.return_value.first.side_effect = [None, existing]
+        session.query.return_value.filter.return_value.first.side_effect = [
+            None,
+            existing,
+        ]
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -299,9 +302,17 @@ class TestUpdatePriceMetadata:
         query_mock = MagicMock()
         session.query.side_effect = [
             # First query chain: TickerRegistry lookup
-            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=entry)))),
+            MagicMock(
+                filter=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=entry))
+                )
+            ),
             # Second query chain: stats lookup
-            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=stats_result)))),
+            MagicMock(
+                filter=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=stats_result))
+                )
+            ),
         ]
 
         with patch(SESSION_PATCH, return_value=ctx):
@@ -328,8 +339,16 @@ class TestUpdatePriceMetadata:
         stats_result.count = 0
 
         session.query.side_effect = [
-            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=entry)))),
-            MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=stats_result)))),
+            MagicMock(
+                filter=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=entry))
+                )
+            ),
+            MagicMock(
+                filter=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=stats_result))
+                )
+            ),
         ]
 
         with patch(SESSION_PATCH, return_value=ctx):
@@ -371,3 +390,62 @@ class TestGetRegistryStats:
         assert result["active"] == 0
         assert result["invalid"] == 0
         assert result["inactive"] == 0
+
+
+class TestRegisterTickersFundamentals:
+    """Tests for the fundamentals auto-populate hook in register_tickers."""
+
+    FUNDAMENTALS_PATCH = "shit.market_data.fundamentals_provider.FundamentalsProvider"
+
+    def test_triggers_fundamentals_fetch_for_new_tickers(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(self.FUNDAMENTALS_PATCH) as mock_provider_cls,
+        ):
+            mock_provider = MagicMock()
+            mock_provider_cls.return_value = mock_provider
+
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL", "TSLA"])
+
+        # Should call update_fundamentals for each new ticker
+        assert mock_provider.update_fundamentals.call_count == 2
+        mock_provider.update_fundamentals.assert_any_call("AAPL", force=True)
+        mock_provider.update_fundamentals.assert_any_call("TSLA", force=True)
+
+    def test_fundamentals_failure_does_not_break_registration(self):
+        ctx, session = _mock_session()
+        session.query.return_value.filter.return_value.first.return_value = None
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(self.FUNDAMENTALS_PATCH) as mock_provider_cls,
+        ):
+            mock_provider = MagicMock()
+            mock_provider.update_fundamentals.side_effect = Exception("yfinance down")
+            mock_provider_cls.return_value = mock_provider
+
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL"])
+
+        # Registration should still succeed despite fundamentals failure
+        assert newly == ["AAPL"]
+        session.add.assert_called_once()
+
+    def test_does_not_fetch_fundamentals_when_no_new_tickers(self):
+        ctx, session = _mock_session()
+        existing = MagicMock(status="active")
+        session.query.return_value.filter.return_value.first.return_value = existing
+
+        with (
+            patch(SESSION_PATCH, return_value=ctx),
+            patch(self.FUNDAMENTALS_PATCH) as mock_provider_cls,
+        ):
+            service = TickerRegistryService()
+            newly, known = service.register_tickers(["AAPL"])
+
+        # No new tickers, so FundamentalsProvider should not be instantiated
+        mock_provider_cls.assert_not_called()

--- a/shit_tests/shitty_ui/test_screener.py
+++ b/shit_tests/shitty_ui/test_screener.py
@@ -15,6 +15,8 @@ from components.screener import (
     _hex_to_rgb,
     _text_color,
     _sentiment_badge,
+    _screener_sector_badge,
+    _SECTOR_ABBREV,
     _SUCCESS_RGB,
     _DANGER_RGB,
 )
@@ -180,15 +182,11 @@ class TestBuildScreenerTable:
     """Tests for the main screener table builder."""
 
     def test_returns_div_with_data(self):
-        result = build_screener_table(
-            _make_screener_df(), _make_sparkline_data()
-        )
+        result = build_screener_table(_make_screener_df(), _make_sparkline_data())
         assert isinstance(result, html.Div)
 
     def test_table_has_correct_row_count(self):
-        result = build_screener_table(
-            _make_screener_df(5), _make_sparkline_data()
-        )
+        result = build_screener_table(_make_screener_df(5), _make_sparkline_data())
         table = result.children
         assert isinstance(table, html.Table)
         tbody = table.children[1]
@@ -206,9 +204,9 @@ class TestBuildScreenerTable:
         result = build_screener_table(df, sparklines)
         table = result.children
         tbody = table.children[1]
-        # Row 2 (CMCSA) should have a placeholder in cell 1 (sparkline)
+        # Row 2 (CMCSA) should have a placeholder in cell 2 (sparkline, after sector)
         cmcsa_row = tbody.children[2]
-        spark_cell = cmcsa_row.children[1]
+        spark_cell = cmcsa_row.children[2]
         # Placeholder is an html.Div, not a dcc.Graph
         assert not isinstance(spark_cell.children, dcc.Graph)
 
@@ -235,72 +233,121 @@ class TestBuildScreenerTable:
         assert first_ticker.children == "CMCSA"
 
     def test_row_has_screener_row_class(self):
-        result = build_screener_table(
-            _make_screener_df(1), {}
-        )
+        result = build_screener_table(_make_screener_df(1), {})
         table = result.children
         tbody = table.children[1]
         row = tbody.children[0]
         assert row.className == "screener-row"
 
     def test_row_has_pattern_match_id(self):
-        result = build_screener_table(
-            _make_screener_df(1), {}
-        )
+        result = build_screener_table(_make_screener_df(1), {})
         table = result.children
         tbody = table.children[1]
         row = tbody.children[0]
         assert row.id == {"type": "screener-row", "index": "XLE"}
 
     def test_asset_link_href(self):
-        result = build_screener_table(
-            _make_screener_df(1), {}
-        )
+        result = build_screener_table(_make_screener_df(1), {})
         table = result.children
         tbody = table.children[1]
         row = tbody.children[0]
         link = row.children[0].children  # First td -> dcc.Link
         assert link.href == "/assets/XLE"
 
-    def test_header_has_eight_columns(self):
-        result = build_screener_table(
-            _make_screener_df(1), {}
-        )
+    def test_header_has_nine_columns(self):
+        result = build_screener_table(_make_screener_df(1), {})
         table = result.children
         thead = table.children[0]
         header_row = thead.children
-        assert len(header_row.children) == 8
+        assert len(header_row.children) == 9
 
     def test_sparkline_cell_has_hide_class(self):
         """Sparkline column should have screener-hide-mobile class."""
-        result = build_screener_table(
-            _make_screener_df(1), _make_sparkline_data()
-        )
+        result = build_screener_table(_make_screener_df(1), _make_sparkline_data())
         table = result.children
         tbody = table.children[1]
-        spark_td = tbody.children[0].children[1]
+        spark_td = tbody.children[0].children[2]  # After sector column
         assert "screener-hide-mobile" in spark_td.className
 
     def test_confidence_cell_has_hide_class(self):
         """Confidence column should have screener-hide-mobile class."""
-        result = build_screener_table(
-            _make_screener_df(1), {}
-        )
+        result = build_screener_table(_make_screener_df(1), {})
         table = result.children
         tbody = table.children[1]
-        # Confidence is the last column (index 7)
-        conf_td = tbody.children[0].children[7]
+        # Confidence is the last column (index 8, after adding sector)
+        conf_td = tbody.children[0].children[8]
         assert "screener-hide-mobile" in conf_td.className
 
     def test_heat_mapped_return_positive_has_green_bg(self):
         """Positive avg_return should get green background."""
         result = build_screener_table(
-            _make_screener_df(1), {}  # XLE has avg_return=2.48
+            _make_screener_df(1),
+            {},  # XLE has avg_return=2.48
         )
         table = result.children
         tbody = table.children[1]
-        # 7d Return is column index 4
-        return_td = tbody.children[0].children[4]
+        # 7d Return is column index 5 (after sector column)
+        return_td = tbody.children[0].children[5]
         bg = return_td.style["backgroundColor"]
         r, g, b = _SUCCESS_RGB
         assert f"rgba({r}, {g}, {b}," in bg
+
+
+# ── screener_sector_badge ────────────────────────────────────────────
+
+
+class TestScreenerSectorBadge:
+    """Tests for _screener_sector_badge helper."""
+
+    def test_renders_known_sector_abbreviation(self):
+        badge = _screener_sector_badge("Technology")
+        assert badge.children == "TECH"
+
+    def test_renders_unknown_sector_truncated(self):
+        badge = _screener_sector_badge("Quantum Computing")
+        assert badge.children == "QUAN"
+
+    def test_renders_dash_for_none_sector(self):
+        badge = _screener_sector_badge(None)
+        assert badge.children == "-"
+
+    def test_sector_badge_has_tooltip(self):
+        badge = _screener_sector_badge("Financial Services")
+        assert badge.title == "Financial Services"
+        assert badge.children == "FIN"
+
+
+# ── build_screener_table with sectors ────────────────────────────────
+
+
+class TestBuildScreenerTableWithSectors:
+    """Tests for sector integration in the screener table."""
+
+    def test_table_has_sector_column_header(self):
+        result = build_screener_table(_make_screener_df(1), {})
+        table = result.children
+        thead = table.children[0]
+        header_row = thead.children
+        # Sector is the second column header (index 1)
+        sector_th = header_row.children[1]
+        assert sector_th.children == "Sector"
+
+    def test_rows_include_sector_badges(self):
+        sector_data = {"XLE": "Energy", "DIS": "Communication Services"}
+        result = build_screener_table(_make_screener_df(2), {}, sector_data=sector_data)
+        table = result.children
+        tbody = table.children[1]
+        # XLE row: sector cell at index 1
+        xle_sector_td = tbody.children[0].children[1]
+        assert xle_sector_td.children.children == "ENGY"
+        # DIS row: sector cell at index 1
+        dis_sector_td = tbody.children[1].children[1]
+        assert dis_sector_td.children.children == "COMM"
+
+    def test_works_without_sector_data(self):
+        """sector_data=None should render dashes for all sectors."""
+        result = build_screener_table(_make_screener_df(1), {}, sector_data=None)
+        table = result.children
+        tbody = table.children[1]
+        sector_td = tbody.children[0].children[1]
+        assert sector_td.children.children == "-"

--- a/shitty_ui/components/screener.py
+++ b/shitty_ui/components/screener.py
@@ -104,6 +104,59 @@ def _sentiment_badge(sentiment: Optional[str]) -> html.Span:
     )
 
 
+# ── Sector badge ─────────────────────────────────────────────────────
+
+# Sector abbreviation map for compact display
+_SECTOR_ABBREV: Dict[str, str] = {
+    "Technology": "TECH",
+    "Healthcare": "HLTH",
+    "Financial Services": "FIN",
+    "Consumer Cyclical": "CYCL",
+    "Consumer Defensive": "DEF",
+    "Communication Services": "COMM",
+    "Energy": "ENGY",
+    "Industrials": "INDL",
+    "Basic Materials": "MATL",
+    "Real Estate": "REAL",
+    "Utilities": "UTIL",
+}
+
+
+def _screener_sector_badge(sector: Optional[str]) -> html.Span:
+    """Render a compact sector badge for the screener table.
+
+    Args:
+        sector: Sector name from yfinance (e.g., "Technology"). None renders a dash.
+
+    Returns:
+        html.Span with abbreviated sector name.
+    """
+    if not sector:
+        return html.Span(
+            "-",
+            style={"color": COLORS["text_muted"], "fontSize": "0.75rem"},
+        )
+
+    label = _SECTOR_ABBREV.get(sector, sector[:4].upper())
+
+    return html.Span(
+        label,
+        title=sector,  # Full name on hover
+        style={
+            "backgroundColor": f"{COLORS['navy']}30",
+            "color": COLORS["text_muted"],
+            "fontSize": "0.65rem",
+            "padding": "2px 6px",
+            "borderRadius": "4px",
+            "fontWeight": "500",
+            "letterSpacing": "0.03em",
+            "textTransform": "uppercase",
+            "display": "inline-block",
+            "cursor": "default",
+        },
+    )
+
+
 # ── Sparkline cell ────────────────────────────────────────────────────
 
 
@@ -197,6 +250,7 @@ def _sort_header(
 def build_screener_table(
     screener_df: pd.DataFrame,
     sparkline_data: Dict[str, pd.DataFrame],
+    sector_data: Optional[Dict[str, str]] = None,
     sort_column: str = "total_predictions",
     sort_ascending: bool = False,
     timeframe_label: str = "7d",
@@ -206,6 +260,7 @@ def build_screener_table(
     Args:
         screener_df: DataFrame from get_asset_screener_data().
         sparkline_data: Dict from get_screener_sparkline_prices().
+        sector_data: Dict mapping symbol -> sector name (optional).
         sort_column: Column key to sort by.
         sort_ascending: Sort direction.
 
@@ -253,6 +308,15 @@ def build_screener_table(
                 html.Th(
                     "Asset",
                     style={**_HEADER_STYLE, "textAlign": "left", "width": "80px"},
+                ),
+                html.Th(
+                    "Sector",
+                    className="screener-hide-mobile",
+                    style={
+                        **_HEADER_STYLE,
+                        "textAlign": "left",
+                        "width": "100px",
+                    },
                 ),
                 html.Th(
                     "30d Price",
@@ -323,6 +387,17 @@ def build_screener_table(
                         ),
                         style={
                             "padding": "10px 12px",
+                            "verticalAlign": "middle",
+                        },
+                    ),
+                    # Sector badge
+                    html.Td(
+                        _screener_sector_badge(
+                            sector_data.get(symbol) if sector_data else None
+                        ),
+                        className="screener-hide-mobile",
+                        style={
+                            "padding": "10px 8px",
                             "verticalAlign": "middle",
                         },
                     ),

--- a/shitty_ui/data/__init__.py
+++ b/shitty_ui/data/__init__.py
@@ -83,6 +83,8 @@ from data.asset_queries import (  # noqa: F401
     get_asset_predictions,
     get_asset_stats,
     get_related_assets,
+    get_ticker_fundamentals,
+    get_screener_sectors,
 )
 
 # --- Insight queries ---
@@ -112,11 +114,13 @@ def clear_all_caches() -> None:
     get_top_predicted_asset.clear_cache()  # type: ignore
     get_empty_state_context.clear_cache()  # type: ignore
 
-    # Asset queries (4 cached functions)
+    # Asset queries (6 cached functions)
     get_asset_stats.clear_cache()  # type: ignore
     get_asset_screener_data.clear_cache()  # type: ignore
     get_screener_sparkline_prices.clear_cache()  # type: ignore
     get_sparkline_prices.clear_cache()  # type: ignore
+    get_ticker_fundamentals.clear_cache()  # type: ignore
+    get_screener_sectors.clear_cache()  # type: ignore
 
     # Insight queries (1 cached function)
     get_dynamic_insights.clear_cache()  # type: ignore
@@ -181,6 +185,8 @@ __all__ = [
     "get_asset_predictions",
     "get_asset_stats",
     "get_related_assets",
+    "get_ticker_fundamentals",
+    "get_screener_sectors",
     # Insight queries
     "get_dynamic_insights",
 ]

--- a/shitty_ui/data/asset_queries.py
+++ b/shitty_ui/data/asset_queries.py
@@ -505,9 +505,7 @@ def get_asset_predictions(symbol: str, limit: int = 50) -> pd.DataFrame:
 
 
 @ttl_cache(ttl_seconds=300)  # Cache for 5 minutes
-def get_asset_stats(
-    symbol: str, timeframe: str = DEFAULT_TIMEFRAME
-) -> Dict[str, Any]:
+def get_asset_stats(symbol: str, timeframe: str = DEFAULT_TIMEFRAME) -> Dict[str, Any]:
     """
     Get aggregate performance statistics for a specific asset,
     alongside overall system averages for comparison.
@@ -622,6 +620,86 @@ def get_asset_stats(
         "overall_accuracy": 0.0,
         "overall_avg_return": 0.0,
     }
+
+
+@ttl_cache(ttl_seconds=600)  # Cache for 10 minutes (fundamentals change slowly)
+def get_ticker_fundamentals(symbol: str) -> Dict[str, Any]:
+    """Get company fundamental data from the ticker registry.
+
+    Args:
+        symbol: Ticker symbol (e.g., 'AAPL').
+
+    Returns:
+        Dictionary with keys: company_name, sector, industry, market_cap,
+        pe_ratio, forward_pe, dividend_yield, beta, exchange, asset_type,
+        description, fundamentals_updated_at.
+        Returns dict with all None values if ticker not found.
+    """
+    query = text("""
+        SELECT
+            company_name,
+            sector,
+            industry,
+            market_cap,
+            pe_ratio,
+            forward_pe,
+            dividend_yield,
+            beta,
+            exchange,
+            asset_type,
+            description,
+            fundamentals_updated_at
+        FROM ticker_registry
+        WHERE symbol = :symbol
+    """)
+
+    empty = {
+        "company_name": None,
+        "sector": None,
+        "industry": None,
+        "market_cap": None,
+        "pe_ratio": None,
+        "forward_pe": None,
+        "dividend_yield": None,
+        "beta": None,
+        "exchange": None,
+        "asset_type": None,
+        "description": None,
+        "fundamentals_updated_at": None,
+    }
+
+    try:
+        rows, columns = _base.execute_query(query, {"symbol": symbol.upper()})
+        if rows and rows[0]:
+            row = rows[0]
+            return {col: row[i] for i, col in enumerate(columns)}
+    except Exception as e:
+        logger.error(f"Error loading fundamentals for {symbol}: {e}")
+
+    return empty
+
+
+@ttl_cache(ttl_seconds=300)
+def get_screener_sectors() -> Dict[str, str]:
+    """Get sector mapping for all active tickers.
+
+    Returns:
+        Dict mapping symbol -> sector (e.g., {"AAPL": "Technology", "XOM": "Energy"}).
+        Tickers without sector data are excluded.
+    """
+    query = text("""
+        SELECT symbol, sector
+        FROM ticker_registry
+        WHERE status = 'active'
+            AND sector IS NOT NULL
+    """)
+
+    try:
+        rows, columns = _base.execute_query(query)
+        return {row[0]: row[1] for row in rows} if rows else {}
+    except Exception as e:
+        logger.error(f"Error loading screener sectors: {e}")
+        return {}
 
 
 def get_related_assets(

--- a/shitty_ui/pages/assets.py
+++ b/shitty_ui/pages/assets.py
@@ -1,6 +1,7 @@
 """Asset deep dive page layout and callbacks."""
 
 import traceback
+from typing import Optional
 
 from dash import Dash, html, dcc, Input, Output, callback_context
 import dash_bootstrap_components as dbc
@@ -23,6 +24,7 @@ from data import (
     get_asset_stats,
     get_price_with_signals,
     get_related_assets,
+    get_ticker_fundamentals,
 )
 
 
@@ -53,6 +55,12 @@ def create_asset_page(symbol: str) -> html.Div:
                         type="default",
                         color=COLORS["accent"],
                         children=html.Div(id="asset-stat-cards", className="mb-4"),
+                    ),
+                    # Company Profile card (populated by callback)
+                    dcc.Loading(
+                        type="default",
+                        color=COLORS["accent"],
+                        children=html.Div(id="asset-company-profile", className="mb-4"),
                     ),
                     # Price chart + Performance summary
                     dbc.Row(
@@ -211,7 +219,7 @@ def create_asset_page(symbol: str) -> html.Div:
 def create_asset_header(symbol: str) -> html.Div:
     """
     Create the header bar for an asset page.
-    Includes back navigation, symbol name, and a placeholder for
+    Includes back navigation, symbol name, company name, and a placeholder for
     current price (populated by callback).
 
     Args:
@@ -241,7 +249,7 @@ def create_asset_header(symbol: str) -> html.Div:
                     "marginBottom": "10px",
                 },
             ),
-            # Symbol + Price
+            # Symbol + Company Name + Price
             html.Div(
                 [
                     html.Div(
@@ -266,12 +274,23 @@ def create_asset_header(symbol: str) -> html.Div:
                         ],
                         style={"display": "flex", "alignItems": "baseline"},
                     ),
+                    # Company name + sector badge (populated by callback)
+                    html.Div(
+                        id="asset-company-subtitle",
+                        style={
+                            "display": "flex",
+                            "alignItems": "center",
+                            "gap": "8px",
+                            "marginTop": "2px",
+                        },
+                    ),
                     html.P(
                         COPY["asset_page_subtitle"].format(symbol=symbol),
                         style={
                             "color": COLORS["text_muted"],
                             "margin": 0,
                             "fontSize": "0.9rem",
+                            "marginTop": "4px",
                         },
                     ),
                 ]
@@ -294,6 +313,8 @@ def register_asset_callbacks(app: Dash):
         [
             Output("asset-stat-cards", "children"),
             Output("asset-current-price", "children"),
+            Output("asset-company-subtitle", "children"),
+            Output("asset-company-profile", "children"),
             Output("asset-performance-summary", "children"),
             Output("asset-signal-summary", "children"),
             Output("asset-prediction-timeline", "children"),
@@ -308,9 +329,14 @@ def register_asset_callbacks(app: Dash):
         """
         if not symbol:
             empty = html.P("No asset selected.", style={"color": COLORS["text_muted"]})
-            return empty, "", empty, empty, empty, empty
+            return empty, "", [], html.Div(), empty, empty, empty, empty
 
         try:
+            # --- COMPANY FUNDAMENTALS ---
+            fundamentals = get_ticker_fundamentals(symbol)
+            company_subtitle = _build_company_subtitle(fundamentals)
+            company_profile = _build_company_profile_card(fundamentals)
+
             # --- STAT CARDS ---
             stats = get_asset_stats(symbol)
             stat_cards = dbc.Row(
@@ -430,6 +456,8 @@ def register_asset_callbacks(app: Dash):
             return (
                 stat_cards,
                 current_price_text,
+                company_subtitle,
+                company_profile,
                 performance_summary,
                 signal_summary,
                 timeline_cards,
@@ -439,7 +467,16 @@ def register_asset_callbacks(app: Dash):
         except Exception as e:
             print(f"Error loading asset page for {symbol}: {traceback.format_exc()}")
             error_card = create_error_card(f"Unable to load data for {symbol}", str(e))
-            return error_card, "", error_card, error_card, error_card, error_card
+            return (
+                error_card,
+                "",
+                [],
+                html.Div(),
+                error_card,
+                error_card,
+                error_card,
+                error_card,
+            )
 
     @app.callback(
         Output("asset-price-chart", "figure"),
@@ -695,4 +732,209 @@ def _mini_stat_card(value: str, label: str, color: str) -> html.Div:
             "borderRadius": "8px",
             "border": f"1px solid {COLORS['border']}",
         },
+    )
+
+
+def _format_market_cap(market_cap: Optional[int]) -> str:
+    """Format market cap as human-readable string.
+
+    Args:
+        market_cap: Market capitalization in USD.
+
+    Returns:
+        Formatted string like "$2.8T", "$150.3B", "$4.2M", or "N/A".
+    """
+    if market_cap is None:
+        return "N/A"
+    if market_cap >= 1_000_000_000_000:
+        return f"${market_cap / 1_000_000_000_000:.1f}T"
+    if market_cap >= 1_000_000_000:
+        return f"${market_cap / 1_000_000_000:.1f}B"
+    if market_cap >= 1_000_000:
+        return f"${market_cap / 1_000_000:.1f}M"
+    return f"${market_cap:,.0f}"
+
+
+def _sector_badge(sector: Optional[str]) -> html.Span:
+    """Render a compact sector badge.
+
+    Args:
+        sector: Sector name (e.g. "Technology"). None renders nothing.
+
+    Returns:
+        html.Span badge component, or empty Span if sector is None.
+    """
+    if not sector:
+        return html.Span()
+
+    return html.Span(
+        sector,
+        style={
+            "backgroundColor": f"{COLORS['navy']}40",
+            "color": COLORS["text"],
+            "fontSize": "0.75rem",
+            "padding": "2px 10px",
+            "borderRadius": "9999px",
+            "fontWeight": "500",
+            "letterSpacing": "0.02em",
+            "display": "inline-block",
+        },
+    )
+
+
+def _build_company_subtitle(fundamentals: dict) -> list:
+    """Build the company name + sector badge row for the header.
+
+    Args:
+        fundamentals: Dict from get_ticker_fundamentals().
+
+    Returns:
+        List of Dash components for the subtitle div.
+    """
+    children = []
+
+    company_name = fundamentals.get("company_name")
+    if company_name:
+        children.append(
+            html.Span(
+                company_name,
+                style={
+                    "color": COLORS["text_muted"],
+                    "fontSize": "1rem",
+                    "fontWeight": "400",
+                },
+            )
+        )
+
+    sector = fundamentals.get("sector")
+    if sector:
+        children.append(_sector_badge(sector))
+
+    return children
+
+
+def _build_company_profile_card(fundamentals: dict) -> html.Div:
+    """Build the Company Profile card for the asset page.
+
+    Shows sector, industry, market cap, P/E, dividend yield, beta, and description.
+    Returns an empty Div if no fundamental data is available.
+
+    Args:
+        fundamentals: Dict from get_ticker_fundamentals().
+
+    Returns:
+        dbc.Card component or empty html.Div.
+    """
+    # Check if any meaningful data exists
+    has_data = any(
+        fundamentals.get(key) is not None
+        for key in ["company_name", "sector", "market_cap", "pe_ratio", "description"]
+    )
+
+    if not has_data:
+        return html.Div()  # No fundamentals, render nothing
+
+    # Build metric items
+    metrics = []
+
+    def _add_metric(label: str, value: str, icon: str):
+        metrics.append(
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.I(
+                                className=f"fas fa-{icon} me-2",
+                                style={"color": COLORS["accent"], "width": "16px"},
+                            ),
+                            html.Span(
+                                label,
+                                style={
+                                    "color": COLORS["text_muted"],
+                                    "fontSize": "0.8rem",
+                                },
+                            ),
+                        ],
+                        style={"display": "flex", "alignItems": "center"},
+                    ),
+                    html.Div(
+                        value,
+                        style={
+                            "color": COLORS["text"],
+                            "fontSize": "0.9rem",
+                            "fontWeight": "600",
+                            "marginTop": "2px",
+                        },
+                    ),
+                ],
+                style={
+                    "padding": "8px 0",
+                    "borderBottom": f"1px solid {COLORS['border']}",
+                },
+            )
+        )
+
+    if fundamentals.get("sector"):
+        _add_metric("Sector", fundamentals["sector"], "layer-group")
+
+    if fundamentals.get("industry"):
+        _add_metric("Industry", fundamentals["industry"], "industry")
+
+    if fundamentals.get("market_cap") is not None:
+        _add_metric(
+            "Market Cap", _format_market_cap(fundamentals["market_cap"]), "coins"
+        )
+
+    if fundamentals.get("pe_ratio") is not None:
+        pe_str = f"{fundamentals['pe_ratio']:.1f}"
+        if fundamentals.get("forward_pe") is not None:
+            pe_str += f" / {fundamentals['forward_pe']:.1f} fwd"
+        _add_metric("P/E Ratio", pe_str, "calculator")
+
+    if fundamentals.get("dividend_yield") is not None:
+        _add_metric(
+            "Dividend Yield",
+            f"{fundamentals['dividend_yield'] * 100:.2f}%",
+            "percentage",
+        )
+
+    if fundamentals.get("beta") is not None:
+        _add_metric("Beta", f"{fundamentals['beta']:.2f}", "wave-square")
+
+    if fundamentals.get("exchange"):
+        _add_metric("Exchange", fundamentals["exchange"], "building-columns")
+
+    # Build the card
+    card_body_children = []
+
+    if metrics:
+        card_body_children.append(html.Div(metrics))
+
+    # Description (truncated)
+    if fundamentals.get("description"):
+        card_body_children.append(
+            html.P(
+                fundamentals["description"],
+                style={
+                    "color": COLORS["text_muted"],
+                    "fontSize": "0.8rem",
+                    "lineHeight": "1.5",
+                    "marginTop": "12px",
+                    "marginBottom": "0",
+                },
+            )
+        )
+
+    return dbc.Card(
+        [
+            dbc.CardHeader(
+                [
+                    html.I(className="fas fa-building me-2"),
+                    "Company Profile",
+                ],
+                className="fw-bold",
+            ),
+            dbc.CardBody(card_body_children),
+        ],
+        style={"backgroundColor": COLORS["secondary"]},
     )

--- a/shitty_ui/pages/dashboard_callbacks/content.py
+++ b/shitty_ui/pages/dashboard_callbacks/content.py
@@ -21,6 +21,7 @@ from brand_copy import COPY
 from data import (
     get_asset_screener_data,
     get_screener_sparkline_prices,
+    get_screener_sectors,
     load_recent_posts,
     get_dashboard_kpis_with_fallback,
     get_dynamic_insights,
@@ -77,17 +78,18 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Asset Screener Table =====
         try:
-            screener_df = get_asset_screener_data(
-                days=days, timeframe=timeframe
-            )
+            screener_df = get_asset_screener_data(days=days, timeframe=timeframe)
             sparkline_data = {}
+            sector_data = {}
             if not screener_df.empty:
                 symbols = tuple(screener_df["symbol"].tolist())
                 sparkline_data = get_screener_sparkline_prices(symbols=symbols)
+                sector_data = get_screener_sectors()
 
             screener_table = build_screener_table(
                 screener_df=screener_df,
                 sparkline_data=sparkline_data,
+                sector_data=sector_data,
                 sort_column="total_predictions",
                 sort_ascending=False,
                 timeframe_label=tf_label_short,
@@ -99,9 +101,7 @@ def register_content_callbacks(app: Dash) -> None:
 
         # ===== Performance Metrics with error handling =====
         try:
-            kpis = get_dashboard_kpis_with_fallback(
-                days=days, timeframe=timeframe
-            )
+            kpis = get_dashboard_kpis_with_fallback(days=days, timeframe=timeframe)
             fallback_note = kpis["fallback_label"] if kpis["is_fallback"] else ""
             tf_label = kpis.get("timeframe_label", tf["label_long"])
 


### PR DESCRIPTION
## Summary
- Extended TickerRegistry with 10 fundamental data columns
- Created FundamentalsProvider service (yfinance .info with 24h staleness caching)
- Auto-populate hook in register_tickers()
- Company profile card on asset detail page
- Sector badges in screener table

## Test plan
- [x] 35 new tests, all passing
- [x] 1119 tests pass in relevant directories
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)