### PR TITLE
feat: market-aware timing for outcome calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Market-aware timing** — Outcome calculations now use trading-day offsets instead of calendar days (T+1 on Friday = Monday, holidays skipped)
+  - `MarketCalendar` wrapper around `exchange_calendars` for NYSE session scheduling with naive fallbacks
+  - `IntradayPriceSnapshot` + `fetch_intraday_snapshot()` for same-day/1h outcome tracking via yfinance 1h bars
+  - `bar_datetime` formal field on `RawPriceRecord` dataclass for intraday bar timestamps
+  - `_get_source_datetime` as primary method on `OutcomeCalculator` (UTC-aware datetime extraction)
+  - New `PredictionOutcome` columns: `post_published_at`, `price_at_post`, `price_at_next_close`, `price_1h_after`, `return_same_day`, `return_1h`, `correct_same_day`, `correct_1h`, `pnl_same_day`, `pnl_1h`
+  - `get_price_on_date` uses MarketCalendar for backward lookback on non-trading days
+  - 64 new tests across `test_market_calendar.py` (44), `test_intraday_provider.py` (9), and new outcome calculator test classes (11)
 - **Multi-timeframe dashboard** — New "Outcome Window" toggle (T+1, T+3, T+7, T+30) on the dashboard lets users view KPIs, screener, and insights across any prediction timeframe instead of only T+7
 - **Timeframe column mapping module** — `data/timeframe.py` provides `get_tf_columns()`, `TIMEFRAME_OPTIONS`, `VALID_TIMEFRAMES`, and `DEFAULT_TIMEFRAME` as single source of truth for timeframe→column mapping
 - 12 new tests for timeframe module (`test_timeframe.py`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,12 +293,20 @@ python -m shitposts --mode backfill --from 2024-01-01 --to 2024-12-31
 
 **`prediction_outcomes`** - Validated prediction accuracy with returns
 - `id`, `prediction_id` (FK → predictions.id), `symbol`
-- Prediction snapshot: `prediction_date`, `prediction_sentiment`, `prediction_confidence`
-- Price evolution: `price_at_prediction`, `price_t1`, `price_t3`, `price_t7`, `price_t30`
-- Returns: `return_t1`, `return_t3`, `return_t7`, `return_t30` (percentage change)
-- Accuracy: `correct_t1`, `correct_t3`, `correct_t7`, `correct_t30` (boolean)
-- P&L simulation: `pnl_t1`, `pnl_t3`, `pnl_t7`, `pnl_t30` ($1000 position)
+- Prediction snapshot: `prediction_date`, `prediction_sentiment`, `prediction_confidence`, `prediction_timeframe_days`
+- Post timing: `post_published_at` (datetime) -- Full datetime for intraday calculations
+- Price at prediction: `price_at_prediction` (daily close on prediction date)
+- Intraday snapshots: `price_at_post`, `price_at_next_close`, `price_1h_after` (ephemeral, captured once)
+- Price evolution (trading days): `price_t1`, `price_t3`, `price_t7`, `price_t30`
+- Returns -- daily (trading days): `return_t1`, `return_t3`, `return_t7`, `return_t30` (percentage change)
+- Returns -- intraday: `return_same_day` (post→next close), `return_1h` (post→1h after)
+- Accuracy -- daily: `correct_t1`, `correct_t3`, `correct_t7`, `correct_t30` (boolean)
+- Accuracy -- intraday: `correct_same_day`, `correct_1h` (boolean)
+- P&L simulation -- daily: `pnl_t1`, `pnl_t3`, `pnl_t7`, `pnl_t30` ($1000 position)
+- P&L simulation -- intraday: `pnl_same_day`, `pnl_1h` ($1000 position)
+- Market context: `market_volatility`, `sector`
 - `is_complete` (boolean) -- All timeframes tracked?
+- `last_price_update`, `notes`
 
 **`signals`** - Source-agnostic content model for multi-platform support
 - `id`, `signal_id` (string, unique) -- Platform-specific content ID

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ numpy>=1.24.0
 
 # Market data
 yfinance>=0.2.48
+exchange_calendars>=4.5.0
 
 # Dashboard dependencies
 dash>=4.0.0,<5.0.0

--- a/shit/market_data/__init__.py
+++ b/shit/market_data/__init__.py
@@ -6,10 +6,16 @@ Fetches stock prices and calculates prediction outcomes.
 from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
 from shit.market_data.client import MarketDataClient
 from shit.market_data.outcome_calculator import OutcomeCalculator
-from shit.market_data.price_provider import PriceProvider, ProviderChain, RawPriceRecord, ProviderError
+from shit.market_data.price_provider import (
+    PriceProvider,
+    ProviderChain,
+    RawPriceRecord,
+    ProviderError,
+)
 from shit.market_data.yfinance_provider import YFinanceProvider
 from shit.market_data.alphavantage_provider import AlphaVantageProvider
 from shit.market_data.health import run_health_check, HealthReport
+from shit.market_data.market_calendar import MarketCalendar
 
 __all__ = [
     "MarketPrice",
@@ -25,4 +31,5 @@ __all__ = [
     "AlphaVantageProvider",
     "run_health_check",
     "HealthReport",
+    "MarketCalendar",
 ]

--- a/shit/market_data/client.py
+++ b/shit/market_data/client.py
@@ -12,7 +12,10 @@ from sqlalchemy import and_
 
 from shit.market_data.models import MarketPrice
 from shit.market_data.price_provider import (
-    PriceProvider, ProviderChain, RawPriceRecord, ProviderError,
+    PriceProvider,
+    ProviderChain,
+    RawPriceRecord,
+    ProviderError,
 )
 from shit.market_data.yfinance_provider import YFinanceProvider
 from shit.market_data.alphavantage_provider import AlphaVantageProvider
@@ -121,7 +124,11 @@ class MarketDataClient:
 
         logger.info(
             f"Fetching price history for {symbol}",
-            extra={"symbol": symbol, "start_date": str(start_date), "end_date": str(end_date)}
+            extra={
+                "symbol": symbol,
+                "start_date": str(start_date),
+                "end_date": str(end_date),
+            },
         )
 
         # Check if we already have this data (unless force refresh)
@@ -130,7 +137,7 @@ class MarketDataClient:
             if len(existing) > 0:
                 logger.info(
                     f"Found {len(existing)} existing prices for {symbol}, skipping fetch",
-                    extra={"symbol": symbol, "count": len(existing)}
+                    extra={"symbol": symbol, "count": len(existing)},
                 )
                 return existing
 
@@ -140,7 +147,7 @@ class MarketDataClient:
         if not raw_records:
             logger.warning(
                 f"No price data found for {symbol} from any provider",
-                extra={"symbol": symbol}
+                extra={"symbol": symbol},
             )
             return []
 
@@ -151,7 +158,7 @@ class MarketDataClient:
 
             logger.info(
                 f"Successfully stored {len(prices)} prices for {symbol}",
-                extra={"symbol": symbol, "count": len(prices)}
+                extra={"symbol": symbol, "count": len(prices)},
             )
             return prices
 
@@ -185,23 +192,33 @@ class MarketDataClient:
 
         for attempt in range(max_retries + 1):
             try:
-                return self._provider_chain.fetch_with_fallback(symbol, start_date, end_date)
+                return self._provider_chain.fetch_with_fallback(
+                    symbol, start_date, end_date
+                )
             except ProviderError as e:
                 last_error = e
 
                 if attempt == max_retries:
                     logger.error(
                         f"All providers failed for {symbol} after {max_retries + 1} attempts: {e}",
-                        extra={"symbol": symbol, "attempts": max_retries + 1, "error": str(e)}
+                        extra={
+                            "symbol": symbol,
+                            "attempts": max_retries + 1,
+                            "error": str(e),
+                        },
                     )
                     _send_failure_alert(symbol, str(e))
                     return []
 
-                wait_time = delay * (backoff ** attempt)
+                wait_time = delay * (backoff**attempt)
                 logger.warning(
                     f"Provider chain failed for {symbol} (attempt {attempt + 1}/{max_retries + 1}), "
                     f"retrying in {wait_time:.1f}s: {e}",
-                    extra={"symbol": symbol, "attempt": attempt + 1, "wait_time": wait_time}
+                    extra={
+                        "symbol": symbol,
+                        "attempt": attempt + 1,
+                        "wait_time": wait_time,
+                    },
                 )
                 time.sleep(wait_time)
 
@@ -217,12 +234,16 @@ class MarketDataClient:
 
         for record in records:
             # Check if price already exists
-            existing_price = self.session.query(MarketPrice).filter(
-                and_(
-                    MarketPrice.symbol == record.symbol,
-                    MarketPrice.date == record.date,
+            existing_price = (
+                self.session.query(MarketPrice)
+                .filter(
+                    and_(
+                        MarketPrice.symbol == record.symbol,
+                        MarketPrice.date == record.date,
+                    )
                 )
-            ).first()
+                .first()
+            )
 
             if existing_price and not force_refresh:
                 prices.append(existing_price)
@@ -252,60 +273,81 @@ class MarketDataClient:
         return prices
 
     def get_price_on_date(
-        self,
-        symbol: str,
-        target_date: date,
-        lookback_days: int = 7
+        self, symbol: str, target_date: date, lookback_days: int = 7
     ) -> Optional[MarketPrice]:
-        """Get price for a specific date, with fallback for market closed days."""
-        price = self.session.query(MarketPrice).filter(
-            and_(
-                MarketPrice.symbol == symbol,
-                MarketPrice.date == target_date
-            )
-        ).first()
+        """Get price for a specific date, with fallback for non-trading days.
+
+        Uses the market calendar to walk backward through actual trading days
+        rather than calendar days. If target_date is a weekend or holiday,
+        this returns the most recent trading day's close.
+        """
+        from shit.market_data.market_calendar import MarketCalendar
+
+        price = (
+            self.session.query(MarketPrice)
+            .filter(and_(MarketPrice.symbol == symbol, MarketPrice.date == target_date))
+            .first()
+        )
 
         if price:
             return price
 
         logger.debug(
-            f"No price found for {symbol} on {target_date}, checking previous days",
-            extra={"symbol": symbol, "target_date": str(target_date)}
+            f"No price found for {symbol} on {target_date}, checking previous trading days",
+            extra={"symbol": symbol, "target_date": str(target_date)},
         )
 
-        for days_back in range(1, lookback_days + 1):
-            check_date = target_date - timedelta(days=days_back)
-            price = self.session.query(MarketPrice).filter(
-                and_(
-                    MarketPrice.symbol == symbol,
-                    MarketPrice.date == check_date
+        # Use market calendar to find the most recent trading day
+        calendar = MarketCalendar()
+        check_date = target_date
+        for _ in range(lookback_days):
+            try:
+                check_date = calendar.previous_trading_day(check_date)
+            except Exception:
+                # Fallback to naive walk if calendar fails
+                check_date = check_date - timedelta(days=1)
+                while check_date.weekday() >= 5:
+                    check_date -= timedelta(days=1)
+
+            price = (
+                self.session.query(MarketPrice)
+                .filter(
+                    and_(MarketPrice.symbol == symbol, MarketPrice.date == check_date)
                 )
-            ).first()
+                .first()
+            )
 
             if price:
                 logger.debug(
-                    f"Found price for {symbol} on {check_date} ({days_back} days before {target_date})",
-                    extra={"symbol": symbol, "price_date": str(check_date)}
+                    f"Found price for {symbol} on {check_date} (nearest trading day before {target_date})",
+                    extra={"symbol": symbol, "price_date": str(check_date)},
                 )
                 return price
 
         logger.warning(
-            f"No price found for {symbol} within {lookback_days} days of {target_date}",
-            extra={"symbol": symbol, "target_date": str(target_date), "lookback_days": lookback_days}
+            f"No price found for {symbol} within {lookback_days} trading days of {target_date}",
+            extra={
+                "symbol": symbol,
+                "target_date": str(target_date),
+                "lookback_days": lookback_days,
+            },
         )
         return None
 
     def get_latest_price(self, symbol: str) -> Optional[MarketPrice]:
         """Get the most recent price for a symbol."""
-        return self.session.query(MarketPrice).filter(
-            MarketPrice.symbol == symbol
-        ).order_by(MarketPrice.date.desc()).first()
+        return (
+            self.session.query(MarketPrice)
+            .filter(MarketPrice.symbol == symbol)
+            .order_by(MarketPrice.date.desc())
+            .first()
+        )
 
     def update_prices_for_symbols(
         self,
         symbols: List[str],
         start_date: Optional[date] = None,
-        end_date: Optional[date] = None
+        end_date: Optional[date] = None,
     ) -> Dict[str, int]:
         """Update prices for multiple symbols."""
         if start_date is None:
@@ -321,38 +363,42 @@ class MarketDataClient:
             except Exception as e:
                 logger.error(
                     f"Failed to update prices for {symbol}: {e}",
-                    extra={"symbol": symbol, "error": str(e)}
+                    extra={"symbol": symbol, "error": str(e)},
                 )
                 results[symbol] = 0
 
         return results
 
     def _get_existing_prices(
-        self,
-        symbol: str,
-        start_date: date,
-        end_date: date
+        self, symbol: str, start_date: date, end_date: date
     ) -> List[MarketPrice]:
         """Get existing prices in database for date range."""
-        return self.session.query(MarketPrice).filter(
-            and_(
-                MarketPrice.symbol == symbol,
-                MarketPrice.date >= start_date,
-                MarketPrice.date <= end_date
+        return (
+            self.session.query(MarketPrice)
+            .filter(
+                and_(
+                    MarketPrice.symbol == symbol,
+                    MarketPrice.date >= start_date,
+                    MarketPrice.date <= end_date,
+                )
             )
-        ).order_by(MarketPrice.date).all()
+            .order_by(MarketPrice.date)
+            .all()
+        )
 
     def get_price_stats(self, symbol: str) -> Dict[str, Any]:
         """Get statistics about stored prices for a symbol."""
         from sqlalchemy import func
 
-        stats = self.session.query(
-            func.count(MarketPrice.id).label('count'),
-            func.min(MarketPrice.date).label('earliest_date'),
-            func.max(MarketPrice.date).label('latest_date')
-        ).filter(
-            MarketPrice.symbol == symbol
-        ).first()
+        stats = (
+            self.session.query(
+                func.count(MarketPrice.id).label("count"),
+                func.min(MarketPrice.date).label("earliest_date"),
+                func.max(MarketPrice.date).label("latest_date"),
+            )
+            .filter(MarketPrice.symbol == symbol)
+            .first()
+        )
 
         if not stats or stats.count == 0:
             return {
@@ -360,7 +406,7 @@ class MarketDataClient:
                 "count": 0,
                 "earliest_date": None,
                 "latest_date": None,
-                "latest_price": None
+                "latest_price": None,
             }
 
         latest = self.get_latest_price(symbol)
@@ -370,5 +416,5 @@ class MarketDataClient:
             "count": stats.count,
             "earliest_date": stats.earliest_date,
             "latest_date": stats.latest_date,
-            "latest_price": latest.close if latest else None
+            "latest_price": latest.close if latest else None,
         }

--- a/shit/market_data/intraday_provider.py
+++ b/shit/market_data/intraday_provider.py
@@ -1,0 +1,137 @@
+"""
+Intraday Price Provider
+Fetches intraday prices near a specific timestamp for prediction tracking.
+
+This is intentionally simple -- it fetches 1h bars for a single day and finds
+the bar closest to the requested timestamp. NOT stored in the database
+(intraday data is too voluminous). Used only to populate snapshot columns
+on PredictionOutcome at creation time.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from shit.market_data.yfinance_provider import YFinanceProvider
+from shit.market_data.market_calendar import MarketCalendar
+from shit.logging import get_service_logger
+
+logger = get_service_logger("intraday_provider")
+
+
+class IntradayPriceSnapshot:
+    """Container for intraday price data near a post timestamp."""
+
+    def __init__(
+        self,
+        price_at_post: Optional[float] = None,
+        price_1h_after: Optional[float] = None,
+        price_at_next_close: Optional[float] = None,
+    ):
+        self.price_at_post = price_at_post
+        self.price_1h_after = price_1h_after
+        self.price_at_next_close = price_at_next_close
+
+
+def fetch_intraday_snapshot(
+    symbol: str,
+    post_datetime: datetime,
+) -> IntradayPriceSnapshot:
+    """Fetch intraday prices around a post's publication time.
+
+    Captures three data points:
+    - price_at_post: The price of the closest 1h bar at or before the post time
+    - price_1h_after: The price of the bar ~1 hour after the post
+    - price_at_next_close: The daily close price of the next trading session
+      (uses the daily close from MarketPrice, not intraday)
+
+    If intraday data is not available (symbol not supported, data too old),
+    falls back gracefully by returning None for each unavailable field.
+
+    Args:
+        symbol: Ticker symbol
+        post_datetime: When the post was published (timezone-aware or naive-UTC)
+
+    Returns:
+        IntradayPriceSnapshot with available prices filled in.
+    """
+    snapshot = IntradayPriceSnapshot()
+    calendar = MarketCalendar()
+
+    # Ensure timezone-aware
+    if post_datetime.tzinfo is None:
+        post_datetime = post_datetime.replace(tzinfo=timezone.utc)
+
+    # Determine the relevant trading session
+    post_date = post_datetime.date()
+
+    # If the post is during/after market hours, the "relevant day" is today.
+    # If the post is before market open or on a non-trading day,
+    # the "relevant day" is the next trading session.
+    if calendar.is_trading_day(post_date):
+        session_close = calendar.session_close_time(post_date)
+        if session_close and post_datetime < session_close:
+            # Post is before today's close -- use today's session
+            relevant_date = post_date
+        else:
+            # Post is after today's close -- next session
+            relevant_date = calendar.next_trading_day(post_date)
+    else:
+        relevant_date = calendar.nearest_trading_day(post_date)
+
+    # Fetch 1h bars for the relevant trading day
+    provider = YFinanceProvider()
+    try:
+        bars = provider.fetch_intraday_prices(symbol, relevant_date, interval="1h")
+    except Exception as e:
+        logger.warning(
+            f"Intraday fetch failed for {symbol} on {relevant_date}: {e}",
+            extra={"symbol": symbol, "date": str(relevant_date)},
+        )
+        return snapshot
+
+    if not bars:
+        logger.debug(
+            f"No intraday bars for {symbol} on {relevant_date}",
+            extra={"symbol": symbol},
+        )
+        return snapshot
+
+    # Find the bar closest to post time (at or before)
+    bar_datetimes = []
+    for bar in bars:
+        bar_dt = bar.bar_datetime
+        if bar_dt is not None:
+            if bar_dt.tzinfo is None:
+                bar_dt = bar_dt.replace(tzinfo=timezone.utc)
+            bar_datetimes.append((bar_dt, bar))
+
+    bar_datetimes.sort(key=lambda x: x[0])
+
+    if not bar_datetimes:
+        return snapshot
+
+    # price_at_post: latest bar at or before post time
+    at_or_before = [(dt, bar) for dt, bar in bar_datetimes if dt <= post_datetime]
+    if at_or_before:
+        _, closest_bar = at_or_before[-1]
+        snapshot.price_at_post = closest_bar.close
+    else:
+        # Post is before first bar (pre-market post) -- use first bar's open
+        _, first_bar = bar_datetimes[0]
+        snapshot.price_at_post = first_bar.open if first_bar.open else first_bar.close
+
+    # price_1h_after: bar closest to post_time + 1 hour
+    target_1h = post_datetime + timedelta(hours=1)
+    at_or_before_1h = [(dt, bar) for dt, bar in bar_datetimes if dt <= target_1h]
+    if at_or_before_1h:
+        _, bar_1h = at_or_before_1h[-1]
+        snapshot.price_1h_after = bar_1h.close
+    # else: no bar available 1h after post (post too close to close)
+
+    # price_at_next_close: use the last bar's close as proxy for daily close
+    # (The actual daily close from MarketPrice table is more accurate,
+    #  so the caller should prefer that if available.)
+    _, last_bar = bar_datetimes[-1]
+    snapshot.price_at_next_close = last_bar.close
+
+    return snapshot

--- a/shit/market_data/market_calendar.py
+++ b/shit/market_data/market_calendar.py
@@ -1,0 +1,237 @@
+"""
+Market Calendar Utility
+Wraps exchange_calendars for NYSE/NASDAQ trading day awareness.
+
+Usage:
+    from shit.market_data.market_calendar import MarketCalendar
+
+    cal = MarketCalendar()
+    cal.is_trading_day(date(2025, 12, 25))  # False (Christmas)
+    cal.next_trading_day(date(2025, 7, 4))  # date(2025, 7, 7) (skip Fri holiday + weekend)
+    cal.trading_days_between(date(2025, 1, 6), date(2025, 1, 10))  # 5
+    cal.trading_day_offset(date(2025, 6, 13), 1)  # date(2025, 6, 16) -- Friday +1 = Monday
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+import exchange_calendars as xcals
+import pandas as pd
+
+from shit.logging import get_service_logger
+
+logger = get_service_logger("market_calendar")
+
+
+class MarketCalendar:
+    """NYSE/NASDAQ market calendar for trading-day arithmetic.
+
+    This class is stateless and cheap to instantiate. It wraps a singleton
+    exchange_calendars.ExchangeCalendar under the hood (the library caches
+    calendar instances internally).
+
+    All methods accept plain ``datetime.date`` objects and return plain
+    ``datetime.date`` or ``datetime.datetime`` objects -- no pandas types
+    leak into the public API.
+    """
+
+    # NYSE calendar covers both NYSE and NASDAQ holidays (same schedule)
+    _EXCHANGE_KEY = "XNYS"
+
+    def __init__(self) -> None:
+        self._cal = xcals.get_calendar(self._EXCHANGE_KEY)
+
+    # -- Trading-day queries --------------------------------------------------
+
+    def is_trading_day(self, d: date) -> bool:
+        """Return True if *d* is a regular NYSE trading session."""
+        ts = pd.Timestamp(d)
+        try:
+            return self._cal.is_session(ts)
+        except ValueError:
+            # Date outside calendar range (far future / far past)
+            return False
+
+    def next_trading_day(self, d: date) -> date:
+        """Return the next trading day strictly after *d*.
+
+        If *d* is a trading day, this returns the *following* trading day.
+        If *d* is a weekend or holiday, this returns the next open session.
+        """
+        ts = pd.Timestamp(d)
+        try:
+            return self._cal.next_session(ts).date()
+        except ValueError:
+            # Fallback: naive walk forward (handles edge of calendar range)
+            return self._naive_next_trading_day(d)
+
+    def previous_trading_day(self, d: date) -> date:
+        """Return the most recent trading day strictly before *d*."""
+        ts = pd.Timestamp(d)
+        try:
+            return self._cal.previous_session(ts).date()
+        except ValueError:
+            return self._naive_previous_trading_day(d)
+
+    def nearest_trading_day(self, d: date) -> date:
+        """Return *d* if it is a trading day, otherwise the next trading day."""
+        if self.is_trading_day(d):
+            return d
+        return self.next_trading_day(d)
+
+    def trading_day_offset(self, d: date, offset: int) -> date:
+        """Return the trading day *offset* sessions away from *d*.
+
+        Args:
+            d: Anchor date. If not a trading day, snaps to the nearest
+               trading day (next for positive offset, previous for negative).
+            offset: Number of trading days to advance (positive) or go back
+                    (negative). ``offset=0`` returns the nearest trading day.
+
+        Returns:
+            The target trading day.
+
+        Examples:
+            Friday 2025-06-13, offset=1  -> Monday 2025-06-16
+            Friday 2025-06-13, offset=3  -> Wednesday 2025-06-18
+            Saturday 2025-06-14, offset=1 -> Monday 2025-06-16
+        """
+        if offset == 0:
+            return self.nearest_trading_day(d)
+
+        # Snap to nearest session first
+        ts = pd.Timestamp(d)
+        try:
+            if self._cal.is_session(ts):
+                anchor = ts
+            elif offset > 0:
+                anchor = self._cal.date_to_session(ts, direction="next")
+            else:
+                anchor = self._cal.date_to_session(ts, direction="previous")
+            result = self._cal.session_offset(anchor, offset)
+            return result.date()
+        except ValueError:
+            # Fallback for edge-of-range dates
+            return self._naive_offset(d, offset)
+
+    def trading_days_between(self, start: date, end: date) -> int:
+        """Count the number of trading sessions in [start, end] inclusive.
+
+        Both endpoints are included if they are trading days.
+        """
+        ts_start = pd.Timestamp(start)
+        ts_end = pd.Timestamp(end)
+        try:
+            sessions = self._cal.sessions_in_range(ts_start, ts_end)
+            return len(sessions)
+        except ValueError:
+            return 0
+
+    # -- Market-hours queries -------------------------------------------------
+
+    def next_market_open(self, dt: datetime) -> datetime:
+        """Return the next NYSE market open after *dt* (timezone-aware, UTC).
+
+        If *dt* is during market hours, returns the *next day's* open.
+        If *dt* is before today's open, returns today's open (if today is a session).
+        """
+        dt_utc = self._ensure_utc(dt)
+        ts = pd.Timestamp(dt_utc)
+        result = self._cal.next_open(ts)
+        return result.to_pydatetime().replace(tzinfo=timezone.utc)
+
+    def next_market_close(self, dt: datetime) -> datetime:
+        """Return the next NYSE market close after *dt* (timezone-aware, UTC).
+
+        If *dt* is during market hours, returns *today's* close.
+        If *dt* is after today's close, returns the next session's close.
+        """
+        dt_utc = self._ensure_utc(dt)
+        ts = pd.Timestamp(dt_utc)
+        result = self._cal.next_close(ts)
+        return result.to_pydatetime().replace(tzinfo=timezone.utc)
+
+    def session_close_time(self, d: date) -> Optional[datetime]:
+        """Return the close time (UTC) for a specific session date.
+
+        Returns None if *d* is not a trading day.
+        """
+        if not self.is_trading_day(d):
+            return None
+        ts = pd.Timestamp(d)
+        close_ts = self._cal.session_close(ts)
+        return close_ts.to_pydatetime().replace(tzinfo=timezone.utc)
+
+    def session_open_time(self, d: date) -> Optional[datetime]:
+        """Return the open time (UTC) for a specific session date.
+
+        Returns None if *d* is not a trading day.
+        """
+        if not self.is_trading_day(d):
+            return None
+        ts = pd.Timestamp(d)
+        open_ts = self._cal.session_open(ts)
+        return open_ts.to_pydatetime().replace(tzinfo=timezone.utc)
+
+    def is_market_open(self, dt: datetime) -> bool:
+        """Return True if the market is open at the given datetime."""
+        dt_utc = self._ensure_utc(dt)
+        d = dt_utc.date()
+        if not self.is_trading_day(d):
+            return False
+        open_time = self.session_open_time(d)
+        close_time = self.session_close_time(d)
+        if open_time is None or close_time is None:
+            return False
+        return open_time <= dt_utc < close_time
+
+    # -- Calendar-day to trading-day conversion --------------------------------
+
+    def calendar_days_for_trading_days(self, trading_days: int) -> int:
+        """Estimate calendar days needed to span *trading_days* trading days.
+
+        More accurate than the naive 2x multiplier used in asset_queries.py.
+        Adds buffer for weekends and potential holidays.
+        """
+        # 5 trading days = 7 calendar days + 1 buffer for holidays
+        weeks = trading_days // 5
+        remainder = trading_days % 5
+        return weeks * 7 + remainder + 2  # +2 buffer for holidays
+
+    # -- Private helpers -------------------------------------------------------
+
+    @staticmethod
+    def _ensure_utc(dt: datetime) -> datetime:
+        """Ensure a datetime is timezone-aware in UTC."""
+        if dt.tzinfo is None:
+            # Assume UTC for naive datetimes
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    @staticmethod
+    def _naive_next_trading_day(d: date) -> date:
+        """Fallback: walk forward skipping weekends."""
+        candidate = d + timedelta(days=1)
+        while candidate.weekday() >= 5:  # 5=Sat, 6=Sun
+            candidate += timedelta(days=1)
+        return candidate
+
+    @staticmethod
+    def _naive_previous_trading_day(d: date) -> date:
+        """Fallback: walk backward skipping weekends."""
+        candidate = d - timedelta(days=1)
+        while candidate.weekday() >= 5:
+            candidate -= timedelta(days=1)
+        return candidate
+
+    @staticmethod
+    def _naive_offset(d: date, offset: int) -> date:
+        """Fallback: walk forward/backward by offset trading days."""
+        step = 1 if offset > 0 else -1
+        remaining = abs(offset)
+        candidate = d
+        while remaining > 0:
+            candidate += timedelta(days=step)
+            if candidate.weekday() < 5:
+                remaining -= 1
+        return candidate

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -5,7 +5,18 @@ SQLAlchemy models for tracking stock prices and prediction outcomes.
 
 from datetime import datetime, date
 from typing import Optional
-from sqlalchemy import Column, String, Date, DateTime, Float, BigInteger, ForeignKey, Integer, Boolean, Text
+from sqlalchemy import (
+    Column,
+    String,
+    Date,
+    DateTime,
+    Float,
+    BigInteger,
+    ForeignKey,
+    Integer,
+    Boolean,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from shit.db.data_models import Base, TimestampMixin, IDMixin
@@ -17,7 +28,9 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
     __tablename__ = "market_prices"
 
     # Asset identification
-    symbol = Column(String(20), nullable=False, index=True)  # Ticker symbol (AAPL, TSLA, BTC-USD, etc.)
+    symbol = Column(
+        String(20), nullable=False, index=True
+    )  # Ticker symbol (AAPL, TSLA, BTC-USD, etc.)
     date = Column(Date, nullable=False, index=True)  # Trading date
 
     # OHLCV data (Open, High, Low, Close, Volume)
@@ -32,7 +45,9 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
 
     # Data source tracking
     source = Column(String(50), default="yfinance")  # yfinance, alpha_vantage, etc.
-    last_updated = Column(DateTime, default=datetime.utcnow)  # When this data was fetched
+    last_updated = Column(
+        DateTime, default=datetime.utcnow
+    )  # When this data was fetched
 
     # Metadata
     is_market_open = Column(Boolean, default=True)  # Was market open this day?
@@ -43,9 +58,7 @@ class MarketPrice(Base, IDMixin, TimestampMixin):
         return f"<MarketPrice(symbol='{self.symbol}', date={self.date}, close=${self.close})>"
 
     # Unique constraint on symbol + date (one price record per symbol per day)
-    __table_args__ = (
-        {'sqlite_autoincrement': True},
-    )
+    __table_args__ = ({"sqlite_autoincrement": True},)
 
 
 class PredictionOutcome(Base, IDMixin, TimestampMixin):
@@ -54,19 +67,33 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     __tablename__ = "prediction_outcomes"
 
     # Link to prediction
-    prediction_id = Column(Integer, ForeignKey("predictions.id"), nullable=False, index=True)
+    prediction_id = Column(
+        Integer, ForeignKey("predictions.id"), nullable=False, index=True
+    )
 
     # Asset being tracked
     symbol = Column(String(20), nullable=False, index=True)  # Ticker symbol
 
     # Prediction details (denormalized for easier querying)
-    prediction_date = Column(Date, nullable=False, index=True)  # When prediction was made
-    prediction_sentiment = Column(String(20), nullable=True)  # bullish, bearish, neutral
+    prediction_date = Column(
+        Date, nullable=False, index=True
+    )  # When prediction was made
+    prediction_sentiment = Column(
+        String(20), nullable=True
+    )  # bullish, bearish, neutral
     prediction_confidence = Column(Float, nullable=True)  # 0.0-1.0
     prediction_timeframe_days = Column(Integer, nullable=True)  # Expected timeframe
 
-    # Price at prediction time
+    # Post publication timestamp (full datetime for intraday calculations)
+    post_published_at = Column(DateTime, nullable=True)
+
+    # Price at prediction time (daily close)
     price_at_prediction = Column(Float, nullable=True)  # Price when prediction was made
+
+    # Intraday snapshot prices (captured once at prediction creation)
+    price_at_post = Column(Float, nullable=True)  # Price when post was published
+    price_at_next_close = Column(Float, nullable=True)  # Next market close after post
+    price_1h_after = Column(Float, nullable=True)  # 1 hour after post
 
     # Outcomes at different timeframes (T+N days)
     price_t1 = Column(Float, nullable=True)  # Price after 1 day
@@ -74,23 +101,37 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     price_t7 = Column(Float, nullable=True)  # Price after 7 days
     price_t30 = Column(Float, nullable=True)  # Price after 30 days
 
-    # Returns (percentage change)
-    return_t1 = Column(Float, nullable=True)  # % change after 1 day
-    return_t3 = Column(Float, nullable=True)  # % change after 3 days
-    return_t7 = Column(Float, nullable=True)  # % change after 7 days
-    return_t30 = Column(Float, nullable=True)  # % change after 30 days
+    # Returns (percentage change) -- daily timeframes (trading days)
+    return_t1 = Column(Float, nullable=True)  # T+1 trading day
+    return_t3 = Column(Float, nullable=True)  # T+3 trading days
+    return_t7 = Column(Float, nullable=True)  # T+7 trading days
+    return_t30 = Column(Float, nullable=True)  # T+30 trading days
 
-    # Accuracy validation (was prediction correct?)
-    correct_t1 = Column(Boolean, nullable=True)  # Correct at T+1?
-    correct_t3 = Column(Boolean, nullable=True)  # Correct at T+3?
-    correct_t7 = Column(Boolean, nullable=True)  # Correct at T+7?
-    correct_t30 = Column(Boolean, nullable=True)  # Correct at T+30?
+    # Returns -- intraday timeframes
+    return_same_day = Column(
+        Float, nullable=True
+    )  # price_at_post -> price_at_next_close
+    return_1h = Column(Float, nullable=True)  # price_at_post -> price_1h_after
 
-    # Profit/Loss simulation (assuming $1000 position)
-    pnl_t1 = Column(Float, nullable=True)  # P&L after 1 day
-    pnl_t3 = Column(Float, nullable=True)  # P&L after 3 days
-    pnl_t7 = Column(Float, nullable=True)  # P&L after 7 days
-    pnl_t30 = Column(Float, nullable=True)  # P&L after 30 days
+    # Accuracy validation -- daily timeframes
+    correct_t1 = Column(Boolean, nullable=True)
+    correct_t3 = Column(Boolean, nullable=True)
+    correct_t7 = Column(Boolean, nullable=True)
+    correct_t30 = Column(Boolean, nullable=True)
+
+    # Accuracy -- intraday timeframes
+    correct_same_day = Column(Boolean, nullable=True)
+    correct_1h = Column(Boolean, nullable=True)
+
+    # Profit/Loss simulation ($1000 position) -- daily
+    pnl_t1 = Column(Float, nullable=True)
+    pnl_t3 = Column(Float, nullable=True)
+    pnl_t7 = Column(Float, nullable=True)
+    pnl_t30 = Column(Float, nullable=True)
+
+    # P&L -- intraday
+    pnl_same_day = Column(Float, nullable=True)
+    pnl_1h = Column(Float, nullable=True)
 
     # Market context (for better analysis)
     market_volatility = Column(Float, nullable=True)  # VIX or calculated volatility
@@ -107,19 +148,25 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     def __repr__(self):
         return f"<PredictionOutcome(symbol='{self.symbol}', sentiment='{self.prediction_sentiment}', return_t7={self.return_t7}%)>"
 
-    def calculate_return(self, price_initial: float, price_final: Optional[float]) -> Optional[float]:
+    def calculate_return(
+        self, price_initial: float, price_final: Optional[float]
+    ) -> Optional[float]:
         """Calculate percentage return between two prices."""
         if price_initial is None or price_final is None or price_initial == 0:
             return None
         return ((price_final - price_initial) / price_initial) * 100
 
-    def calculate_pnl(self, return_pct: Optional[float], position_size: float = 1000.0) -> Optional[float]:
+    def calculate_pnl(
+        self, return_pct: Optional[float], position_size: float = 1000.0
+    ) -> Optional[float]:
         """Calculate P&L for a given return percentage and position size."""
         if return_pct is None:
             return None
         return (return_pct / 100) * position_size
 
-    def is_correct(self, sentiment: str, return_pct: Optional[float], threshold: float = 0.5) -> Optional[bool]:
+    def is_correct(
+        self, sentiment: str, return_pct: Optional[float], threshold: float = 0.5
+    ) -> Optional[bool]:
         """
         Determine if prediction was correct based on sentiment and actual return.
 
@@ -136,11 +183,11 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
 
         sentiment = sentiment.lower()
 
-        if sentiment == 'bullish':
+        if sentiment == "bullish":
             return return_pct > threshold
-        elif sentiment == 'bearish':
+        elif sentiment == "bearish":
             return return_pct < -threshold
-        elif sentiment == 'neutral':
+        elif sentiment == "neutral":
             return abs(return_pct) <= threshold
         else:
             return None
@@ -177,7 +224,9 @@ class TickerRegistry(Base, IDMixin, TimestampMixin):
     total_price_records = Column(Integer, default=0)
 
     # Metadata
-    asset_type = Column(String(20), nullable=True)  # stock, crypto, etf, commodity, index
+    asset_type = Column(
+        String(20), nullable=True
+    )  # stock, crypto, etf, commodity, index
     exchange = Column(String(20), nullable=True)  # NYSE, NASDAQ, etc.
 
     def __repr__(self):
@@ -188,8 +237,12 @@ class TickerRegistry(Base, IDMixin, TimestampMixin):
 from sqlalchemy import Index
 
 # Create composite indexes for common queries
-Index('idx_market_price_symbol_date', MarketPrice.symbol, MarketPrice.date, unique=True)
-Index('idx_prediction_outcome_symbol_date', PredictionOutcome.symbol, PredictionOutcome.prediction_date)
-Index('idx_prediction_outcome_prediction_id', PredictionOutcome.prediction_id)
-Index('idx_ticker_registry_symbol', TickerRegistry.symbol, unique=True)
-Index('idx_ticker_registry_status', TickerRegistry.status)
+Index("idx_market_price_symbol_date", MarketPrice.symbol, MarketPrice.date, unique=True)
+Index(
+    "idx_prediction_outcome_symbol_date",
+    PredictionOutcome.symbol,
+    PredictionOutcome.prediction_date,
+)
+Index("idx_prediction_outcome_prediction_id", PredictionOutcome.prediction_id)
+Index("idx_ticker_registry_symbol", TickerRegistry.symbol, unique=True)
+Index("idx_ticker_registry_status", TickerRegistry.status)

--- a/shit/market_data/outcome_calculator.py
+++ b/shit/market_data/outcome_calculator.py
@@ -1,16 +1,25 @@
 """
 Prediction Outcome Calculator
 Calculates actual outcomes for predictions by comparing with real market data.
+
+Timeframe semantics (v2 -- trading-day based):
+- T+1 = 1 trading day after the post date (Friday -> Monday)
+- T+3 = 3 trading days after the post date
+- T+7 = 7 trading days after the post date (~1.5 calendar weeks)
+- T+30 = 30 trading days after the post date (~6 calendar weeks)
+- same_day = price_at_post -> next market close
+- 1h = price_at_post -> 1 hour after post
 """
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional, Dict, Any
-import logging
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_
+from sqlalchemy import and_
 
-from shit.market_data.models import PredictionOutcome, MarketPrice
+from shit.market_data.models import PredictionOutcome
 from shit.market_data.client import MarketDataClient
+from shit.market_data.market_calendar import MarketCalendar
+from shit.market_data.intraday_provider import fetch_intraday_snapshot
 from shit.db.sync_session import get_session
 from shit.logging import get_service_logger
 from shitvault.shitpost_models import Prediction  # noqa: F401
@@ -20,7 +29,11 @@ logger = get_service_logger("outcome_calculator")
 
 
 class OutcomeCalculator:
-    """Calculates prediction outcomes by comparing predictions with actual market data."""
+    """Calculates prediction outcomes by comparing predictions with actual market data.
+
+    Uses trading-day offsets (via MarketCalendar) for all timeframe calculations.
+    T+1 means "1 trading day later" (Friday -> Monday), not "1 calendar day later".
+    """
 
     def __init__(self, session: Optional[Session] = None):
         """
@@ -33,6 +46,7 @@ class OutcomeCalculator:
         self._session_context = None
         self._own_session = session is None
         self._failed_symbols: set = set()  # Cache of symbols that failed price fetch
+        self._calendar = MarketCalendar()
 
     def __enter__(self):
         if self._own_session:
@@ -58,7 +72,7 @@ class OutcomeCalculator:
         Returns:
             List of PredictionOutcome objects (one per asset)
         """
-        from shitvault.shitpost_models import Prediction
+        from shitvault.shitpost_models import Prediction  # noqa: F811
 
         # Get prediction
         prediction = (
@@ -99,6 +113,9 @@ class OutcomeCalculator:
             )
             return []
 
+        # Full datetime for intraday price lookups
+        post_datetime = self._get_source_datetime(prediction)
+
         outcomes = []
 
         # Calculate outcome for each asset
@@ -118,6 +135,7 @@ class OutcomeCalculator:
                     sentiment=sentiment,
                     confidence=prediction.confidence,
                     force_refresh=force_refresh,
+                    post_datetime=post_datetime,
                 )
                 if outcome:
                     outcomes.append(outcome)
@@ -145,6 +163,7 @@ class OutcomeCalculator:
         sentiment: Optional[str],
         confidence: Optional[float],
         force_refresh: bool = False,
+        post_datetime: Optional[datetime] = None,
     ) -> Optional[PredictionOutcome]:
         """Calculate outcome for a single asset prediction."""
 
@@ -226,7 +245,9 @@ class OutcomeCalculator:
 
         outcome.price_at_prediction = price_t0.close
 
-        # Calculate outcomes for different timeframes
+        # Calculate outcomes for trading-day timeframes
+        # NOTE: These are TRADING DAYS, not calendar days.
+        # T+1 on Friday = Monday. T+1 before a holiday skips the holiday.
         timeframes = [
             (1, "price_t1", "return_t1", "correct_t1", "pnl_t1"),
             (3, "price_t3", "return_t3", "correct_t3", "pnl_t3"),
@@ -236,8 +257,10 @@ class OutcomeCalculator:
 
         outcome.is_complete = True  # Assume complete until we find missing data
 
-        for days, price_attr, return_attr, correct_attr, pnl_attr in timeframes:
-            target_date = prediction_date + timedelta(days=days)
+        for trading_days, price_attr, return_attr, correct_attr, pnl_attr in timeframes:
+            target_date = self._calendar.trading_day_offset(
+                prediction_date, trading_days
+            )
 
             # Skip future dates
             if target_date > date.today():
@@ -248,15 +271,16 @@ class OutcomeCalculator:
             if getattr(outcome, price_attr) is not None:
                 continue
 
-            # Get price at T+N
+            # Get price at T+N (trading days)
             price_tn = self.market_client.get_price_on_date(symbol, target_date)
 
             if not price_tn:
-                # Try to fetch it
+                # Try to fetch it -- use calendar-aware window for the fetch range
+                fetch_start = self._calendar.previous_trading_day(target_date)
                 try:
                     self.market_client.fetch_price_history(
                         symbol,
-                        start_date=target_date - timedelta(days=7),
+                        start_date=fetch_start,
                         end_date=target_date,
                     )
                     price_tn = self.market_client.get_price_on_date(symbol, target_date)
@@ -285,6 +309,76 @@ class OutcomeCalculator:
                 setattr(outcome, pnl_attr, pnl)
             else:
                 outcome.is_complete = False
+
+        # -- Intraday timeframes (same-day close, +1 hour) --------------------
+        # Only attempt for predictions where we have the full post datetime
+        if post_datetime and price_t0:
+            outcome.post_published_at = post_datetime
+
+            # Only fetch intraday for outcomes that don't already have it
+            if outcome.price_at_post is None:
+                try:
+                    snapshot = fetch_intraday_snapshot(symbol, post_datetime)
+                    outcome.price_at_post = snapshot.price_at_post
+                    outcome.price_1h_after = snapshot.price_1h_after
+                    # Prefer daily close from MarketPrice over intraday last bar
+                    if outcome.price_at_next_close is None:
+                        # Get the next trading day's close for "same-day close"
+                        next_close_date = self._calendar.nearest_trading_day(
+                            post_datetime.date()
+                        )
+                        # If post is after market close, next close is next trading day
+                        if self._calendar.is_trading_day(post_datetime.date()):
+                            close_time = self._calendar.session_close_time(
+                                post_datetime.date()
+                            )
+                            if close_time and post_datetime >= close_time:
+                                next_close_date = self._calendar.next_trading_day(
+                                    post_datetime.date()
+                                )
+                        next_close_price = self.market_client.get_price_on_date(
+                            symbol, next_close_date
+                        )
+                        if next_close_price:
+                            outcome.price_at_next_close = next_close_price.close
+                        elif snapshot.price_at_next_close:
+                            outcome.price_at_next_close = snapshot.price_at_next_close
+                except Exception as e:
+                    logger.debug(
+                        f"Intraday snapshot failed for {symbol}: {e}",
+                        extra={"symbol": symbol, "error": str(e)},
+                    )
+
+            # Calculate intraday returns (from price_at_post, not price_at_prediction)
+            base_price = outcome.price_at_post
+            if base_price and base_price > 0:
+                # Same-day close return
+                if outcome.price_at_next_close is not None:
+                    outcome.return_same_day = outcome.calculate_return(
+                        base_price, outcome.price_at_next_close
+                    )
+                    outcome.correct_same_day = (
+                        outcome.is_correct(sentiment, outcome.return_same_day)
+                        if sentiment
+                        else None
+                    )
+                    outcome.pnl_same_day = outcome.calculate_pnl(
+                        outcome.return_same_day, position_size=1000.0
+                    )
+
+                # 1-hour return
+                if outcome.price_1h_after is not None:
+                    outcome.return_1h = outcome.calculate_return(
+                        base_price, outcome.price_1h_after
+                    )
+                    outcome.correct_1h = (
+                        outcome.is_correct(sentiment, outcome.return_1h)
+                        if sentiment
+                        else None
+                    )
+                    outcome.pnl_1h = outcome.calculate_pnl(
+                        outcome.return_1h, position_size=1000.0
+                    )
 
         outcome.last_price_update = date.today()
 
@@ -324,7 +418,7 @@ class OutcomeCalculator:
         Returns:
             Dict with statistics about processed predictions
         """
-        from shitvault.shitpost_models import Prediction
+        from shitvault.shitpost_models import Prediction  # noqa: F811
 
         query = self.session.query(Prediction).filter(
             Prediction.analysis_status == "completed"
@@ -380,7 +474,7 @@ class OutcomeCalculator:
                 )
                 stats["errors"] += 1
 
-        logger.info(f"Completed outcome calculation", extra=stats)
+        logger.info("Completed outcome calculation", extra=stats)
 
         return stats
 
@@ -537,6 +631,45 @@ class OutcomeCalculator:
             "accuracy": round(accuracy, 2),
         }
 
+    def _get_source_datetime(self, prediction) -> Optional[datetime]:
+        """Get the full datetime of the source post publication.
+
+        Unlike ``_get_source_date`` which returns only a date, this returns
+        the full datetime including time-of-day -- needed for intraday
+        price lookups (price_at_post, price_1h_after).
+
+        Returns:
+            Timezone-aware datetime (UTC), or None.
+        """
+        # Truth Social shitpost timestamp
+        try:
+            if prediction.shitpost and prediction.shitpost.timestamp:
+                ts = prediction.shitpost.timestamp
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                return ts
+        except Exception:
+            pass
+
+        # Source-agnostic signal published_at
+        try:
+            if prediction.signal and prediction.signal.published_at:
+                ts = prediction.signal.published_at
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                return ts
+        except Exception:
+            pass
+
+        # Fallback: prediction creation time
+        if prediction.created_at:
+            ts = prediction.created_at
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return ts
+
+        return None
+
     def _get_source_date(self, prediction) -> Optional[date]:
         """Get the correct anchor date for a prediction from the original post timestamp.
 
@@ -544,31 +677,14 @@ class OutcomeCalculator:
         Truth Social / another platform), NOT prediction.created_at (when
         analysis was performed).  Falls back to created_at only when no source
         timestamp is available.
+
+        Delegates to ``_get_source_datetime`` for the actual timestamp extraction,
+        then returns just the date portion.
         """
-        # Truth Social shitpost timestamp
-        try:
-            if prediction.shitpost and prediction.shitpost.timestamp:
-                return prediction.shitpost.timestamp.date()
-        except Exception:
-            pass
-
-        # Source-agnostic signal published_at
-        try:
-            if prediction.signal and prediction.signal.published_at:
-                return prediction.signal.published_at.date()
-        except Exception:
-            pass
-
-        # Fallback: prediction creation time (analysis time)
-        if prediction.created_at:
-            logger.debug(
-                f"Prediction {prediction.id}: falling back to created_at "
-                f"(no shitpost/signal timestamp found)",
-                extra={"prediction_id": prediction.id},
-            )
-            return prediction.created_at.date()
-
-        return None
+        dt = self._get_source_datetime(prediction)
+        if dt is None:
+            return None
+        return dt.date()
 
     def _extract_sentiment(
         self, market_impact: Dict[str, Any], asset: Optional[str] = None

--- a/shit/market_data/price_provider.py
+++ b/shit/market_data/price_provider.py
@@ -5,7 +5,7 @@ Defines the interface for market data sources (yfinance, Alpha Vantage, etc.).
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import List, Optional
 
 from shit.logging import get_service_logger
@@ -19,6 +19,7 @@ class RawPriceRecord:
 
     This is a plain data transfer object -- no SQLAlchemy dependency.
     """
+
     symbol: str
     date: date
     open: Optional[float]
@@ -28,6 +29,7 @@ class RawPriceRecord:
     volume: Optional[int]
     adjusted_close: Optional[float]
     source: str  # e.g. "yfinance", "alphavantage"
+    bar_datetime: Optional[datetime] = None  # Full datetime for intraday bars
 
 
 class PriceProvider(ABC):
@@ -74,7 +76,12 @@ class PriceProvider(ABC):
 class ProviderError(Exception):
     """Raised when a price provider fails to fetch data."""
 
-    def __init__(self, provider_name: str, message: str, original_error: Optional[Exception] = None):
+    def __init__(
+        self,
+        provider_name: str,
+        message: str,
+        original_error: Optional[Exception] = None,
+    ):
         self.provider_name = provider_name
         self.original_error = original_error
         super().__init__(f"[{provider_name}] {message}")
@@ -118,30 +125,37 @@ class ProviderChain:
             try:
                 logger.info(
                     f"Attempting {provider.name} for {symbol}",
-                    extra={"provider": provider.name, "symbol": symbol}
+                    extra={"provider": provider.name, "symbol": symbol},
                 )
                 records = provider.fetch_prices(symbol, start_date, end_date)
                 if records:
                     logger.info(
                         f"{provider.name} returned {len(records)} records for {symbol}",
-                        extra={"provider": provider.name, "symbol": symbol, "count": len(records)}
+                        extra={
+                            "provider": provider.name,
+                            "symbol": symbol,
+                            "count": len(records),
+                        },
                     )
                     return records
                 else:
                     logger.warning(
                         f"{provider.name} returned empty results for {symbol}",
-                        extra={"provider": provider.name, "symbol": symbol}
+                        extra={"provider": provider.name, "symbol": symbol},
                     )
             except Exception as e:
                 logger.warning(
                     f"{provider.name} failed for {symbol}: {e}",
-                    extra={"provider": provider.name, "symbol": symbol, "error": str(e)}
+                    extra={
+                        "provider": provider.name,
+                        "symbol": symbol,
+                        "error": str(e),
+                    },
                 )
                 errors.append(ProviderError(provider.name, str(e), original_error=e))
 
         # All providers failed
         error_summary = "; ".join(str(e) for e in errors)
         raise ProviderError(
-            "all_providers",
-            f"All providers failed for {symbol}: {error_summary}"
+            "all_providers", f"All providers failed for {symbol}: {error_summary}"
         )

--- a/shit/market_data/yfinance_provider.py
+++ b/shit/market_data/yfinance_provider.py
@@ -42,23 +42,31 @@ class YFinanceProvider(PriceProvider):
             if hist.empty:
                 logger.warning(
                     f"yfinance returned empty data for {symbol}",
-                    extra={"symbol": symbol}
+                    extra={"symbol": symbol},
                 )
                 return []
 
             records = []
             for idx, row in hist.iterrows():
-                price_date = idx.date() if hasattr(idx, 'date') else idx
+                price_date = idx.date() if hasattr(idx, "date") else idx
 
                 record = RawPriceRecord(
                     symbol=symbol,
                     date=price_date,
-                    open=float(row['Open']) if 'Open' in row and row['Open'] is not None else None,
-                    high=float(row['High']) if 'High' in row and row['High'] is not None else None,
-                    low=float(row['Low']) if 'Low' in row and row['Low'] is not None else None,
-                    close=float(row['Close']) if 'Close' in row else 0.0,
-                    volume=int(row['Volume']) if 'Volume' in row and row['Volume'] is not None else None,
-                    adjusted_close=float(row['Close']) if 'Close' in row else None,
+                    open=float(row["Open"])
+                    if "Open" in row and row["Open"] is not None
+                    else None,
+                    high=float(row["High"])
+                    if "High" in row and row["High"] is not None
+                    else None,
+                    low=float(row["Low"])
+                    if "Low" in row and row["Low"] is not None
+                    else None,
+                    close=float(row["Close"]) if "Close" in row else 0.0,
+                    volume=int(row["Volume"])
+                    if "Volume" in row and row["Volume"] is not None
+                    else None,
+                    adjusted_close=float(row["Close"]) if "Close" in row else None,
                     source="yfinance",
                 )
                 records.append(record)
@@ -66,4 +74,82 @@ class YFinanceProvider(PriceProvider):
             return records
 
         except Exception as e:
-            raise ProviderError("yfinance", f"Failed to fetch {symbol}: {e}", original_error=e)
+            raise ProviderError(
+                "yfinance", f"Failed to fetch {symbol}: {e}", original_error=e
+            )
+
+    def fetch_intraday_prices(
+        self,
+        symbol: str,
+        target_date: date,
+        interval: str = "1h",
+    ) -> List[RawPriceRecord]:
+        """Fetch intraday price data from yfinance for a specific date.
+
+        yfinance limitations:
+        - 1m data: last 30 days only
+        - 1h data: last 730 days
+        - Data may not be available for all symbols (e.g., some ETFs)
+
+        Args:
+            symbol: Ticker symbol (e.g., 'AAPL')
+            target_date: The date to fetch intraday data for
+            interval: Price interval ('1h', '5m', '1m'). Default '1h'.
+
+        Returns:
+            List of RawPriceRecord with intraday timestamps.
+            Records have ``bar_datetime`` set to the bar's datetime.
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            start = target_date
+            end = target_date + timedelta(days=1)
+            hist = ticker.history(start=start, end=end, interval=interval)
+
+            if hist.empty:
+                logger.debug(
+                    f"yfinance returned no intraday data for {symbol} on {target_date}",
+                    extra={
+                        "symbol": symbol,
+                        "date": str(target_date),
+                        "interval": interval,
+                    },
+                )
+                return []
+
+            records = []
+            for idx, row in hist.iterrows():
+                bar_dt = idx.to_pydatetime() if hasattr(idx, "to_pydatetime") else idx
+                # Store the bar date (not the intraday timestamp) for RawPriceRecord
+                bar_date = bar_dt.date() if hasattr(bar_dt, "date") else bar_dt
+
+                record = RawPriceRecord(
+                    symbol=symbol,
+                    date=bar_date,
+                    open=float(row["Open"])
+                    if "Open" in row and row["Open"] is not None
+                    else None,
+                    high=float(row["High"])
+                    if "High" in row and row["High"] is not None
+                    else None,
+                    low=float(row["Low"])
+                    if "Low" in row and row["Low"] is not None
+                    else None,
+                    close=float(row["Close"]) if "Close" in row else 0.0,
+                    volume=int(row["Volume"])
+                    if "Volume" in row and row["Volume"] is not None
+                    else None,
+                    adjusted_close=None,
+                    source="yfinance_intraday",
+                    bar_datetime=bar_dt,
+                )
+                records.append(record)
+
+            return records
+
+        except Exception as e:
+            logger.warning(
+                f"Failed to fetch intraday data for {symbol} on {target_date}: {e}",
+                extra={"symbol": symbol, "date": str(target_date), "error": str(e)},
+            )
+            return []

--- a/shit_tests/shit/market_data/test_intraday_provider.py
+++ b/shit_tests/shit/market_data/test_intraday_provider.py
@@ -1,0 +1,198 @@
+"""Tests for intraday_provider.py."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import patch, MagicMock
+
+from shit.market_data.intraday_provider import (
+    IntradayPriceSnapshot,
+    fetch_intraday_snapshot,
+)
+
+
+class TestIntradayPriceSnapshot:
+    def test_defaults_to_none(self):
+        snap = IntradayPriceSnapshot()
+        assert snap.price_at_post is None
+        assert snap.price_1h_after is None
+        assert snap.price_at_next_close is None
+
+    def test_accepts_values(self):
+        snap = IntradayPriceSnapshot(
+            price_at_post=150.0,
+            price_1h_after=151.0,
+            price_at_next_close=149.5,
+        )
+        assert snap.price_at_post == 150.0
+        assert snap.price_1h_after == 151.0
+        assert snap.price_at_next_close == 149.5
+
+
+class TestFetchIntradaySnapshot:
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_returns_empty_snapshot_when_no_bars(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+        mock_cal.nearest_trading_day.return_value = date(2025, 6, 16)
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = []
+
+        result = fetch_intraday_snapshot(
+            "AAPL", datetime(2025, 6, 16, 14, 0, tzinfo=timezone.utc)
+        )
+        assert result.price_at_post is None
+        assert result.price_1h_after is None
+        assert result.price_at_next_close is None
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_finds_price_at_post(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+        mock_cal.nearest_trading_day.return_value = date(2025, 6, 16)
+
+        # Create mock bars with bar_datetime as formal field
+        bar1 = MagicMock()
+        bar1.close = 150.0
+        bar1.open = 149.5
+        bar1.bar_datetime = datetime(2025, 6, 16, 13, 30, tzinfo=timezone.utc)
+
+        bar2 = MagicMock()
+        bar2.close = 151.0
+        bar2.open = 150.0
+        bar2.bar_datetime = datetime(2025, 6, 16, 14, 30, tzinfo=timezone.utc)
+
+        bar3 = MagicMock()
+        bar3.close = 152.0
+        bar3.open = 151.0
+        bar3.bar_datetime = datetime(2025, 6, 16, 15, 30, tzinfo=timezone.utc)
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = [bar1, bar2, bar3]
+
+        # Post at 2:15 PM UTC
+        result = fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 16, 14, 15, tzinfo=timezone.utc),
+        )
+        # Closest bar at or before 2:15 PM is bar1 (1:30 PM)
+        assert result.price_at_post == 150.0
+        # 1h after 2:15 PM is 3:15 PM, closest bar at/before that is bar2 (2:30 PM)
+        assert result.price_1h_after == 151.0
+        # price_at_next_close is last bar's close
+        assert result.price_at_next_close == 152.0
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_premarket_post_uses_first_bar_open(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+        mock_cal.nearest_trading_day.return_value = date(2025, 6, 16)
+
+        bar1 = MagicMock()
+        bar1.close = 150.0
+        bar1.open = 149.0
+        bar1.bar_datetime = datetime(2025, 6, 16, 13, 30, tzinfo=timezone.utc)
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = [bar1]
+
+        # Post at 10:00 AM UTC (before 1:30 PM bar)
+        result = fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 16, 10, 0, tzinfo=timezone.utc),
+        )
+        # Pre-market: use first bar's open
+        assert result.price_at_post == 149.0
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_non_trading_day_uses_next_session(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = False
+        mock_cal.nearest_trading_day.return_value = date(2025, 6, 16)  # Monday
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = []
+
+        # Post on Saturday
+        fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 14, 12, 0, tzinfo=timezone.utc),
+        )
+        # Should have called fetch_intraday_prices with Monday's date
+        mock_provider.fetch_intraday_prices.assert_called_once_with(
+            "AAPL", date(2025, 6, 16), interval="1h"
+        )
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_after_close_uses_next_session(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+        mock_cal.next_trading_day.return_value = date(2025, 6, 17)
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = []
+
+        # Post at 9 PM UTC (after close)
+        fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 16, 21, 0, tzinfo=timezone.utc),
+        )
+        # Should have called fetch_intraday_prices with next trading day
+        mock_provider.fetch_intraday_prices.assert_called_once_with(
+            "AAPL", date(2025, 6, 17), interval="1h"
+        )
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_handles_fetch_exception_gracefully(self, mock_cal_cls, mock_yf_cls):
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.side_effect = RuntimeError("network error")
+
+        result = fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 16, 14, 0, tzinfo=timezone.utc),
+        )
+        assert result.price_at_post is None
+        assert result.price_1h_after is None
+
+    @patch("shit.market_data.intraday_provider.YFinanceProvider")
+    @patch("shit.market_data.intraday_provider.MarketCalendar")
+    def test_naive_datetime_assumed_utc(self, mock_cal_cls, mock_yf_cls):
+        """Naive datetimes should be treated as UTC."""
+        mock_cal = mock_cal_cls.return_value
+        mock_cal.is_trading_day.return_value = True
+        mock_cal.session_close_time.return_value = datetime(
+            2025, 6, 16, 20, 0, tzinfo=timezone.utc
+        )
+
+        mock_provider = mock_yf_cls.return_value
+        mock_provider.fetch_intraday_prices.return_value = []
+
+        # Should not raise -- naive datetime gets UTC timezone
+        result = fetch_intraday_snapshot(
+            "AAPL",
+            datetime(2025, 6, 16, 14, 0),  # naive
+        )
+        assert result.price_at_post is None

--- a/shit_tests/shit/market_data/test_market_calendar.py
+++ b/shit_tests/shit/market_data/test_market_calendar.py
@@ -1,0 +1,215 @@
+"""Tests for MarketCalendar (shit/market_data/market_calendar.py)."""
+
+import pytest
+from datetime import date, datetime, timezone
+
+from shit.market_data.market_calendar import MarketCalendar
+
+
+@pytest.fixture
+def cal():
+    return MarketCalendar()
+
+
+class TestIsTradingDay:
+    def test_weekday_is_trading_day(self, cal):
+        # Monday 2025-06-16
+        assert cal.is_trading_day(date(2025, 6, 16)) is True
+
+    def test_saturday_is_not_trading_day(self, cal):
+        assert cal.is_trading_day(date(2025, 6, 14)) is False
+
+    def test_sunday_is_not_trading_day(self, cal):
+        assert cal.is_trading_day(date(2025, 6, 15)) is False
+
+    def test_christmas_is_not_trading_day(self, cal):
+        assert cal.is_trading_day(date(2025, 12, 25)) is False
+
+    def test_july_4th_is_not_trading_day(self, cal):
+        assert cal.is_trading_day(date(2025, 7, 4)) is False
+
+    def test_new_years_day_is_not_trading_day(self, cal):
+        assert cal.is_trading_day(date(2026, 1, 1)) is False
+
+
+class TestNextTradingDay:
+    def test_friday_next_is_monday(self, cal):
+        result = cal.next_trading_day(date(2025, 6, 13))  # Friday
+        assert result == date(2025, 6, 16)  # Monday
+
+    def test_saturday_next_is_monday(self, cal):
+        result = cal.next_trading_day(date(2025, 6, 14))  # Saturday
+        assert result == date(2025, 6, 16)
+
+    def test_wednesday_next_is_thursday(self, cal):
+        result = cal.next_trading_day(date(2025, 6, 11))  # Wednesday
+        assert result == date(2025, 6, 12)  # Thursday
+
+    def test_day_before_holiday_skips_holiday(self, cal):
+        # July 3 2025 is Thursday, July 4 is holiday, next = July 7 (Monday)
+        result = cal.next_trading_day(date(2025, 7, 3))
+        assert result == date(2025, 7, 7)
+
+
+class TestPreviousTradingDay:
+    def test_monday_previous_is_friday(self, cal):
+        result = cal.previous_trading_day(date(2025, 6, 16))  # Monday
+        assert result == date(2025, 6, 13)  # Friday
+
+    def test_sunday_previous_is_friday(self, cal):
+        result = cal.previous_trading_day(date(2025, 6, 15))  # Sunday
+        assert result == date(2025, 6, 13)  # Friday
+
+
+class TestTradingDayOffset:
+    def test_t_plus_1_on_friday_is_monday(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 13), 1)  # Friday +1
+        assert result == date(2025, 6, 16)  # Monday
+
+    def test_t_plus_3_on_friday(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 13), 3)  # Friday +3
+        assert result == date(2025, 6, 18)  # Wednesday
+
+    def test_t_plus_7_spans_full_week(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 9), 7)  # Monday +7
+        assert result == date(2025, 6, 18)  # Next Wednesday
+
+    def test_t_plus_1_on_saturday_snaps_forward(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 14), 1)  # Saturday +1
+        assert result == date(2025, 6, 17)  # Tuesday (Monday=snap + 1)
+
+    def test_offset_zero_returns_nearest_trading_day(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 14), 0)  # Saturday
+        assert result == date(2025, 6, 16)  # Monday
+
+    def test_negative_offset(self, cal):
+        result = cal.trading_day_offset(date(2025, 6, 16), -1)  # Monday -1
+        assert result == date(2025, 6, 13)  # Friday
+
+    def test_offset_across_holiday(self, cal):
+        # July 3 2025 (Thu) + 1 should skip July 4 (holiday) -> July 7 (Mon)
+        result = cal.trading_day_offset(date(2025, 7, 3), 1)
+        assert result == date(2025, 7, 7)
+
+
+class TestTradingDaysBetween:
+    def test_monday_to_friday_is_5(self, cal):
+        result = cal.trading_days_between(date(2025, 6, 9), date(2025, 6, 13))
+        assert result == 5
+
+    def test_friday_to_monday_is_2(self, cal):
+        result = cal.trading_days_between(date(2025, 6, 13), date(2025, 6, 16))
+        assert result == 2
+
+    def test_same_day_trading_day_is_1(self, cal):
+        result = cal.trading_days_between(date(2025, 6, 9), date(2025, 6, 9))
+        assert result == 1
+
+    def test_same_day_non_trading_is_0(self, cal):
+        result = cal.trading_days_between(date(2025, 6, 14), date(2025, 6, 14))
+        assert result == 0
+
+
+class TestMarketHours:
+    def test_next_market_close_during_hours(self, cal):
+        # 2 PM UTC on a Monday (10 AM ET) -- market is open, close is 8 PM UTC (4 PM ET)
+        dt = datetime(2025, 6, 16, 14, 0, 0, tzinfo=timezone.utc)
+        result = cal.next_market_close(dt)
+        assert result.date() == date(2025, 6, 16)
+
+    def test_next_market_close_after_hours(self, cal):
+        # 9 PM UTC on Monday (5 PM ET) -- after close, next close is Tuesday
+        dt = datetime(2025, 6, 16, 21, 0, 0, tzinfo=timezone.utc)
+        result = cal.next_market_close(dt)
+        assert result.date() == date(2025, 6, 17)
+
+    def test_next_market_close_on_weekend(self, cal):
+        dt = datetime(2025, 6, 14, 12, 0, 0, tzinfo=timezone.utc)  # Saturday
+        result = cal.next_market_close(dt)
+        assert result.date() == date(2025, 6, 16)  # Monday's close
+
+    def test_is_market_open_during_session(self, cal):
+        # 2 PM UTC (10 AM ET) on a trading day
+        dt = datetime(2025, 6, 16, 14, 0, 0, tzinfo=timezone.utc)
+        assert cal.is_market_open(dt) is True
+
+    def test_is_market_open_after_close(self, cal):
+        dt = datetime(2025, 6, 16, 21, 0, 0, tzinfo=timezone.utc)
+        assert cal.is_market_open(dt) is False
+
+    def test_is_market_open_on_weekend(self, cal):
+        dt = datetime(2025, 6, 14, 14, 0, 0, tzinfo=timezone.utc)
+        assert cal.is_market_open(dt) is False
+
+
+class TestSessionTimes:
+    def test_session_open_time_returns_datetime(self, cal):
+        result = cal.session_open_time(date(2025, 6, 16))  # Monday
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
+    def test_session_close_time_returns_datetime(self, cal):
+        result = cal.session_close_time(date(2025, 6, 16))  # Monday
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
+    def test_session_open_time_non_trading_day_returns_none(self, cal):
+        assert cal.session_open_time(date(2025, 6, 14)) is None  # Saturday
+
+    def test_session_close_time_non_trading_day_returns_none(self, cal):
+        assert cal.session_close_time(date(2025, 6, 14)) is None  # Saturday
+
+
+class TestCalendarDaysForTradingDays:
+    def test_5_trading_days(self, cal):
+        result = cal.calendar_days_for_trading_days(5)
+        assert result == 9  # 7 + 2 buffer
+
+    def test_1_trading_day(self, cal):
+        result = cal.calendar_days_for_trading_days(1)
+        assert result == 3  # 1 + 2 buffer
+
+    def test_30_trading_days(self, cal):
+        result = cal.calendar_days_for_trading_days(30)
+        assert result == 44  # 6*7 + 0 + 2
+
+
+class TestNaiveFallbacks:
+    """Test that fallback methods work when exchange_calendars fails."""
+
+    def test_naive_next_trading_day_skips_weekend(self):
+        result = MarketCalendar._naive_next_trading_day(date(2025, 6, 13))
+        assert result == date(2025, 6, 16)
+
+    def test_naive_previous_trading_day_skips_weekend(self):
+        result = MarketCalendar._naive_previous_trading_day(date(2025, 6, 16))
+        assert result == date(2025, 6, 13)
+
+    def test_naive_offset_forward(self):
+        result = MarketCalendar._naive_offset(date(2025, 6, 13), 3)
+        assert result == date(2025, 6, 18)
+
+    def test_naive_offset_backward(self):
+        result = MarketCalendar._naive_offset(date(2025, 6, 16), -1)
+        assert result == date(2025, 6, 13)
+
+    def test_ensure_utc_naive_datetime(self):
+        dt = datetime(2025, 6, 16, 14, 0, 0)
+        result = MarketCalendar._ensure_utc(dt)
+        assert result.tzinfo == timezone.utc
+        assert result.hour == 14
+
+    def test_ensure_utc_aware_datetime(self):
+        dt = datetime(2025, 6, 16, 14, 0, 0, tzinfo=timezone.utc)
+        result = MarketCalendar._ensure_utc(dt)
+        assert result.tzinfo == timezone.utc
+
+
+class TestNearestTradingDay:
+    def test_trading_day_returns_same(self, cal):
+        result = cal.nearest_trading_day(date(2025, 6, 16))  # Monday
+        assert result == date(2025, 6, 16)
+
+    def test_weekend_returns_next_monday(self, cal):
+        result = cal.nearest_trading_day(date(2025, 6, 14))  # Saturday
+        assert result == date(2025, 6, 16)  # Monday

--- a/shit_tests/shit/market_data/test_outcome_calculator.py
+++ b/shit_tests/shit/market_data/test_outcome_calculator.py
@@ -1,7 +1,7 @@
 """Tests for OutcomeCalculator (shit/market_data/outcome_calculator.py)."""
 
 import pytest
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from sqlalchemy.orm import Session
 
@@ -18,6 +18,15 @@ def mock_session():
 def calculator(mock_session):
     calc = OutcomeCalculator(session=mock_session)
     calc.market_client = MagicMock()
+    # Mock the market calendar to behave like simple date arithmetic for existing tests
+    mock_calendar = MagicMock()
+    mock_calendar.trading_day_offset.side_effect = lambda d, n: d + timedelta(days=n)
+    mock_calendar.previous_trading_day.side_effect = lambda d: d - timedelta(days=1)
+    mock_calendar.nearest_trading_day.side_effect = lambda d: d
+    mock_calendar.is_trading_day.return_value = True
+    mock_calendar.session_close_time.return_value = None
+    mock_calendar.next_trading_day.side_effect = lambda d: d + timedelta(days=1)
+    calc._calendar = mock_calendar
     return calc
 
 
@@ -344,7 +353,7 @@ class TestCalculateSingleOutcome:
         calculator.market_client.get_price_on_date.return_value = None
         calculator.market_client.fetch_price_history.return_value = []
 
-        result = calculator._calculate_single_outcome(
+        calculator._calculate_single_outcome(
             prediction_id=1,
             symbol="AAPL",
             prediction_date=date(2025, 6, 15),
@@ -465,3 +474,249 @@ class TestGetAccuracyStats:
         result = calculator.get_accuracy_stats()
         assert result["accuracy"] == 0.0
         assert result["pending"] == 2
+
+
+# -- _get_source_datetime ---------------------------------------------------
+
+
+class TestGetSourceDatetime:
+    def test_returns_datetime_from_shitpost(self, calculator):
+        pred = _make_prediction(
+            shitpost_timestamp=datetime(2025, 6, 14, 9, 30, 0),
+        )
+        result = calculator._get_source_datetime(pred)
+        assert result == datetime(2025, 6, 14, 9, 30, 0, tzinfo=timezone.utc)
+
+    def test_returns_none_when_no_timestamps(self, calculator):
+        pred = _make_prediction(shitpost=None, signal=None, created_at=None)
+        result = calculator._get_source_datetime(pred)
+        assert result is None
+
+    def test_returns_datetime_from_signal(self, calculator):
+        signal = MagicMock()
+        signal.published_at = datetime(2025, 7, 1, 8, 0, 0)
+
+        pred = _make_prediction(shitpost=None, signal=signal)
+        result = calculator._get_source_datetime(pred)
+        assert result == datetime(2025, 7, 1, 8, 0, 0, tzinfo=timezone.utc)
+
+    def test_falls_back_to_created_at(self, calculator):
+        pred = _make_prediction(
+            shitpost=None,
+            signal=None,
+            created_at=datetime(2025, 6, 15, 10, 0, 0),
+        )
+        result = calculator._get_source_datetime(pred)
+        assert result == datetime(2025, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_preserves_timezone_if_already_aware(self, calculator):
+        pred = _make_prediction(
+            shitpost_timestamp=datetime(2025, 6, 14, 9, 30, 0, tzinfo=timezone.utc),
+        )
+        result = calculator._get_source_datetime(pred)
+        assert result.tzinfo == timezone.utc
+
+    def test_get_source_date_delegates_to_get_source_datetime(self, calculator):
+        """Verify _get_source_date returns the date of _get_source_datetime's result."""
+        pred = _make_prediction(
+            shitpost_timestamp=datetime(2025, 6, 14, 23, 59, 0),
+        )
+        date_result = calculator._get_source_date(pred)
+        dt_result = calculator._get_source_datetime(pred)
+        assert date_result == dt_result.date()
+
+
+# -- Trading-day timeframes --------------------------------------------------
+
+
+class TestTradingDayTimeframes:
+    """Verify that outcome calculation uses trading days, not calendar days."""
+
+    @patch("shit.market_data.outcome_calculator.fetch_intraday_snapshot")
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_friday_prediction_t1_is_monday(
+        self, mock_date, mock_intraday, calculator, mock_session
+    ):
+        """T+1 on Friday should use Monday's close, not Saturday."""
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        mock_intraday.return_value = MagicMock(
+            price_at_post=None, price_1h_after=None, price_at_next_close=None
+        )
+
+        # Override calendar mock to use real trading-day logic
+        from shit.market_data.market_calendar import MarketCalendar
+
+        real_cal = MarketCalendar()
+        calculator._calendar = real_cal
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_price = MagicMock(close=100.0)
+        calculator.market_client.get_price_on_date.return_value = mock_price
+
+        calculator._calculate_single_outcome(
+            prediction_id=1,
+            symbol="AAPL",
+            prediction_date=date(2025, 6, 13),  # Friday
+            sentiment="bullish",
+            confidence=0.8,
+        )
+
+        # Verify T+1 call was for Monday June 16, not Saturday June 14
+        calls = calculator.market_client.get_price_on_date.call_args_list
+        # First call is price_at_prediction (June 13)
+        # Second call should be T+1 = June 16 (Monday)
+        t1_call_date = calls[1][0][1]  # second positional arg of second call
+        assert t1_call_date == date(2025, 6, 16)
+
+    @patch("shit.market_data.outcome_calculator.fetch_intraday_snapshot")
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_holiday_skip(self, mock_date, mock_intraday, calculator, mock_session):
+        """T+1 before July 4 holiday should skip to the next trading day."""
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        mock_intraday.return_value = MagicMock(
+            price_at_post=None, price_1h_after=None, price_at_next_close=None
+        )
+
+        from shit.market_data.market_calendar import MarketCalendar
+
+        real_cal = MarketCalendar()
+        calculator._calendar = real_cal
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_price = MagicMock(close=100.0)
+        calculator.market_client.get_price_on_date.return_value = mock_price
+
+        calculator._calculate_single_outcome(
+            prediction_id=1,
+            symbol="AAPL",
+            prediction_date=date(2025, 7, 3),  # Thursday before July 4
+            sentiment="bullish",
+            confidence=0.8,
+        )
+
+        calls = calculator.market_client.get_price_on_date.call_args_list
+        # T+1 should be July 7 (Monday), skipping July 4 (holiday) and weekend
+        t1_call_date = calls[1][0][1]
+        assert t1_call_date == date(2025, 7, 7)
+
+
+# -- Intraday calculations --------------------------------------------------
+
+
+class TestIntradayCalculations:
+    """Verify intraday snapshot integration in _calculate_single_outcome."""
+
+    @patch("shit.market_data.outcome_calculator.fetch_intraday_snapshot")
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_intraday_fields_populated_when_post_datetime_provided(
+        self, mock_date, mock_intraday, calculator, mock_session
+    ):
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        # Set up intraday snapshot
+        mock_snapshot = MagicMock()
+        mock_snapshot.price_at_post = 149.0
+        mock_snapshot.price_1h_after = 151.0
+        mock_snapshot.price_at_next_close = 150.0
+        mock_intraday.return_value = mock_snapshot
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_price = MagicMock(close=100.0)
+        calculator.market_client.get_price_on_date.return_value = mock_price
+
+        post_dt = datetime(2025, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
+        result = calculator._calculate_single_outcome(
+            prediction_id=1,
+            symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish",
+            confidence=0.8,
+            post_datetime=post_dt,
+        )
+
+        assert result is not None
+        assert result.post_published_at == post_dt
+        assert result.price_at_post == 149.0
+        assert result.price_1h_after == 151.0
+
+    @patch("shit.market_data.outcome_calculator.fetch_intraday_snapshot")
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_intraday_skipped_when_no_post_datetime(
+        self, mock_date, mock_intraday, calculator, mock_session
+    ):
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_price = MagicMock(close=100.0)
+        calculator.market_client.get_price_on_date.return_value = mock_price
+
+        result = calculator._calculate_single_outcome(
+            prediction_id=1,
+            symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish",
+            confidence=0.8,
+            post_datetime=None,  # No post datetime
+        )
+
+        assert result is not None
+        # Intraday should not be attempted
+        mock_intraday.assert_not_called()
+
+    @patch("shit.market_data.outcome_calculator.fetch_intraday_snapshot")
+    @patch("shit.market_data.outcome_calculator.date")
+    def test_intraday_returns_calculated(
+        self, mock_date, mock_intraday, calculator, mock_session
+    ):
+        mock_date.today.return_value = date(2025, 7, 20)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.price_at_post = 100.0
+        mock_snapshot.price_1h_after = 102.0
+        mock_snapshot.price_at_next_close = 105.0
+        mock_intraday.return_value = mock_snapshot
+
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        # price_t0 = 100, timeframe prices = 110
+        # For the intraday "next close" lookup, return a different daily close
+        mock_price_t0 = MagicMock(close=100.0)
+        mock_price_tn = MagicMock(close=110.0)
+        mock_daily_close = MagicMock(close=105.0)  # same as snapshot for consistency
+
+        # Control which dates return which prices:
+        # 1st call: price_at_prediction (t0)
+        # 2nd-5th: timeframe prices (t1,t3,t7,t30)
+        # 6th: intraday "next close date" lookup -> daily close of 105
+        calculator.market_client.get_price_on_date.side_effect = [
+            mock_price_t0,  # price at prediction
+            mock_price_tn,  # T+1
+            mock_price_tn,  # T+3
+            mock_price_tn,  # T+7
+            mock_price_tn,  # T+30
+            mock_daily_close,  # next close date for intraday
+        ]
+
+        post_dt = datetime(2025, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
+        result = calculator._calculate_single_outcome(
+            prediction_id=1,
+            symbol="AAPL",
+            prediction_date=date(2025, 6, 15),
+            sentiment="bullish",
+            confidence=0.8,
+            post_datetime=post_dt,
+        )
+
+        assert result is not None
+        # return_1h: (102 - 100) / 100 * 100 = 2.0%
+        assert result.return_1h == 2.0
+        assert result.correct_1h is True  # bullish + positive
+        # return_same_day: (105 - 100) / 100 * 100 = 5.0%
+        # (105 comes from the daily close MarketPrice, which is preferred over snapshot)
+        assert result.return_same_day == 5.0
+        assert result.correct_same_day is True

--- a/shit_tests/shit/market_data/test_outcome_maturation.py
+++ b/shit_tests/shit/market_data/test_outcome_maturation.py
@@ -6,7 +6,7 @@ import os
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 import pytest
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 from sqlalchemy.orm import Session
 
@@ -23,6 +23,15 @@ def mock_session():
 def calculator(mock_session):
     calc = OutcomeCalculator(session=mock_session)
     calc.market_client = MagicMock()
+    # Mock the market calendar to behave like simple date arithmetic for existing tests
+    mock_calendar = MagicMock()
+    mock_calendar.trading_day_offset.side_effect = lambda d, n: d + timedelta(days=n)
+    mock_calendar.previous_trading_day.side_effect = lambda d: d - timedelta(days=1)
+    mock_calendar.nearest_trading_day.side_effect = lambda d: d
+    mock_calendar.is_trading_day.return_value = True
+    mock_calendar.session_close_time.return_value = None
+    mock_calendar.next_trading_day.side_effect = lambda d: d + timedelta(days=1)
+    calc._calendar = mock_calendar
     return calc
 
 
@@ -71,7 +80,11 @@ class TestMatureOutcomes:
         o1 = _make_incomplete_outcome(prediction_id=1, symbol="AAPL")
         o2 = _make_incomplete_outcome(prediction_id=1, symbol="TSLA")
         o3 = _make_incomplete_outcome(prediction_id=2, symbol="GOOG")
-        mock_session.query.return_value.filter.return_value.all.return_value = [o1, o2, o3]
+        mock_session.query.return_value.filter.return_value.all.return_value = [
+            o1,
+            o2,
+            o3,
+        ]
 
         # Mock calculate_outcome_for_prediction to return outcomes
         mock_outcome_complete = MagicMock(is_complete=True)
@@ -168,11 +181,15 @@ class TestMatureOutcomes:
 class TestFixedEarlyReturn:
     """Tests for the fixed early-return in _calculate_single_outcome."""
 
-    def test_returns_existing_when_complete_and_no_force(self, calculator, mock_session):
+    def test_returns_existing_when_complete_and_no_force(
+        self, calculator, mock_session
+    ):
         """Complete outcomes are still returned immediately without re-evaluation."""
         existing = MagicMock(spec=PredictionOutcome)
         existing.is_complete = True
-        mock_session.query.return_value.filter.return_value.first.return_value = existing
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            existing
+        )
 
         result = calculator._calculate_single_outcome(
             prediction_id=1,
@@ -191,10 +208,12 @@ class TestFixedEarlyReturn:
         existing.is_complete = False
         existing.price_at_prediction = 100.0
         existing.price_t1 = 101.0  # Already filled
-        existing.price_t3 = None   # Not yet filled
+        existing.price_t3 = None  # Not yet filled
         existing.price_t7 = None
         existing.price_t30 = None
-        mock_session.query.return_value.filter.return_value.first.return_value = existing
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            existing
+        )
 
         # Provide price data for the re-evaluation
         mock_price = MagicMock(close=100.0)
@@ -216,7 +235,9 @@ class TestFixedEarlyReturn:
         existing = MagicMock(spec=PredictionOutcome)
         existing.is_complete = True
         existing.price_at_prediction = 100.0
-        mock_session.query.return_value.filter.return_value.first.return_value = existing
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            existing
+        )
 
         mock_price = MagicMock(close=100.0)
         calculator.market_client.get_price_on_date.return_value = mock_price
@@ -258,7 +279,9 @@ class TestSkipFilledTimeframes:
             pnl_t1=10.0,
             is_complete=False,
         )
-        mock_session.query.return_value.filter.return_value.first.return_value = existing
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            existing
+        )
 
         # Price data for unfilled timeframes
         mock_price_t0 = MagicMock(close=100.0)
@@ -295,16 +318,19 @@ class TestMatureOutcomesCLI:
     @pytest.fixture
     def runner(self):
         from click.testing import CliRunner
+
         return CliRunner()
 
     def test_command_exists(self, runner):
         from shit.market_data.cli import cli
+
         result = runner.invoke(cli, ["mature-outcomes", "--help"])
         assert result.exit_code == 0
         assert "Re-evaluate incomplete prediction outcomes" in result.output
 
     def test_command_in_cli_help(self, runner):
         from shit.market_data.cli import cli
+
         result = runner.invoke(cli, ["--help"])
         assert "mature-outcomes" in result.output
 
@@ -329,9 +355,7 @@ class TestMatureOutcomesCLI:
         assert result.exit_code == 0
         assert "Incomplete outcomes found: 5" in result.output
         assert "Newly complete: 2" in result.output
-        mock_calc.mature_outcomes.assert_called_once_with(
-            limit=None, emit_event=False
-        )
+        mock_calc.mature_outcomes.assert_called_once_with(limit=None, emit_event=False)
 
     @patch("shit.market_data.cli.OutcomeCalculator")
     def test_with_limit(self, mock_calc_class, runner):
@@ -352,9 +376,7 @@ class TestMatureOutcomesCLI:
 
         result = runner.invoke(cli, ["mature-outcomes", "--limit", "10"])
         assert result.exit_code == 0
-        mock_calc.mature_outcomes.assert_called_once_with(
-            limit=10, emit_event=False
-        )
+        mock_calc.mature_outcomes.assert_called_once_with(limit=10, emit_event=False)
 
     @patch("shit.market_data.cli.OutcomeCalculator")
     def test_with_emit_event_flag(self, mock_calc_class, runner):
@@ -375,9 +397,7 @@ class TestMatureOutcomesCLI:
 
         result = runner.invoke(cli, ["mature-outcomes", "--emit-event"])
         assert result.exit_code == 0
-        mock_calc.mature_outcomes.assert_called_once_with(
-            limit=None, emit_event=True
-        )
+        mock_calc.mature_outcomes.assert_called_once_with(limit=None, emit_event=True)
 
     @patch("shit.market_data.cli.OutcomeCalculator")
     def test_error_handling(self, mock_calc_class, runner):


### PR DESCRIPTION
## Summary
- Outcome calculations now use **trading-day offsets** instead of calendar days (T+1 on Friday = Monday, NYSE holidays skipped) via new `MarketCalendar` wrapper around `exchange_calendars`
- Added **intraday outcome tracking** with `IntradayPriceSnapshot` for same-day and 1-hour returns using yfinance 1h bars
- Added `bar_datetime` as formal field on `RawPriceRecord` dataclass, 12 new nullable columns on `PredictionOutcome`, and updated `get_price_on_date` for calendar-aware lookback
- 64 new tests (44 calendar, 9 intraday, 11 outcome calculator additions), all 287 market data tests pass

## Test plan
- [x] All 287 market data tests pass
- [x] Full suite: 2365 passed (only pre-existing failures)
- [x] Ruff lint clean on all new/modified files
- [x] Ruff format applied to all files
- [ ] After merge: run ALTER TABLE migration SQL to add new columns in production
- [ ] After deploy: run retroactive recalculation to apply trading-day offsets to existing outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)