### PR TITLE
feat: API test coverage + CORS hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **API test coverage** — 54 tests for all FastAPI endpoints, query functions, and response schemas
+  - Feed router: navigation bounds, JSON parsing, engagement defaults, error cases
+  - Price router: yfinance/DB fallback, cache TTL, post_timestamp indexing, validation
+  - Telegram router: webhook processing, error resilience, health check
+  - Query layer: offset logic, JSON string parsing, empty results
+
+### Security
+- **CORS hardening** — Restrict `allow_origins` to Railway domain in production
+  - Added `ALLOWED_ORIGINS` env var (comma-separated, defaults to Railway URL)
+  - Wildcard `*` only used when `ENVIRONMENT=development`
+
+### Added
 - **Data model remediation** — Full data model audit and remediation based on 30 findings across 10 tables
   - 4 missing indexes on `predictions` table (`shitpost_id`, `signal_id`, `analysis_status`, `created_at`)
   - Denormalized `post_timestamp` on `predictions` to eliminate N+1 lazy loading in OutcomeCalculator

--- a/api/main.py
+++ b/api/main.py
@@ -27,10 +27,19 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS for local development (Vite on :5173, API on :8000)
+# CORS — restrict origins in production, allow all in development
+_default_origins = "https://shitpost-alpha-web-production.up.railway.app"
+_allowed_origins_str = os.environ.get("ALLOWED_ORIGINS", _default_origins)
+_environment = os.environ.get("ENVIRONMENT", "production")
+
+if _environment == "development":
+    _allowed_origins = ["*"]
+else:
+    _allowed_origins = [o.strip() for o in _allowed_origins_str.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -63,7 +72,9 @@ if os.path.isdir(_frontend_dir):
         # Serve actual files (eagle.svg, favicon, etc.) if they exist
         if full_path:
             file_path = os.path.realpath(os.path.join(_frontend_dir, full_path))
-            if file_path.startswith(os.path.realpath(_frontend_dir)) and os.path.isfile(file_path):
+            if file_path.startswith(os.path.realpath(_frontend_dir)) and os.path.isfile(
+                file_path
+            ):
                 return FileResponse(file_path)
         # SPA fallback — serve index.html for client-side routing
         index = os.path.join(_frontend_dir, "index.html")

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/00_TECH_DEBT.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/00_TECH_DEBT.md
@@ -1,0 +1,119 @@
+# Tech Debt Overview — 2026-03-26
+
+**Session**: `tech-debt-2026-03-26`
+**Scan date**: 2026-03-26
+**Scan scope**: Full codebase (147 source files, 110 test files, ~2,338 tests)
+**Archive destination**: `documentation/archive/tech-debt-2026-03-26/`
+
+---
+
+## Executive Summary
+
+A full codebase scan of shitpost-alpha identified **5 actionable workstreams** across security, test coverage, dependency hygiene, code complexity, and legacy cleanup. The most urgent finding is that the **FastAPI API module (`api/`) has zero test coverage** despite serving production traffic on Railway, compounded by a **CORS wildcard (`allow_origins=["*"]`)** that exposes every endpoint to cross-origin abuse. The notifications database layer has thin coverage with 11 functions sharing a duplicated try/session/except pattern ripe for deduplication. Four unused dependencies inflate the install footprint, the outcome calculator contains a 245-line function begging for decomposition, and 5 stale TODOs plus misleading "Phase 2" comments add friction for future contributors.
+
+The remediation is organized into 5 phases (one PR each), prioritized by production risk. Phases 1 and 2 can execute in parallel since they touch entirely disjoint file sets. Phases 3-5 are independent of each other and of Phases 1-2.
+
+---
+
+## Complete Inventory
+
+### CRITICAL
+
+| # | Finding | Location | Blast Radius | Fix Complexity | Risk if Unfixed |
+|---|---------|----------|--------------|----------------|-----------------|
+| C1 | **API module has zero test coverage** | `api/main.py`, `api/routers/feed.py`, `api/routers/prices.py`, `api/routers/telegram.py`, `api/queries/feed_queries.py`, `api/queries/price_queries.py`, `api/schemas/feed.py`, `api/dependencies.py` | HIGH -- any regression in feed, price, or webhook endpoints is invisible until users report it | MEDIUM -- ~50 tests across 3-4 test files using `httpx.ASGITransport` | Silent production regressions, broken Telegram webhook ingestion, incorrect price/feed data served to React frontend |
+| C2 | **CORS wildcard in production** | `api/main.py:33` (`allow_origins=["*"]`) | HIGH -- every browser on the internet can make authenticated requests to the API | LOW -- replace `*` with environment-driven allowlist | Cross-site request forgery, data exfiltration, Telegram webhook spoofing |
+
+### HIGH
+
+| # | Finding | Location | Blast Radius | Fix Complexity | Risk if Unfixed |
+|---|---------|----------|--------------|----------------|-----------------|
+| H1 | **Notifications DB thin test coverage** | `notifications/db.py` (461 lines, 11 functions) | MEDIUM -- alert delivery failures affect Telegram subscribers | MEDIUM -- ~30 tests covering all 11 functions | Silent subscription bugs, alert delivery failures, error counter drift |
+| H2 | **Notifications DB duplicated query pattern** | `notifications/db.py` -- every function repeats try/get_session/except/finally | LOW -- code smell, no production impact | LOW -- extract shared session-management helper | Maintenance burden, copy-paste bugs on future changes |
+
+### MEDIUM
+
+| # | Finding | Location | Blast Radius | Fix Complexity | Risk if Unfixed |
+|---|---------|----------|--------------|----------------|-----------------|
+| M1 | **245-line function in outcome_calculator** | `shit/market_data/outcome_calculator.py:~158` (`_calculate_single_outcome`) | LOW -- well-tested (725-line test file), but hard to review/modify | MEDIUM -- decompose into 3 focused helpers | Increasing cognitive load, harder code review, elevated bug risk on future changes |
+| M2 | **754-line CLI with 14 commands** | `shit/market_data/cli.py` | LOW -- CLI is developer-facing, not user-facing | MEDIUM -- split into 3 sub-modules | Slow IDE navigation, merge conflicts when multiple devs touch CLI |
+| M3 | **4 unused dependencies** | `requirements.txt` lines for `apscheduler`, `asyncio-mqtt`, `asyncio-throttle`, `structlog` | LOW -- no runtime impact, inflates install | LOW -- delete 4 lines | Slower installs, misleading dependency list, potential supply-chain surface |
+| M4 | **65 outdated packages** | `requirements.txt` (notable: openai 2.24->2.30, pydantic 2.11->2.12, psycopg 3.2->3.3, sqlalchemy 2.0.47->2.0.48) | MEDIUM -- security patches, bug fixes accumulating | MEDIUM -- bump minors only, skip pandas 3.x and pytest 9.x majors | Missed security patches, growing upgrade delta, eventual forced migration |
+
+### LOW
+
+| # | Finding | Location | Blast Radius | Fix Complexity | Risk if Unfixed |
+|---|---------|----------|--------------|----------------|-----------------|
+| L1 | **5 stale TODO comments** | `shitposts/twitter_harvester.py:66,92`, `shitvault/s3_processor.py:217`, `shit/utils/error_handling.py:26,27` | NONE -- informational | LOW -- resolve or convert to tracked issues | Mental clutter, false impression of incomplete work |
+| L2 | **Misleading "Phase 2" comments** | `requirements.txt:37-44` | NONE -- informational | LOW -- update or remove comments | Confuses new contributors about project roadmap |
+| L3 | **Dual PostgreSQL drivers** | `psycopg[binary]` (async) + `psycopg2-binary` (sync) both in requirements | NONE -- both are actively used | N/A -- keep both, document rationale | Minor confusion for new contributors |
+| L4 | **`twilio` dependency (lazy import)** | `notifications/dispatcher.py:331` | NONE -- lazy-loaded, never called in current flow | LOW -- annotate in requirements.txt | Misleading dependency list |
+
+---
+
+## Prioritized Remediation Order
+
+| Phase | PR Title | Priority | Findings Addressed | Effort | Risk |
+|-------|----------|----------|-------------------|--------|------|
+| **1** | API Test Coverage + Security Hardening | HIGHEST | C1, C2 | High (~50 tests, CORS fix) | Medium (touches production config) |
+| **2** | Notifications Test Coverage + Query Dedup | HIGH | H1, H2 | Medium (~30 tests, helper extraction) | Low (additive tests + internal refactor) |
+| **3** | Dependency Cleanup | MEDIUM | M3, M4, L2, L4 | Low (delete lines, bump versions) | Low (minor version bumps only) |
+| **4** | outcome_calculator Decomposition + CLI Split | MEDIUM | M1, M2 | Medium (refactor 2 files, update tests) | Medium (production code refactor) |
+| **5** | TODO Resolution + Legacy Documentation | LOWER | L1, L3 | Low (resolve/convert 5 TODOs, add comments) | None |
+
+### Why this order
+
+1. **Phase 1 first** because zero test coverage on a production API is the highest-risk finding. The CORS wildcard is a security issue that should ship with the tests so the fix is verified.
+2. **Phase 2 parallel with Phase 1** because notifications DB is the second-largest coverage gap and touches completely disjoint files.
+3. **Phase 3 after 1-2** because dependency cleanup benefits from the new test coverage -- bumping packages is safer when tests catch regressions.
+4. **Phase 4 after 1-2** because outcome_calculator decomposition is a production code refactor that benefits from the broader test safety net established in Phases 1-2.
+5. **Phase 5 last** because TODOs and documentation have zero production risk and can be done anytime.
+
+---
+
+## Dependency Matrix
+
+```
+Phase 1 (API Tests + CORS) ──────┐
+                                  ├──→ Phase 3 (Deps) ──→ [done]
+Phase 2 (Notifications Tests) ────┘
+                                  ├──→ Phase 4 (Decomposition) ──→ [done]
+                                  │
+                                  └──→ Phase 5 (TODOs) ──→ [done]
+```
+
+| Phase | Blocked By | Unlocks |
+|-------|-----------|---------|
+| 1 | None | 3, 4 (safer with test coverage) |
+| 2 | None | 3, 4 (safer with test coverage) |
+| 3 | None (recommended after 1-2) | None |
+| 4 | None (recommended after 1-2) | None |
+| 5 | None | None |
+
+**Parallel safety:**
+- **Phases 1 and 2**: SAFE to run in parallel. Phase 1 touches `api/`, `shit_tests/api/`. Phase 2 touches `notifications/db.py`, `shit_tests/notifications/`. Zero file overlap.
+- **Phases 3, 4, 5**: SAFE to run in parallel with each other and after 1-2. Phase 3 touches `requirements.txt`. Phase 4 touches `shit/market_data/outcome_calculator.py`, `shit/market_data/cli.py`, and their tests. Phase 5 touches `shitposts/twitter_harvester.py`, `shitvault/s3_processor.py`, `shit/utils/error_handling.py`.
+
+---
+
+## Phase Summary Table
+
+| # | PR Title | Priority | Effort | Risk | Dependencies | Unlocks | Key Files |
+|---|----------|----------|--------|------|-------------|---------|-----------|
+| 1 | API Test Coverage + Security Hardening | HIGHEST | High (~50 tests) | Medium | None | 3, 4 | `api/**`, `shit_tests/api/**` (new) |
+| 2 | Notifications Test Coverage + Query Dedup | HIGH | Medium (~30 tests) | Low | None | 3, 4 | `notifications/db.py`, `shit_tests/notifications/` |
+| 3 | Dependency Cleanup | MEDIUM | Low | Low | Recommended after 1-2 | None | `requirements.txt` |
+| 4 | outcome_calculator Decomposition + CLI Split | MEDIUM | Medium | Medium | Recommended after 1-2 | None | `shit/market_data/outcome_calculator.py`, `shit/market_data/cli.py`, `shit/market_data/cli_fetch.py` (new), `shit/market_data/cli_outcomes.py` (new), `shit/market_data/cli_registry.py` (new) |
+| 5 | TODO Resolution + Legacy Documentation | LOWER | Low | None | None | None | `shitposts/twitter_harvester.py`, `shitvault/s3_processor.py`, `shit/utils/error_handling.py`, `requirements.txt` |
+
+---
+
+## Out of Scope
+
+The following items were noted during the scan but are explicitly **not addressed** in this remediation:
+
+- **Dash dashboard (`shitty_ui/`) refactoring** -- this module is being retired in favor of the React+FastAPI frontend. No investment in refactoring retiring code.
+- **pandas 3.x major upgrade** -- breaking changes require dedicated migration effort; skip for now and revisit when pandas 2.x reaches EOL.
+- **pytest 9.x major upgrade** -- breaking changes to fixture semantics; skip for now.
+- **Dual PostgreSQL driver consolidation** -- both `psycopg` (async) and `psycopg2-binary` (sync) are actively used by different subsystems. Document rationale but do not consolidate.
+- **Signals migration backfill** -- tracked separately in `documentation/planning/SIGNALS_MIGRATION.md`.

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/01_api-test-coverage.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/01_api-test-coverage.md
@@ -1,0 +1,2183 @@
+# Phase 01: API Test Coverage + CORS Hardening
+
+**Status**: ✅ COMPLETE
+**Started**: 2026-03-28
+**Completed**: 2026-03-28
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: API test coverage + CORS hardening` |
+| **Risk** | Low |
+| **Effort** | Medium |
+| **Files Created** | 7 (`shit_tests/api/__init__.py`, `shit_tests/api/conftest.py`, `shit_tests/api/test_feed_router.py`, `shit_tests/api/test_prices_router.py`, `shit_tests/api/test_telegram_router.py`, `shit_tests/api/test_feed_queries.py`, `shit_tests/api/test_price_queries.py`) |
+| **Files Modified** | 1 (`api/main.py`) |
+| **Files Deleted** | 0 |
+| **Dependencies** | None |
+| **Unlocks** | None |
+
+---
+
+## Context
+
+The `api/` module serves production traffic as the FastAPI backend for the React frontend deployed at `https://shitpost-alpha-web-production.up.railway.app/`. Despite being a production-facing module, it has **zero tests** — the only untested module in the entire codebase (2,338+ tests across 110 test files). Additionally, the CORS middleware uses `allow_origins=["*"]` which is overly permissive for a production deployment.
+
+This phase adds comprehensive test coverage for all API routes, query functions, and response schemas, plus hardens the CORS configuration to restrict origins in production while keeping the wildcard for local development.
+
+---
+
+## Dependencies
+
+- **Depends on**: None — this is a standalone phase.
+- **Unlocks**: None — no other phases depend on this.
+- **Parallel safety**: This phase touches only `api/main.py` (one modification) and creates new files under `shit_tests/api/`. It is safe to run in parallel with any phase that does not modify `api/main.py`.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Create `shit_tests/api/__init__.py`
+
+Create an empty init file so pytest discovers the test package.
+
+**Create file** `shit_tests/api/__init__.py`:
+
+```python
+```
+
+(Empty file — just needs to exist for package discovery.)
+
+---
+
+### Step 2: Create `shit_tests/api/conftest.py`
+
+This conftest provides:
+1. A mock for `api.dependencies.execute_query` so no real database is needed
+2. A FastAPI `TestClient` fixture
+3. Sample data fixtures for feed responses, price data, and outcomes
+
+**Create file** `shit_tests/api/conftest.py`:
+
+```python
+"""
+Conftest for API tests.
+Provides TestClient, mock execute_query, and sample data fixtures.
+"""
+
+import os
+import sys
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is on path
+project_root = os.path.join(os.path.dirname(__file__), "..", "..")
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Mock settings before any api module imports
+_mock_settings = MagicMock()
+_mock_settings.DATABASE_URL = "sqlite:///test.db"
+_mock_settings.TELEGRAM_BOT_TOKEN = "test-bot-token-123"
+
+sys.modules.setdefault("shit.config.shitpost_settings", MagicMock())
+sys.modules["shit.config.shitpost_settings"].settings = _mock_settings
+
+# Set DATABASE_URL env var as fallback
+os.environ["DATABASE_URL"] = "sqlite:///test.db"
+
+
+@pytest.fixture
+def mock_execute_query():
+    """Mock api.dependencies.execute_query to return controlled data.
+
+    Usage in tests:
+        def test_something(client, mock_execute_query):
+            mock_execute_query.return_value = (rows, columns)
+            response = client.get("/api/feed/latest")
+    """
+    with patch("api.dependencies.execute_query") as mock_eq:
+        # Default: return empty results
+        mock_eq.return_value = ([], [])
+        yield mock_eq
+
+
+@pytest.fixture
+def client(mock_execute_query):
+    """FastAPI TestClient with mocked database.
+
+    The mock_execute_query fixture is automatically active.
+    Access it via the mock_execute_query fixture if you need to
+    configure return values.
+    """
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def sample_post_row() -> tuple[list[tuple], list[str]]:
+    """A single analyzed post row as returned by execute_query.
+
+    Returns (rows, columns) matching get_analyzed_post_at_offset's SQL.
+    """
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_abc123",  # shitpost_id
+        "Big tariff announcement coming!",  # text
+        "<p>Big tariff announcement coming!</p>",  # content_html
+        datetime(2026, 3, 25, 14, 30, 0),  # timestamp
+        "realDonaldTrump",  # username
+        "https://truthsocial.com/@realDonaldTrump/post_abc123",  # url
+        42,  # replies_count
+        150,  # reblogs_count
+        500,  # favourites_count
+        300,  # upvotes_count
+        10,  # downvotes_count
+        101,  # prediction_id
+        ["AAPL", "TSLA"],  # assets (already a list)
+        {"AAPL": "bearish", "TSLA": "bullish"},  # market_impact (already a dict)
+        0.85,  # confidence
+        "Tariffs on China will hurt Apple supply chain but benefit Tesla domestic production.",  # thesis
+        "completed",  # analysis_status
+        0.7,  # engagement_score
+        0.8,  # viral_score
+        -0.3,  # sentiment_score
+        0.9,  # urgency_score
+    )
+    return ([row], columns)
+
+
+@pytest.fixture
+def sample_post_row_json_strings() -> tuple[list[tuple], list[str]]:
+    """A post row where assets and market_impact are JSON strings (not parsed).
+
+    This simulates what some database drivers return.
+    """
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_json456",
+        "Trade deal signed!",
+        "<p>Trade deal signed!</p>",
+        datetime(2026, 3, 24, 10, 0, 0),
+        "realDonaldTrump",
+        None,
+        10,
+        50,
+        200,
+        100,
+        5,
+        202,
+        '["SPY", "DIA"]',  # assets as JSON string
+        '{"SPY": "bullish", "DIA": "bullish"}',  # market_impact as JSON string
+        0.72,
+        "Trade deal boosts market indices.",
+        "completed",
+        0.5,
+        0.6,
+        0.4,
+        0.3,
+    )
+    return ([row], columns)
+
+
+@pytest.fixture
+def sample_outcomes_rows() -> tuple[list[tuple], list[str]]:
+    """Outcome rows as returned by get_outcomes_for_prediction's SQL."""
+    columns = [
+        "symbol",
+        "prediction_sentiment",
+        "prediction_confidence",
+        "price_at_prediction",
+        "price_at_post",
+        "price_at_next_close",
+        "price_1h_after",
+        "price_t1",
+        "price_t3",
+        "price_t7",
+        "price_t30",
+        "return_t1",
+        "return_t3",
+        "return_t7",
+        "return_t30",
+        "return_same_day",
+        "return_1h",
+        "correct_t1",
+        "correct_t3",
+        "correct_t7",
+        "correct_t30",
+        "correct_same_day",
+        "correct_1h",
+        "pnl_t1",
+        "pnl_t3",
+        "pnl_t7",
+        "pnl_t30",
+        "pnl_same_day",
+        "pnl_1h",
+        "is_complete",
+    ]
+    row_aapl = (
+        "AAPL",  # symbol
+        "bearish",  # prediction_sentiment
+        0.85,  # prediction_confidence
+        178.50,  # price_at_prediction
+        178.20,  # price_at_post
+        177.80,  # price_at_next_close
+        178.00,  # price_1h_after
+        176.50,  # price_t1
+        175.00,  # price_t3
+        174.00,  # price_t7
+        180.00,  # price_t30
+        -1.12,  # return_t1
+        -1.96,  # return_t3
+        -2.52,  # return_t7
+        0.84,  # return_t30
+        -0.39,  # return_same_day
+        -0.11,  # return_1h
+        True,  # correct_t1
+        True,  # correct_t3
+        True,  # correct_t7
+        False,  # correct_t30
+        True,  # correct_same_day
+        True,  # correct_1h
+        11.20,  # pnl_t1
+        19.60,  # pnl_t3
+        25.20,  # pnl_t7
+        -8.40,  # pnl_t30
+        3.90,  # pnl_same_day
+        1.10,  # pnl_1h
+        True,  # is_complete
+    )
+    row_tsla = (
+        "TSLA",
+        "bullish",
+        0.85,
+        245.00,
+        244.80,
+        246.50,
+        245.50,
+        248.00,
+        252.00,
+        260.00,
+        240.00,
+        1.22,
+        2.86,
+        6.12,
+        -2.04,
+        0.69,
+        0.20,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        12.20,
+        28.60,
+        61.20,
+        -20.40,
+        6.90,
+        2.00,
+        True,
+    )
+    return ([row_aapl, row_tsla], columns)
+
+
+@pytest.fixture
+def sample_total_count_row() -> tuple[list[tuple], list[str]]:
+    """Total count row as returned by get_total_analyzed_posts."""
+    return ([(42,)], ["total"])
+
+
+@pytest.fixture
+def sample_candle_rows() -> tuple[list[tuple], list[str]]:
+    """Price candle rows as returned from the database fallback query."""
+    from datetime import date
+
+    columns = ["date", "open", "high", "low", "close", "volume"]
+    rows = [
+        (date(2026, 3, 20), 175.0, 178.0, 174.5, 177.0, 50000000),
+        (date(2026, 3, 21), 177.0, 179.5, 176.0, 178.5, 45000000),
+        (date(2026, 3, 24), 178.5, 180.0, 177.0, 179.0, 55000000),
+        (date(2026, 3, 25), 179.0, 181.0, 178.0, 180.5, 60000000),
+    ]
+    return (rows, columns)
+```
+
+---
+
+### Step 3: Create `shit_tests/api/test_feed_router.py`
+
+**Create file** `shit_tests/api/test_feed_router.py`:
+
+```python
+"""Tests for the feed API router (api/routers/feed.py).
+
+Covers:
+- GET /api/feed/latest
+- GET /api/feed/at?offset=N
+- Navigation bounds
+- JSON field parsing
+- Error/edge cases
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/latest — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_post_happy_path(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows, sample_total_count_row
+):
+    """GET /api/feed/latest returns a complete FeedResponse with post, prediction, outcomes."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    # execute_query is called 3 times: post, total, outcomes
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),  # get_analyzed_post_at_offset(0)
+        (count_rows, count_cols),  # get_total_analyzed_posts()
+        (outcome_rows, outcome_cols),  # get_outcomes_for_prediction(101)
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["post"]["shitpost_id"] == "post_abc123"
+    assert data["post"]["text"] == "Big tariff announcement coming!"
+    assert data["post"]["username"] == "realDonaldTrump"
+    assert data["post"]["engagement"]["replies"] == 42
+    assert data["post"]["engagement"]["favourites"] == 500
+
+    assert data["prediction"]["prediction_id"] == 101
+    assert data["prediction"]["confidence"] == 0.85
+    assert data["prediction"]["assets"] == ["AAPL", "TSLA"]
+    assert data["prediction"]["market_impact"] == {"AAPL": "bearish", "TSLA": "bullish"}
+    assert data["prediction"]["scores"]["urgency"] == 0.9
+
+    assert len(data["outcomes"]) == 2
+    assert data["outcomes"][0]["symbol"] == "AAPL"
+    assert data["outcomes"][0]["returns"]["t1"] == -1.12
+    assert data["outcomes"][0]["correct"]["t1"] is True
+    assert data["outcomes"][0]["pnl"]["t1"] == 11.20
+    assert data["outcomes"][1]["symbol"] == "TSLA"
+
+    assert data["navigation"]["current_offset"] == 0
+    assert data["navigation"]["total_posts"] == 42
+    assert data["navigation"]["has_newer"] is False  # offset=0 is newest
+    assert data["navigation"]["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/latest — empty database
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_post_empty_database(client, mock_execute_query):
+    """GET /api/feed/latest returns 404 when no analyzed posts exist."""
+    mock_execute_query.return_value = ([], [])
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 404
+    assert "No post found" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=0 — same as latest
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_zero(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows, sample_total_count_row
+):
+    """GET /api/feed/at?offset=0 behaves identically to /api/feed/latest."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=0")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["post"]["shitpost_id"] == "post_abc123"
+    assert data["navigation"]["current_offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=5 — returns 5th post
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_five(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows, sample_total_count_row
+):
+    """GET /api/feed/at?offset=5 returns the 5th most recent analyzed post."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=5")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["navigation"]["current_offset"] == 5
+    assert data["navigation"]["has_newer"] is True  # offset > 0
+
+    # Verify the query was called with offset=5
+    first_call_params = mock_execute_query.call_args_list[0]
+    assert first_call_params[0][1] == {"offset": 5}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=9999 — out of range returns 404
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_out_of_range(client, mock_execute_query):
+    """GET /api/feed/at?offset=9999 returns 404 when offset exceeds total posts."""
+    mock_execute_query.return_value = ([], [])
+
+    response = client.get("/api/feed/at?offset=9999")
+    assert response.status_code == 404
+    assert "No post found" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=-1 — validation error (ge=0 constraint)
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_negative_offset(client, mock_execute_query):
+    """GET /api/feed/at?offset=-1 returns 422 validation error."""
+    response = client.get("/api/feed/at?offset=-1")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Navigation bounds: has_newer=False when offset=0
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_has_newer_false_at_offset_zero(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At offset=0, has_newer must be False (already at the newest post)."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=0")
+    assert response.status_code == 200
+    assert response.json()["navigation"]["has_newer"] is False
+    assert response.json()["navigation"]["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# Navigation bounds: has_older=False when at last post
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_has_older_false_at_last_post(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At offset = total - 1, has_older must be False (already at the oldest post)."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    # total = 10, offset = 9 (last post)
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=9")
+    assert response.status_code == 200
+
+    nav = response.json()["navigation"]
+    assert nav["has_older"] is False
+    assert nav["has_newer"] is True
+    assert nav["total_posts"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Navigation: mid-range has both directions
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_mid_range_has_both_directions(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At a mid-range offset, both has_newer and has_older must be True."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=5")
+    assert response.status_code == 200
+
+    nav = response.json()["navigation"]
+    assert nav["has_newer"] is True
+    assert nav["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# JSON field parsing: assets as JSON string gets parsed to list
+# ---------------------------------------------------------------------------
+
+
+def test_assets_json_string_parsed_to_list(
+    client, mock_execute_query, sample_post_row_json_strings, sample_total_count_row
+):
+    """When assets comes back as a JSON string from the DB, it gets parsed to a list."""
+    post_rows, post_cols = sample_post_row_json_strings
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),  # no outcomes
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["prediction"]["assets"] == ["SPY", "DIA"]
+    assert isinstance(data["prediction"]["assets"], list)
+
+
+# ---------------------------------------------------------------------------
+# JSON field parsing: market_impact as JSON string gets parsed to dict
+# ---------------------------------------------------------------------------
+
+
+def test_market_impact_json_string_parsed_to_dict(
+    client, mock_execute_query, sample_post_row_json_strings, sample_total_count_row
+):
+    """When market_impact comes back as a JSON string, it gets parsed to a dict."""
+    post_rows, post_cols = sample_post_row_json_strings
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["prediction"]["market_impact"] == {"SPY": "bullish", "DIA": "bullish"}
+    assert isinstance(data["prediction"]["market_impact"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Post with None text gets default empty string
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_none_text_defaults_to_empty_string(
+    client, mock_execute_query, sample_total_count_row
+):
+    """When text is None in the DB row, the response should use an empty string."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_null_text", None, None, datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump", None, 0, 0, 0, 0, 0, 303,
+        ["SPY"], {"SPY": "bullish"}, 0.6, "Some thesis",
+        "completed", None, None, None, None,
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+    assert response.json()["post"]["text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Post with None engagement fields default to 0
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_none_engagement_defaults_to_zero(
+    client, mock_execute_query, sample_total_count_row
+):
+    """When engagement counts are None, the response should default them to 0."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_none_eng", "Test post", None, datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump", None,
+        None, None, None, None, None,  # all engagement counts are None
+        404, ["AAPL"], {"AAPL": "bullish"}, 0.5, "Thesis",
+        "completed", None, None, None, None,
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    eng = response.json()["post"]["engagement"]
+    assert eng["replies"] == 0
+    assert eng["reblogs"] == 0
+    assert eng["favourites"] == 0
+    assert eng["upvotes"] == 0
+    assert eng["downvotes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Outcomes are empty list when prediction has no outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_feed_response_with_no_outcomes(
+    client, mock_execute_query, sample_post_row, sample_total_count_row
+):
+    """When there are no outcomes for a prediction, outcomes list is empty."""
+    post_rows, post_cols = sample_post_row
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),  # no outcomes
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+    assert response.json()["outcomes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Scores with None values are returned as null in JSON
+# ---------------------------------------------------------------------------
+
+
+def test_scores_with_none_values(
+    client, mock_execute_query, sample_total_count_row
+):
+    """When score fields are None, they serialize as null in the JSON response."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_no_scores", "Test", None, datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump", None, 5, 10, 20, 15, 1, 505,
+        ["AAPL"], {"AAPL": "bullish"}, 0.7, "Thesis",
+        "completed", None, None, None, None,  # all scores None
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    scores = response.json()["prediction"]["scores"]
+    assert scores["engagement"] is None
+    assert scores["viral"] is None
+    assert scores["sentiment"] is None
+    assert scores["urgency"] is None
+
+
+# ---------------------------------------------------------------------------
+# Default offset for /at endpoint is 0
+# ---------------------------------------------------------------------------
+
+
+def test_at_endpoint_default_offset_is_zero(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows, sample_total_count_row
+):
+    """GET /api/feed/at without offset param defaults to offset=0."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at")
+    assert response.status_code == 200
+    assert response.json()["navigation"]["current_offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Timestamp is serialized as ISO string
+# ---------------------------------------------------------------------------
+
+
+def test_timestamp_serialized_as_iso_string(
+    client, mock_execute_query, sample_post_row, sample_total_count_row
+):
+    """The post timestamp should be an ISO-format string in the response."""
+    post_rows, post_cols = sample_post_row
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    ts = response.json()["post"]["timestamp"]
+    assert "2026" in ts
+    assert "T" in ts or "-" in ts  # ISO format contains these
+```
+
+---
+
+### Step 4: Create `shit_tests/api/test_prices_router.py`
+
+**Create file** `shit_tests/api/test_prices_router.py`:
+
+```python
+"""Tests for the prices API router (api/routers/prices.py).
+
+Covers:
+- GET /api/prices/{symbol}
+- Days parameter validation
+- post_timestamp handling
+- yfinance fallback to DB
+- TTL cache behavior
+- Edge cases
+"""
+
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_happy_path(client, mock_execute_query):
+    """GET /api/prices/AAPL returns PriceResponse with candles from yfinance."""
+    mock_record = MagicMock()
+    mock_record.date = date(2026, 3, 25)
+    mock_record.open = 180.0
+    mock_record.high = 182.0
+    mock_record.low = 179.0
+    mock_record.close = 181.5
+    mock_record.volume = 50000000
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {
+                    "date": "2026-03-25",
+                    "open": 180.0,
+                    "high": 182.0,
+                    "low": 179.0,
+                    "close": 181.5,
+                    "volume": 50000000,
+                }
+            ]
+
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "AAPL"
+    assert len(data["candles"]) == 1
+    assert data["candles"][0]["close"] == 181.5
+    assert data["post_date_index"] is None  # no post_timestamp given
+    assert data["post_timestamp"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=7 — respects days param
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_respects_days_param(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=7 passes days=7 to get_price_data."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {"date": "2026-03-24", "open": 1, "high": 2, "low": 0.5, "close": 1.5, "volume": 100},
+            ]
+
+            response = client.get("/api/prices/AAPL?days=7")
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=0 — validation error (ge=1)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_days_zero_validation_error(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=0 returns 422 (days must be >= 1)."""
+    response = client.get("/api/prices/AAPL?days=0")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=999 — validation error (le=365)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_days_too_large_validation_error(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=999 returns 422 (days must be <= 365)."""
+    response = client.get("/api/prices/AAPL?days=999")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?post_timestamp=... — finds correct post_date_index
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_with_post_timestamp(client, mock_execute_query):
+    """post_timestamp locates the correct candle index in the response."""
+    candles = [
+        {"date": "2026-03-20", "open": 175, "high": 178, "low": 174, "close": 177, "volume": 50000000},
+        {"date": "2026-03-21", "open": 177, "high": 179, "low": 176, "close": 178, "volume": 45000000},
+        {"date": "2026-03-24", "open": 178, "high": 180, "low": 177, "close": 179, "volume": 55000000},
+        {"date": "2026-03-25", "open": 179, "high": 181, "low": 178, "close": 180, "volume": 60000000},
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+            response = client.get("/api/prices/AAPL?post_timestamp=2026-03-21T14:30:00Z")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["post_date_index"] == 1  # index of 2026-03-21
+    assert data["post_timestamp"] == "2026-03-21T14:30:00Z"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?post_timestamp=invalid — gracefully handles bad timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_invalid_post_timestamp(client, mock_execute_query):
+    """An invalid post_timestamp is silently ignored; post_date_index is None."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {"date": "2026-03-25", "open": 179, "high": 181, "low": 178, "close": 180, "volume": 60000000},
+            ]
+            response = client.get("/api/prices/AAPL?post_timestamp=not-a-date")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["post_date_index"] is None
+
+
+# ---------------------------------------------------------------------------
+# Empty candles returned (yfinance + DB both fail)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_both_sources_fail_returns_empty_candles(client, mock_execute_query):
+    """When yfinance returns [] and DB fallback also returns [], candles is empty."""
+    # mock_execute_query already returns ([], []) by default (DB fallback)
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []  # yfinance fails
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["candles"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cache hit: second request returns cached data
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_cache_hit(client, mock_execute_query):
+    """Second request within TTL returns cached data without re-fetching."""
+    candles = [
+        {"date": "2026-03-25", "open": 179, "high": 181, "low": 178, "close": 180, "volume": 60000000},
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+
+            # First request — populates cache
+            response1 = client.get("/api/prices/AAPL?days=30")
+            assert response1.status_code == 200
+            assert mock_yf.call_count == 1
+
+            # Second request — should hit cache
+            response2 = client.get("/api/prices/AAPL?days=30")
+            assert response2.status_code == 200
+            assert mock_yf.call_count == 1  # NOT called again
+
+    assert response2.json()["candles"] == response1.json()["candles"]
+
+
+# ---------------------------------------------------------------------------
+# Symbol is uppercased in response
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_symbol_uppercased(client, mock_execute_query):
+    """Symbol is uppercased in the response regardless of input casing."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []
+            response = client.get("/api/prices/aapl")
+
+    assert response.status_code == 200
+    assert response.json()["symbol"] == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# yfinance fails, DB fallback succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_yfinance_fails_db_fallback(client, mock_execute_query, sample_candle_rows):
+    """When yfinance returns empty, falls back to database and returns those candles."""
+    db_rows, db_cols = sample_candle_rows
+
+    # mock_execute_query handles the DB fallback query
+    mock_execute_query.return_value = (db_rows, db_cols)
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []  # yfinance returns nothing
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["candles"]) == 4
+    assert data["candles"][0]["date"] == "2026-03-20"
+
+
+# ---------------------------------------------------------------------------
+# post_timestamp between two candle dates picks the earlier one
+# ---------------------------------------------------------------------------
+
+
+def test_post_timestamp_between_dates_picks_earlier(client, mock_execute_query):
+    """When post_timestamp falls between two candle dates, the index of the earlier candle is used."""
+    candles = [
+        {"date": "2026-03-20", "open": 175, "high": 178, "low": 174, "close": 177, "volume": 50000000},
+        {"date": "2026-03-24", "open": 178, "high": 180, "low": 177, "close": 179, "volume": 55000000},
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+            # March 22 is between Mar 20 and Mar 24
+            response = client.get("/api/prices/AAPL?post_timestamp=2026-03-22T12:00:00Z")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["post_date_index"] == 0  # picks the earlier candle (Mar 20)
+```
+
+---
+
+### Step 5: Create `shit_tests/api/test_telegram_router.py`
+
+**Create file** `shit_tests/api/test_telegram_router.py`:
+
+```python
+"""Tests for the Telegram webhook router (api/routers/telegram.py).
+
+Covers:
+- POST /telegram/webhook
+- GET /telegram/health
+- Error handling
+"""
+
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — valid update returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_valid_update(client, mock_execute_query):
+    """POST /telegram/webhook with a valid Telegram update returns 200 {"ok": true}."""
+    update_payload = {
+        "update_id": 123456,
+        "message": {
+            "message_id": 1,
+            "from": {"id": 789, "is_bot": False, "first_name": "Test"},
+            "chat": {"id": 789, "type": "private"},
+            "date": 1711000000,
+            "text": "/start",
+        },
+    }
+
+    with patch("api.routers.telegram.process_update") as mock_process:
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    mock_process.assert_called_once_with(update_payload)
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — invalid JSON returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_invalid_json(client, mock_execute_query):
+    """POST /telegram/webhook with invalid JSON returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"not valid json{{{",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert "Invalid JSON" in response.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — process_update exception still returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_process_update_exception_returns_200(client, mock_execute_query):
+    """Even if process_update raises, the webhook returns 200 to prevent Telegram retries."""
+    update_payload = {"update_id": 999, "message": {"text": "/crash"}}
+
+    with patch("api.routers.telegram.process_update", side_effect=RuntimeError("boom")):
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — returns health info
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_happy_path(client, mock_execute_query):
+    """GET /telegram/health returns full health info when everything works."""
+    mock_stats = {"total": 50, "active": 45, "total_alerts_sent": 1200}
+    mock_last_check = datetime(2026, 3, 25, 14, 0, 0)
+
+    with patch("api.routers.telegram.get_subscription_stats", return_value=mock_stats):
+        with patch("api.routers.telegram.get_last_alert_check", return_value=mock_last_check):
+            with patch("api.routers.telegram.get_bot_token", return_value="valid-token"):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["service"] == "telegram_alerts"
+    assert data["bot_configured"] is True
+    assert data["subscribers"]["total"] == 50
+    assert data["subscribers"]["active"] == 45
+    assert data["total_alerts_sent"] == 1200
+    assert data["last_alert_check"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — with missing bot token
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_missing_bot_token(client, mock_execute_query):
+    """GET /telegram/health reports bot_configured=False when token is missing."""
+    mock_stats = {"total": 10, "active": 8, "total_alerts_sent": 50}
+
+    with patch("api.routers.telegram.get_subscription_stats", return_value=mock_stats):
+        with patch("api.routers.telegram.get_last_alert_check", return_value=None):
+            with patch("api.routers.telegram.get_bot_token", return_value=None):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["bot_configured"] is False
+    assert data["last_alert_check"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — when DB stats fail returns 503
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_db_failure_returns_503(client, mock_execute_query):
+    """GET /telegram/health returns 503 when database calls raise."""
+    with patch(
+        "api.routers.telegram.get_subscription_stats",
+        side_effect=ConnectionError("DB unavailable"),
+    ):
+        response = client.get("/telegram/health")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+    assert "DB unavailable" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — empty body returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_empty_body(client, mock_execute_query):
+    """POST /telegram/webhook with empty body returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — last_alert_check is None when no alerts sent
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_no_alerts_sent(client, mock_execute_query):
+    """GET /telegram/health handles the case where no alerts have ever been sent."""
+    mock_stats = {"total": 1, "active": 1, "total_alerts_sent": 0}
+
+    with patch("api.routers.telegram.get_subscription_stats", return_value=mock_stats):
+        with patch("api.routers.telegram.get_last_alert_check", return_value=None):
+            with patch("api.routers.telegram.get_bot_token", return_value="tok"):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["last_alert_check"] is None
+    assert data["total_alerts_sent"] == 0
+```
+
+**Important note about the telegram router**: The `process_update`, `get_subscription_stats`, `get_last_alert_check`, and `get_bot_token` functions are imported *inside* the endpoint functions (lazy imports). The `with patch(...)` targets must match the import path *as resolved at call time*. Since the imports happen inside the function body using `from notifications.telegram_bot import process_update`, the mock target is `api.routers.telegram.process_update` only if the function was previously imported at module level. Looking at the source code more carefully:
+
+- `process_update` is imported lazily inside `telegram_webhook()` — so the mock target is `notifications.telegram_bot.process_update`
+- `get_subscription_stats`, `get_last_alert_check`, `get_bot_token` are imported lazily inside `telegram_health()` — so mock targets are `notifications.db.get_subscription_stats`, `notifications.telegram_sender.get_bot_token`, etc.
+
+**However**, since these are lazy imports that happen on every call, patching the source module works. The tests above patch `api.routers.telegram.process_update` which will NOT work because the name is not at module scope. Here is the corrected approach — we need to patch at the import source:
+
+**CORRECTION**: Replace all `api.routers.telegram.process_update` patches with `notifications.telegram_bot.process_update`, and similarly for the health check imports. The corrected test file is shown in Step 5 above — but let me provide the exact corrected mock targets below in a dedicated section.
+
+---
+
+### Step 5 (CORRECTED): Telegram mock targets
+
+Because the telegram router uses lazy imports (imports inside the function body), the mock targets must be the *source module* where the functions are defined:
+
+| Function | Source module | Mock target |
+|---|---|---|
+| `process_update` | `notifications.telegram_bot` | `notifications.telegram_bot.process_update` |
+| `get_subscription_stats` | `notifications.db` | `notifications.db.get_subscription_stats` |
+| `get_last_alert_check` | `notifications.db` | `notifications.db.get_last_alert_check` |
+| `get_bot_token` | `notifications.telegram_sender` | `notifications.telegram_sender.get_bot_token` |
+
+**Updated `shit_tests/api/test_telegram_router.py`** (full corrected version):
+
+```python
+"""Tests for the Telegram webhook router (api/routers/telegram.py).
+
+Covers:
+- POST /telegram/webhook
+- GET /telegram/health
+- Error handling
+
+NOTE: The telegram router uses lazy imports (inside function bodies), so
+mock targets point to the source modules, not api.routers.telegram.
+"""
+
+from unittest.mock import patch
+from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — valid update returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_valid_update(client, mock_execute_query):
+    """POST /telegram/webhook with a valid Telegram update returns 200 {"ok": true}."""
+    update_payload = {
+        "update_id": 123456,
+        "message": {
+            "message_id": 1,
+            "from": {"id": 789, "is_bot": False, "first_name": "Test"},
+            "chat": {"id": 789, "type": "private"},
+            "date": 1711000000,
+            "text": "/start",
+        },
+    }
+
+    with patch("notifications.telegram_bot.process_update") as mock_process:
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    mock_process.assert_called_once_with(update_payload)
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — invalid JSON returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_invalid_json(client, mock_execute_query):
+    """POST /telegram/webhook with invalid JSON returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"not valid json{{{",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert "Invalid JSON" in response.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — process_update exception still returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_process_update_exception_returns_200(client, mock_execute_query):
+    """Even if process_update raises, the webhook returns 200 to prevent Telegram retries."""
+    update_payload = {"update_id": 999, "message": {"text": "/crash"}}
+
+    with patch(
+        "notifications.telegram_bot.process_update",
+        side_effect=RuntimeError("boom"),
+    ):
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — returns health info
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_happy_path(client, mock_execute_query):
+    """GET /telegram/health returns full health info when everything works."""
+    mock_stats = {"total": 50, "active": 45, "total_alerts_sent": 1200}
+    mock_last_check = datetime(2026, 3, 25, 14, 0, 0)
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch("notifications.db.get_last_alert_check", return_value=mock_last_check):
+            with patch("notifications.telegram_sender.get_bot_token", return_value="valid-token"):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["service"] == "telegram_alerts"
+    assert data["bot_configured"] is True
+    assert data["subscribers"]["total"] == 50
+    assert data["subscribers"]["active"] == 45
+    assert data["total_alerts_sent"] == 1200
+    assert data["last_alert_check"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — with missing bot token
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_missing_bot_token(client, mock_execute_query):
+    """GET /telegram/health reports bot_configured=False when token is missing."""
+    mock_stats = {"total": 10, "active": 8, "total_alerts_sent": 50}
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch("notifications.db.get_last_alert_check", return_value=None):
+            with patch("notifications.telegram_sender.get_bot_token", return_value=None):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["bot_configured"] is False
+    assert data["last_alert_check"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — when DB stats fail returns 503
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_db_failure_returns_503(client, mock_execute_query):
+    """GET /telegram/health returns 503 when database calls raise."""
+    with patch(
+        "notifications.db.get_subscription_stats",
+        side_effect=ConnectionError("DB unavailable"),
+    ):
+        response = client.get("/telegram/health")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+    assert "DB unavailable" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — empty body returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_empty_body(client, mock_execute_query):
+    """POST /telegram/webhook with empty body returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — last_alert_check is None when no alerts sent
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_no_alerts_sent(client, mock_execute_query):
+    """GET /telegram/health handles the case where no alerts have ever been sent."""
+    mock_stats = {"total": 1, "active": 1, "total_alerts_sent": 0}
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch("notifications.db.get_last_alert_check", return_value=None):
+            with patch("notifications.telegram_sender.get_bot_token", return_value="tok"):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["last_alert_check"] is None
+    assert data["total_alerts_sent"] == 0
+```
+
+---
+
+### Step 6: Create `shit_tests/api/test_feed_queries.py`
+
+**Create file** `shit_tests/api/test_feed_queries.py`:
+
+```python
+"""Tests for feed query functions (api/queries/feed_queries.py).
+
+Unit tests for the query layer, mocking execute_query at the
+api.dependencies level.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — returns dict on success
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_returns_dict():
+    """get_analyzed_post_at_offset returns a dict with all expected keys."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_1", "Hello", None, datetime(2026, 3, 25, 12, 0, 0),
+        "user", None, 1, 2, 3, 4, 5, 100,
+        ["AAPL"], {"AAPL": "bullish"}, 0.9, "Thesis",
+        "completed", 0.5, 0.6, 0.7, 0.8,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result is not None
+    assert result["shitpost_id"] == "post_1"
+    assert result["prediction_id"] == 100
+    assert result["confidence"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — returns None when empty
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_returns_none_when_empty():
+    """get_analyzed_post_at_offset returns None when no rows match."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(9999)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — parses JSON string assets
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_parses_json_string_assets():
+    """When assets is a JSON string, it gets parsed to a list."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_json", "Text", None, datetime(2026, 3, 25, 12, 0, 0),
+        "user", None, 0, 0, 0, 0, 0, 200,
+        '["TSLA", "NVDA"]',  # JSON string
+        '{"TSLA": "bullish"}',  # JSON string
+        0.8, "Thesis", "completed", None, None, None, None,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result["assets"] == ["TSLA", "NVDA"]
+    assert isinstance(result["assets"], list)
+    assert result["market_impact"] == {"TSLA": "bullish"}
+    assert isinstance(result["market_impact"], dict)
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — leaves list/dict assets as-is
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_leaves_native_types():
+    """When assets is already a list and market_impact a dict, they are not re-parsed."""
+    columns = [
+        "shitpost_id", "text", "content_html", "timestamp", "username", "url",
+        "replies_count", "reblogs_count", "favourites_count",
+        "upvotes_count", "downvotes_count", "prediction_id",
+        "assets", "market_impact", "confidence", "thesis",
+        "analysis_status", "engagement_score", "viral_score",
+        "sentiment_score", "urgency_score",
+    ]
+    row = (
+        "post_native", "Text", None, datetime(2026, 3, 25, 12, 0, 0),
+        "user", None, 0, 0, 0, 0, 0, 300,
+        ["AAPL"],  # already a list
+        {"AAPL": "bearish"},  # already a dict
+        0.7, "Thesis", "completed", None, None, None, None,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result["assets"] == ["AAPL"]
+    assert result["market_impact"] == {"AAPL": "bearish"}
+
+
+# ---------------------------------------------------------------------------
+# get_outcomes_for_prediction — returns list of dicts
+# ---------------------------------------------------------------------------
+
+
+def test_get_outcomes_for_prediction_returns_list():
+    """get_outcomes_for_prediction returns a list of outcome dicts."""
+    columns = [
+        "symbol", "prediction_sentiment", "prediction_confidence",
+        "price_at_prediction", "price_at_post", "price_at_next_close",
+        "price_1h_after", "price_t1", "price_t3", "price_t7", "price_t30",
+        "return_t1", "return_t3", "return_t7", "return_t30",
+        "return_same_day", "return_1h",
+        "correct_t1", "correct_t3", "correct_t7", "correct_t30",
+        "correct_same_day", "correct_1h",
+        "pnl_t1", "pnl_t3", "pnl_t7", "pnl_t30",
+        "pnl_same_day", "pnl_1h", "is_complete",
+    ]
+    row = (
+        "AAPL", "bearish", 0.85, 178.5, 178.2, 177.8, 178.0,
+        176.5, 175.0, 174.0, 180.0,
+        -1.12, -1.96, -2.52, 0.84, -0.39, -0.11,
+        True, True, True, False, True, True,
+        11.2, 19.6, 25.2, -8.4, 3.9, 1.1, True,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_outcomes_for_prediction
+
+        result = get_outcomes_for_prediction(101)
+
+    assert len(result) == 1
+    assert result[0]["symbol"] == "AAPL"
+    assert result[0]["return_t1"] == -1.12
+    assert result[0]["is_complete"] is True
+
+
+# ---------------------------------------------------------------------------
+# get_outcomes_for_prediction — empty results
+# ---------------------------------------------------------------------------
+
+
+def test_get_outcomes_for_prediction_empty():
+    """get_outcomes_for_prediction returns empty list when no outcomes exist."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_outcomes_for_prediction
+
+        result = get_outcomes_for_prediction(9999)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_total_analyzed_posts — returns integer count
+# ---------------------------------------------------------------------------
+
+
+def test_get_total_analyzed_posts_returns_count():
+    """get_total_analyzed_posts returns the integer count."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([(42,)], ["total"])):
+        from api.queries.feed_queries import get_total_analyzed_posts
+
+        result = get_total_analyzed_posts()
+
+    assert result == 42
+
+
+# ---------------------------------------------------------------------------
+# get_total_analyzed_posts — empty result returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_get_total_analyzed_posts_empty_returns_zero():
+    """get_total_analyzed_posts returns 0 when query returns no rows."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_total_analyzed_posts
+
+        result = get_total_analyzed_posts()
+
+    assert result == 0
+```
+
+---
+
+### Step 7: Create `shit_tests/api/test_price_queries.py`
+
+**Create file** `shit_tests/api/test_price_queries.py`:
+
+```python
+"""Tests for price query functions (api/queries/price_queries.py).
+
+Unit tests for the query/cache layer, mocking yfinance and execute_query.
+"""
+
+import time
+from datetime import date, datetime
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_happy_path():
+    """_fetch_from_yfinance returns formatted candle dicts from YFinanceProvider."""
+    mock_record = MagicMock()
+    mock_record.date = date(2026, 3, 25)
+    mock_record.open = 180.0
+    mock_record.high = 182.0
+    mock_record.low = 179.0
+    mock_record.close = 181.5
+    mock_record.volume = 50000000
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.return_value = [mock_record]
+
+    with patch("api.queries.price_queries.YFinanceProvider", return_value=mock_provider):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("AAPL", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert len(result) == 1
+    assert result[0]["date"] == "2026-03-25"
+    assert result[0]["close"] == 181.5
+    assert result[0]["volume"] == 50000000
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — ProviderError returns empty
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_provider_error():
+    """_fetch_from_yfinance returns empty list when YFinanceProvider raises ProviderError."""
+    from shit.market_data.price_provider import ProviderError
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.side_effect = ProviderError("No data")
+
+    with patch("api.queries.price_queries.YFinanceProvider", return_value=mock_provider):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("INVALID", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — None values default to 0
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_none_values_default():
+    """_fetch_from_yfinance converts None OHLCV values to 0."""
+    mock_record = MagicMock()
+    mock_record.date = date(2026, 3, 25)
+    mock_record.open = None
+    mock_record.high = None
+    mock_record.low = None
+    mock_record.close = None
+    mock_record.volume = None
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.return_value = [mock_record]
+
+    with patch("api.queries.price_queries.YFinanceProvider", return_value=mock_provider):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("AAPL", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert result[0]["open"] == 0
+    assert result[0]["close"] == 0
+    assert result[0]["volume"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_database — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_database_happy_path():
+    """_fetch_from_database returns formatted candle dicts from DB rows."""
+    columns = ["date", "open", "high", "low", "close", "volume"]
+    rows = [
+        (date(2026, 3, 25), 180.0, 182.0, 179.0, 181.5, 50000000),
+    ]
+
+    with patch("api.queries.price_queries.execute_query", return_value=(rows, columns)):
+        from api.queries.price_queries import _fetch_from_database
+
+        result = _fetch_from_database("AAPL", date(2026, 3, 20))
+
+    assert len(result) == 1
+    assert result[0]["date"] == "2026-03-25"
+    assert result[0]["close"] == 181.5
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_database — empty results
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_database_empty():
+    """_fetch_from_database returns empty list when no rows found."""
+    with patch("api.queries.price_queries.execute_query", return_value=([], [])):
+        from api.queries.price_queries import _fetch_from_database
+
+        result = _fetch_from_database("FAKE", date(2026, 3, 20))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _get_candles — cache miss fetches from yfinance
+# ---------------------------------------------------------------------------
+
+
+def test_get_candles_cache_miss():
+    """_get_candles fetches from yfinance on cache miss."""
+    candles = [{"date": "2026-03-25", "open": 180, "high": 182, "low": 179, "close": 181, "volume": 50000000}]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance", return_value=candles):
+            from api.queries.price_queries import _get_candles
+
+            result = _get_candles("AAPL", 30)
+
+    assert result == candles
+
+
+# ---------------------------------------------------------------------------
+# _get_candles — cache hit returns cached data
+# ---------------------------------------------------------------------------
+
+
+def test_get_candles_cache_hit():
+    """_get_candles returns cached data without re-fetching when TTL is fresh."""
+    cached_candles = [{"date": "2026-03-25", "open": 1, "high": 2, "low": 0, "close": 1, "volume": 100}]
+    cache = {("AAPL", 30): (cached_candles, time.time())}  # fresh cache entry
+
+    with patch("api.queries.price_queries._price_cache", cache):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            from api.queries.price_queries import _get_candles
+
+            result = _get_candles("AAPL", 30)
+
+    mock_yf.assert_not_called()
+    assert result == cached_candles
+
+
+# ---------------------------------------------------------------------------
+# get_price_data — complete response structure
+# ---------------------------------------------------------------------------
+
+
+def test_get_price_data_response_structure():
+    """get_price_data returns dict with symbol, post_timestamp, candles, post_date_index."""
+    candles = [{"date": "2026-03-25", "open": 180, "high": 182, "low": 179, "close": 181, "volume": 50000000}]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance", return_value=candles):
+            from api.queries.price_queries import get_price_data
+
+            result = get_price_data("aapl", 30, None)
+
+    assert result["symbol"] == "AAPL"
+    assert result["post_timestamp"] is None
+    assert result["candles"] == candles
+    assert result["post_date_index"] is None
+```
+
+---
+
+### Step 8: Modify `api/main.py` — CORS Hardening
+
+**File**: `api/main.py`
+
+**Before** (lines 1-37):
+
+```python
+"""FastAPI application for Shitpost Alpha.
+
+Serves the React frontend and JSON API for the single-post feed experience.
+"""
+
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from api.routers import feed, prices, telegram
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan — startup/shutdown hooks."""
+    yield
+
+
+app = FastAPI(
+    title="Shitpost Alpha API",
+    description="Weaponizing Shitposts for American Profit",
+    version="2.0.0",
+    lifespan=lifespan,
+)
+
+# CORS for local development (Vite on :5173, API on :8000)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+**After** (lines 1-47):
+
+```python
+"""FastAPI application for Shitpost Alpha.
+
+Serves the React frontend and JSON API for the single-post feed experience.
+"""
+
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from api.routers import feed, prices, telegram
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan — startup/shutdown hooks."""
+    yield
+
+
+app = FastAPI(
+    title="Shitpost Alpha API",
+    description="Weaponizing Shitposts for American Profit",
+    version="2.0.0",
+    lifespan=lifespan,
+)
+
+# CORS — restrict origins in production, allow all in development
+_default_origins = "https://shitpost-alpha-web-production.up.railway.app"
+_allowed_origins_str = os.environ.get("ALLOWED_ORIGINS", _default_origins)
+_environment = os.environ.get("ENVIRONMENT", "production")
+
+if _environment == "development":
+    _allowed_origins = ["*"]
+else:
+    _allowed_origins = [o.strip() for o in _allowed_origins_str.split(",") if o.strip()]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+**What changed**:
+1. Removed hardcoded `allow_origins=["*"]`
+2. Added `ALLOWED_ORIGINS` env var support (comma-separated list of origins)
+3. Added `ENVIRONMENT` env var check — only `development` gets wildcard `*`
+4. Default production origin is the Railway deployment URL
+5. The rest of `api/main.py` (lines 39-73 becoming lines 49-73) stays unchanged
+
+**Railway configuration note**: No env var changes are needed on Railway — the default (`https://shitpost-alpha-web-production.up.railway.app`) is correct for production. For local development, set `ENVIRONMENT=development` in `.env`.
+
+---
+
+### Step 9: Add health check test to `shit_tests/api/test_feed_router.py`
+
+Rather than a separate file for 2 health check tests, add them at the bottom of `test_feed_router.py` since the health endpoint is defined in `api/main.py` and uses the same `client` fixture.
+
+**Append to `shit_tests/api/test_feed_router.py`** (after the last test):
+
+```python
+# ---------------------------------------------------------------------------
+# GET /api/health — returns ok
+# ---------------------------------------------------------------------------
+
+
+def test_health_check(client, mock_execute_query):
+    """GET /api/health returns {"ok": true, "service": "shitpost-alpha-api"}."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["service"] == "shitpost-alpha-api"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/health — does not require database
+# ---------------------------------------------------------------------------
+
+
+def test_health_check_no_db_dependency(client, mock_execute_query):
+    """GET /api/health returns 200 even if execute_query would fail."""
+    mock_execute_query.side_effect = ConnectionError("DB down")
+
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+```
+
+---
+
+## Test Plan
+
+### New tests to write
+
+| File | Test count | What it covers |
+|---|---|---|
+| `shit_tests/api/test_feed_router.py` | 17 | Feed endpoints, navigation, JSON parsing, engagement defaults, health check |
+| `shit_tests/api/test_prices_router.py` | 11 | Price endpoints, validation, cache, yfinance fallback, post_timestamp |
+| `shit_tests/api/test_telegram_router.py` | 8 | Webhook processing, error resilience, health check |
+| `shit_tests/api/test_feed_queries.py` | 8 | Query layer: offset, JSON parsing, outcomes, total count |
+| `shit_tests/api/test_price_queries.py` | 8 | yfinance provider, DB fallback, cache TTL, response structure |
+| **Total** | **52** | |
+
+### Existing tests to modify
+
+None. All tests are new.
+
+### Coverage expectations
+
+- `api/routers/feed.py` — 100% line coverage
+- `api/routers/prices.py` — 100% line coverage
+- `api/routers/telegram.py` — 100% line coverage
+- `api/queries/feed_queries.py` — 100% line coverage
+- `api/queries/price_queries.py` — ~95% line coverage (lazy import branches)
+- `api/main.py` — ~70% line coverage (SPA serving branch depends on filesystem state)
+- `api/dependencies.py` — covered transitively via mocking (not directly unit-tested since it is the mock boundary)
+
+### Manual verification steps
+
+1. Run `source venv/bin/activate && pytest shit_tests/api/ -v` — all 52 tests pass
+2. Run `source venv/bin/activate && pytest -v` — full suite passes (no regressions)
+3. Run `ruff check api/ shit_tests/api/` — no lint errors
+4. Run `ruff format api/ shit_tests/api/` — files formatted
+5. Verify CORS behavior locally:
+   - Without `ENVIRONMENT=development`: CORS only allows Railway origin
+   - With `ENVIRONMENT=development`: CORS allows all origins
+
+---
+
+## Documentation Updates
+
+### CLAUDE.md
+
+No changes needed. The test structure section in CLAUDE.md says "mirrors source structure under `shit_tests/`" — adding `shit_tests/api/` follows this convention.
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- **API test coverage** — 52 tests for all FastAPI endpoints, query functions, and response schemas
+  - Feed router: navigation bounds, JSON parsing, engagement defaults, error cases
+  - Price router: yfinance/DB fallback, cache TTL, post_timestamp indexing, validation
+  - Telegram router: webhook processing, error resilience, health check
+  - Query layer: offset logic, JSON string parsing, empty results
+
+### Security
+- **CORS hardening** — Restrict `allow_origins` to Railway domain in production
+  - Added `ALLOWED_ORIGINS` env var (comma-separated, defaults to Railway URL)
+  - Wildcard `*` only used when `ENVIRONMENT=development`
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+### Edge cases handled by the test suite
+
+1. **Empty database** — `test_get_latest_post_empty_database`, `test_get_post_at_offset_out_of_range`
+2. **None/null values** — `test_post_with_none_text_defaults_to_empty_string`, `test_post_with_none_engagement_defaults_to_zero`, `test_scores_with_none_values`, `test_fetch_from_yfinance_none_values_default`
+3. **JSON string vs native type** — `test_assets_json_string_parsed_to_list`, `test_market_impact_json_string_parsed_to_dict`, `test_get_analyzed_post_at_offset_parses_json_string_assets`, `test_get_analyzed_post_at_offset_leaves_native_types`
+4. **Validation boundaries** — `test_get_post_at_negative_offset`, `test_get_prices_days_zero_validation_error`, `test_get_prices_days_too_large_validation_error`
+5. **Service failures** — `test_telegram_health_db_failure_returns_503`, `test_telegram_webhook_process_update_exception_returns_200`, `test_get_prices_both_sources_fail_returns_empty_candles`
+6. **Cache behavior** — `test_get_prices_cache_hit`, `test_get_candles_cache_hit`, `test_get_candles_cache_miss`
+7. **Navigation boundaries** — offset=0 (newest), offset=total-1 (oldest), mid-range, out-of-range
+8. **Invalid input** — bad JSON body, invalid timestamp, negative offset
+
+### Not covered (acceptable gaps)
+
+- **SPA serving** (`serve_spa` function in `api/main.py`) — depends on `frontend/dist/` directory existing. Testing would require building the frontend or mocking the filesystem extensively. Low value since it is a thin static file server.
+- **Database connection failures in `execute_query`** — `api/dependencies.py` is the mock boundary. Testing the actual SQLAlchemy session is an integration test concern.
+
+---
+
+## Verification Checklist
+
+- [ ] `shit_tests/api/__init__.py` exists (empty file)
+- [ ] `shit_tests/api/conftest.py` exists with `client`, `mock_execute_query`, and all sample data fixtures
+- [ ] `shit_tests/api/test_feed_router.py` has 17 tests including 2 health check tests
+- [ ] `shit_tests/api/test_prices_router.py` has 11 tests
+- [ ] `shit_tests/api/test_telegram_router.py` has 8 tests
+- [ ] `shit_tests/api/test_feed_queries.py` has 8 tests
+- [ ] `shit_tests/api/test_price_queries.py` has 8 tests
+- [ ] `api/main.py` CORS changed from `["*"]` to environment-aware origins
+- [ ] `ruff check api/ shit_tests/api/` passes
+- [ ] `ruff format api/ shit_tests/api/` passes
+- [ ] `pytest shit_tests/api/ -v` — all 52 tests pass
+- [ ] `pytest -v` — full test suite passes (no regressions)
+- [ ] CHANGELOG.md updated
+
+---
+
+## What NOT To Do
+
+### 1. Do NOT patch `api.routers.telegram.process_update`
+
+The telegram router uses lazy imports inside function bodies:
+
+```python
+# Inside telegram_webhook():
+from notifications.telegram_bot import process_update
+```
+
+This means `process_update` is **never** a module-level attribute of `api.routers.telegram`. Patching `api.routers.telegram.process_update` will raise `AttributeError`. You must patch at the source: `notifications.telegram_bot.process_update`.
+
+The same applies to `get_subscription_stats`, `get_last_alert_check`, and `get_bot_token` in the health endpoint.
+
+### 2. Do NOT use `httpx.AsyncClient` for these tests
+
+The API endpoints are synchronous (`def`, not `async def`). Using `httpx.AsyncClient` would require `pytest-asyncio` and `async` test functions for no benefit. Use `fastapi.testclient.TestClient` (which wraps `httpx` synchronously).
+
+### 3. Do NOT import from `api.main` at module level in conftest
+
+The `client` fixture imports `from api.main import app` inside the fixture function, not at file level. This is intentional — it ensures the mock for `execute_query` is active before the app is constructed. If you import at file level, the app may initialize before mocks are in place.
+
+### 4. Do NOT mock `SessionLocal` directly
+
+The test boundary is `api.dependencies.execute_query`. Mocking `SessionLocal` or `get_db` is unnecessary and fragile — it would couple tests to the database implementation. All API routes use `execute_query`, so mocking that one function covers all database access.
+
+### 5. Do NOT forget to clear `_price_cache` between price tests
+
+The `_price_cache` module-level dict in `api/queries/price_queries.py` persists across tests. Every price test must either:
+- Use `with patch("api.queries.price_queries._price_cache", {})` to start fresh, or
+- Explicitly clear the cache
+
+Failing to do this will cause flaky tests where order matters.
+
+### 6. Do NOT set `ENVIRONMENT=development` in the `.env` committed to git
+
+The CORS hardening defaults to production behavior. For local development, add `ENVIRONMENT=development` to your local `.env` file (which is gitignored). Never commit this setting.
+
+### 7. Do NOT add `ALLOWED_ORIGINS` to Railway env vars
+
+The default value (`https://shitpost-alpha-web-production.up.railway.app`) is correct for the current Railway deployment. Only add the env var if additional origins are needed (e.g., a staging domain).
+
+### 8. Do NOT create a separate `test_health.py` file
+
+The health check endpoint is just 3 lines in `api/main.py`. Two tests at the bottom of `test_feed_router.py` is cleaner than a separate file with two tests and its own imports. Keep the test file count manageable.

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/02_notifications-test-coverage.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/02_notifications-test-coverage.md
@@ -1,0 +1,2410 @@
+# Phase 02 — Notifications DB Test Coverage + Query Dedup
+
+| Field | Value |
+|---|---|
+| **PR Title** | `feat: notifications DB test coverage + query dedup` |
+| **Risk** | Low |
+| **Effort** | Medium |
+| **Files Modified** | 2 (`notifications/db.py`, `shit_tests/notifications/test_db.py`) |
+| **Files Created** | 0 |
+| **Dependencies** | None |
+| **Unlocks** | None |
+
+---
+
+## Context
+
+`notifications/db.py` has 13 public/helper functions but only 9 tests, all focused on the `_UPDATABLE_COLUMNS` whitelist and `update_subscription` SQL injection prevention. The remaining 12 functions (`_row_to_dict`, `_rows_to_dicts`, `get_subscription`, `get_active_subscriptions`, `create_subscription`, `deactivate_subscription`, `record_alert_sent`, `record_error`, `get_subscription_stats`, `get_new_predictions_since`, `get_prediction_stats`, `get_latest_predictions`, `get_last_alert_check`) have zero test coverage.
+
+Additionally, 11 of the 13 functions follow an identical pattern:
+
+```python
+def some_function(args):
+    try:
+        with get_session() as session:
+            query = text("...")
+            result = session.execute(query, params)
+            return _rows_to_dicts(result)  # or _row_to_dict, or commit
+    except Exception as e:
+        logger.error(f"Error ...: {e}")
+        return []  # or None, False, {}
+```
+
+This phase:
+1. Extracts `_execute_read` and `_execute_write` helpers to eliminate the duplicated try/session/except boilerplate
+2. Adds comprehensive tests for all 13 functions (55+ new tests)
+3. Uses the existing `mock_sync_session` autouse fixture from conftest
+
+The refactor is safe because we write tests first against the current API, then refactor, then re-run. The public API of every function is unchanged.
+
+---
+
+## Dependencies
+
+None. This phase touches only `notifications/db.py` and its test file. No other phase modifies these files.
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Add comprehensive tests FIRST (before refactoring)
+
+Write all new tests in `shit_tests/notifications/test_db.py`. The existing conftest at `shit_tests/notifications/conftest.py` provides:
+- `mock_sync_session` (autouse) — patches `notifications.db.get_session` to return a MagicMock
+- `sample_subscription` — a dict representing a subscription row
+- `sample_alert` — a dict representing an alert
+- `sample_preferences` — a dict representing alert preferences
+
+The `mock_sync_session` fixture yields the mock session object itself. When `get_session()` is called in the source code as a context manager (`with get_session() as session:`), the mock's `__enter__` returns the same mock, so `session.execute(...)` calls are captured on the yielded mock.
+
+#### File: `shit_tests/notifications/test_db.py`
+
+**Replace the entire file** with the content below. The existing 9 tests are preserved (classes `TestUpdatableColumnsWhitelist` and `TestUpdateSubscriptionInjectionPrevention`) and new test classes are added.
+
+```python
+"""Tests for notifications/db.py — full coverage of all 13 functions."""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from notifications.db import (
+    _row_to_dict,
+    _rows_to_dicts,
+    _UPDATABLE_COLUMNS,
+    get_subscription,
+    get_active_subscriptions,
+    create_subscription,
+    update_subscription,
+    deactivate_subscription,
+    record_alert_sent,
+    record_error,
+    get_subscription_stats,
+    get_new_predictions_since,
+    get_prediction_stats,
+    get_latest_predictions,
+    get_last_alert_check,
+)
+
+
+# ============================================================
+# _row_to_dict / _rows_to_dicts helpers
+# ============================================================
+
+
+class TestRowToDict:
+    """Tests for the _row_to_dict helper function."""
+
+    def test_returns_dict_for_single_row(self):
+        """A result with one row returns a dict mapping column names to values."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_123", "private", True)]
+        mock_result.keys.return_value = ["chat_id", "chat_type", "is_active"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_123", "chat_type": "private", "is_active": True}
+
+    def test_returns_first_row_when_multiple_rows(self):
+        """When multiple rows exist, only the first row is returned."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("chat_1", "private", True),
+            ("chat_2", "group", False),
+        ]
+        mock_result.keys.return_value = ["chat_id", "chat_type", "is_active"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_1", "chat_type": "private", "is_active": True}
+
+    def test_returns_none_for_empty_result(self):
+        """An empty result set returns None."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+
+        result = _row_to_dict(mock_result)
+
+        assert result is None
+
+    def test_handles_none_values_in_row(self):
+        """None values in the row are preserved in the dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_123", None, None)]
+        mock_result.keys.return_value = ["chat_id", "username", "last_error"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_123", "username": None, "last_error": None}
+
+
+class TestRowsToDicts:
+    """Tests for the _rows_to_dicts helper function."""
+
+    def test_returns_list_of_dicts(self):
+        """Multiple rows are converted to a list of dicts."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("chat_1", True),
+            ("chat_2", False),
+        ]
+        mock_result.keys.return_value = ["chat_id", "is_active"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == [
+            {"chat_id": "chat_1", "is_active": True},
+            {"chat_id": "chat_2", "is_active": False},
+        ]
+
+    def test_returns_empty_list_for_no_rows(self):
+        """An empty result set returns an empty list."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = ["chat_id", "is_active"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == []
+
+    def test_single_row_returns_single_element_list(self):
+        """A single row returns a list with one dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_1", 5)]
+        mock_result.keys.return_value = ["chat_id", "alerts_sent_count"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == [{"chat_id": "chat_1", "alerts_sent_count": 5}]
+
+
+# ============================================================
+# get_subscription
+# ============================================================
+
+
+class TestGetSubscription:
+    """Tests for get_subscription()."""
+
+    def test_returns_subscription_dict_when_found(self, mock_sync_session):
+        """Returns a dict when a matching subscription exists."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "12345", "private", "testuser", "Test", "User",
+             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+        ]
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription("12345")
+
+        assert result is not None
+        assert result["chat_id"] == "12345"
+        assert result["username"] == "testuser"
+        assert result["is_active"] is True
+
+    def test_returns_none_when_not_found(self, mock_sync_session):
+        """Returns None when no subscription matches the chat_id."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription("nonexistent")
+
+        assert result is None
+
+    def test_returns_none_on_database_error(self, mock_sync_session):
+        """Returns None when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_subscription("12345")
+
+        assert result is None
+
+    def test_passes_chat_id_as_string(self, mock_sync_session):
+        """chat_id is always converted to string before passing to the query."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        get_subscription(12345)  # Pass as int
+
+        # Verify the params dict has chat_id as a string
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]  # second positional arg is params dict
+        assert params["chat_id"] == "12345"
+
+
+# ============================================================
+# get_active_subscriptions
+# ============================================================
+
+
+class TestGetActiveSubscriptions:
+    """Tests for get_active_subscriptions()."""
+
+    def test_returns_list_of_active_subscriptions(self, mock_sync_session):
+        """Returns a list of dicts for active subscriptions."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "chat_1", "private", "user1", "Alice", None, None, True, None, "{}", None, 3, 0),
+            (2, "chat_2", "group", None, None, None, "My Group", True, None, "{}", None, 7, 1),
+        ]
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "alert_preferences",
+            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_active_subscriptions()
+
+        assert len(result) == 2
+        assert result[0]["chat_id"] == "chat_1"
+        assert result[1]["chat_id"] == "chat_2"
+
+    def test_returns_empty_list_when_no_active_subs(self, mock_sync_session):
+        """Returns empty list when there are no active subscriptions."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "alert_preferences",
+            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_active_subscriptions()
+
+        assert result == []
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection timeout")
+
+        result = get_active_subscriptions()
+
+        assert result == []
+
+
+# ============================================================
+# create_subscription
+# ============================================================
+
+
+class TestCreateSubscription:
+    """Tests for create_subscription()."""
+
+    def test_creates_new_subscription(self, mock_sync_session):
+        """Creates a new subscription when none exists for the chat_id."""
+        # First call: get_subscription returns None (no existing sub)
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = []
+
+        # Second call: INSERT succeeds
+        mock_result_insert = MagicMock()
+
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_insert]
+
+        result = create_subscription("99999", "private", username="newuser", first_name="New")
+
+        assert result is True
+        # Verify INSERT was called (second execute call)
+        assert mock_sync_session.execute.call_count == 2
+        insert_params = mock_sync_session.execute.call_args_list[1][0][1]
+        assert insert_params["chat_id"] == "99999"
+        assert insert_params["chat_type"] == "private"
+        assert insert_params["username"] == "newuser"
+        assert insert_params["first_name"] == "New"
+        # Verify default preferences are JSON-encoded
+        prefs = json.loads(insert_params["alert_preferences"])
+        assert prefs["min_confidence"] == 0.7
+        assert prefs["assets_of_interest"] == []
+
+    def test_reactivates_inactive_subscription(self, mock_sync_session):
+        """Reactivates an existing inactive subscription instead of creating a new one."""
+        # get_subscription returns an inactive sub
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = [
+            (1, "12345", "private", "user", "Test", None,
+             None, False, None, None, "{}", None, 0, None, 0, None, None, None)
+        ]
+        mock_result_select.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+
+        # update_subscription (called internally for reactivation)
+        mock_result_update = MagicMock()
+
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_update]
+
+        result = create_subscription("12345", "private")
+
+        assert result is True
+
+    def test_returns_true_for_already_active_subscription(self, mock_sync_session):
+        """Returns True immediately if subscription already exists and is active."""
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = [
+            (1, "12345", "private", "user", "Test", None,
+             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+        ]
+        mock_result_select.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result_select
+
+        result = create_subscription("12345", "private")
+
+        assert result is True
+        # Only the SELECT was executed (no INSERT)
+        assert mock_sync_session.execute.call_count == 1
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        # get_subscription raises (first execute call)
+        mock_sync_session.execute.side_effect = Exception("DB error")
+
+        result = create_subscription("12345", "private")
+
+        assert result is False
+
+    def test_optional_params_default_to_none(self, mock_sync_session):
+        """Optional parameters (username, first_name, last_name, title) default to None."""
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = []
+        mock_result_insert = MagicMock()
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_insert]
+
+        result = create_subscription("99999", "channel")
+
+        assert result is True
+        insert_params = mock_sync_session.execute.call_args_list[1][0][1]
+        assert insert_params["username"] is None
+        assert insert_params["first_name"] is None
+        assert insert_params["last_name"] is None
+        assert insert_params["title"] is None
+
+
+# ============================================================
+# update_subscription (existing tests preserved + new tests)
+# ============================================================
+
+
+class TestUpdatableColumnsWhitelist:
+    """Verify the _UPDATABLE_COLUMNS whitelist is correct and complete."""
+
+    def test_whitelist_has_expected_count(self):
+        assert len(_UPDATABLE_COLUMNS) == 14
+
+    def test_whitelist_contains_all_expected_columns(self):
+        expected = {
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "unsubscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "consecutive_errors",
+            "last_error",
+            "last_interaction_at",
+        }
+        assert _UPDATABLE_COLUMNS == expected
+
+    def test_whitelist_is_frozen(self):
+        assert isinstance(_UPDATABLE_COLUMNS, frozenset)
+
+
+class TestUpdateSubscriptionInjectionPrevention:
+    """Verify SQL injection via kwargs keys is blocked."""
+
+    def test_rejects_injected_column_name(self, mock_sync_session):
+        result = update_subscription(
+            "12345", **{"is_active = true; DROP TABLE telegram_subscriptions": "x"}
+        )
+        assert result is False
+
+    def test_rejects_column_with_sql_comment(self, mock_sync_session):
+        result = update_subscription("12345", **{"is_active -- ": True})
+        assert result is False
+
+    def test_rejects_unknown_column(self, mock_sync_session):
+        result = update_subscription("12345", nonexistent_column="value")
+        assert result is False
+
+    def test_accepts_valid_columns(self, mock_sync_session):
+        result = update_subscription("12345", is_active=True)
+        assert result is True
+
+    def test_empty_kwargs_returns_true(self, mock_sync_session):
+        result = update_subscription("12345")
+        assert result is True
+
+
+class TestUpdateSubscription:
+    """Additional update_subscription tests beyond injection prevention."""
+
+    def test_serializes_alert_preferences_dict_to_json(self, mock_sync_session):
+        """When alert_preferences is a dict, it is JSON-serialized before query."""
+        prefs = {"min_confidence": 0.9, "assets_of_interest": ["AAPL"]}
+
+        result = update_subscription("12345", alert_preferences=prefs)
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        # The value should be a JSON string, not a dict
+        assert isinstance(params["alert_preferences"], str)
+        assert json.loads(params["alert_preferences"]) == prefs
+
+    def test_alert_preferences_string_passed_as_is(self, mock_sync_session):
+        """When alert_preferences is already a string, it is not double-serialized."""
+        prefs_str = '{"min_confidence": 0.8}'
+
+        result = update_subscription("12345", alert_preferences=prefs_str)
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["alert_preferences"] == prefs_str
+
+    def test_multiple_columns_updated(self, mock_sync_session):
+        """Multiple valid columns can be updated in a single call."""
+        result = update_subscription(
+            "12345", username="newname", first_name="NewFirst", is_active=True
+        )
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["username"] == "newname"
+        assert params["first_name"] == "NewFirst"
+        assert params["is_active"] is True
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception during UPDATE."""
+        mock_sync_session.execute.side_effect = Exception("Connection lost")
+
+        result = update_subscription("12345", username="new")
+
+        assert result is False
+
+    def test_invalid_column_raises_and_returns_false(self, mock_sync_session):
+        """An invalid column name causes ValueError which is caught, returning False."""
+        result = update_subscription("12345", drop_table="malicious")
+
+        assert result is False
+
+
+# ============================================================
+# deactivate_subscription
+# ============================================================
+
+
+class TestDeactivateSubscription:
+    """Tests for deactivate_subscription()."""
+
+    def test_calls_update_with_is_active_false(self, mock_sync_session):
+        """Deactivation sets is_active=False and unsubscribed_at to a datetime."""
+        result = deactivate_subscription("12345")
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["is_active"] is False
+        assert params["chat_id"] == "12345"
+        # unsubscribed_at should be a datetime (from datetime.utcnow())
+        assert "unsubscribed_at" in params
+
+    def test_returns_false_on_error(self, mock_sync_session):
+        """Returns False when the underlying update fails."""
+        mock_sync_session.execute.side_effect = Exception("DB down")
+
+        result = deactivate_subscription("12345")
+
+        assert result is False
+
+
+# ============================================================
+# record_alert_sent
+# ============================================================
+
+
+class TestRecordAlertSent:
+    """Tests for record_alert_sent()."""
+
+    def test_returns_true_on_success(self, mock_sync_session):
+        """Returns True when the update succeeds."""
+        result = record_alert_sent("12345")
+
+        assert result is True
+        mock_sync_session.execute.assert_called_once()
+
+    def test_passes_chat_id_as_string(self, mock_sync_session):
+        """chat_id is passed as a string to the query params."""
+        record_alert_sent(12345)  # Pass int
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Timeout")
+
+        result = record_alert_sent("12345")
+
+        assert result is False
+
+
+# ============================================================
+# record_error
+# ============================================================
+
+
+class TestRecordError:
+    """Tests for record_error()."""
+
+    def test_returns_true_on_success(self, mock_sync_session):
+        """Returns True when the error is recorded successfully."""
+        result = record_error("12345", "Connection timeout")
+
+        assert result is True
+        mock_sync_session.execute.assert_called_once()
+
+    def test_passes_error_message_to_query(self, mock_sync_session):
+        """The error_message is passed to the query params."""
+        record_error("12345", "Rate limited")
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["error_message"] == "Rate limited"
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("DB error")
+
+        result = record_error("12345", "Some error")
+
+        assert result is False
+
+
+# ============================================================
+# get_subscription_stats
+# ============================================================
+
+
+class TestGetSubscriptionStats:
+    """Tests for get_subscription_stats()."""
+
+    def test_returns_stats_dict(self, mock_sync_session):
+        """Returns aggregated stats as a dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(10, 8, 6, 2, 2, 150)]
+        mock_result.keys.return_value = [
+            "total", "active", "private_chats", "groups", "channels", "total_alerts_sent"
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription_stats()
+
+        assert result["total"] == 10
+        assert result["active"] == 8
+        assert result["private_chats"] == 6
+        assert result["groups"] == 2
+        assert result["channels"] == 2
+        assert result["total_alerts_sent"] == 150
+
+    def test_returns_empty_dict_when_no_subscriptions(self, mock_sync_session):
+        """Returns empty dict when _row_to_dict returns None (no rows)."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription_stats()
+
+        # _row_to_dict returns None, function returns {} via `or {}`
+        assert result == {}
+
+    def test_returns_empty_dict_on_database_error(self, mock_sync_session):
+        """Returns empty dict when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_subscription_stats()
+
+        assert result == {}
+
+
+# ============================================================
+# get_new_predictions_since
+# ============================================================
+
+
+class TestGetNewPredictionsSince:
+    """Tests for get_new_predictions_since()."""
+
+    def test_returns_predictions_list(self, mock_sync_session):
+        """Returns a list of prediction dicts with joined shitpost data."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (
+                datetime(2026, 3, 15, 10, 0, 0),  # timestamp
+                "Big news about tariffs!",         # text
+                "post_123",                        # shitpost_id
+                42,                                # prediction_id
+                '["SPY", "DIA"]',                  # assets
+                '{"SPY": "bearish"}',              # market_impact
+                0.85,                              # confidence
+                "Tariffs likely to impact...",      # thesis
+                "completed",                       # analysis_status
+                datetime(2026, 3, 15, 10, 5, 0),  # prediction_created_at
+            ),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert len(result) == 1
+        assert result[0]["shitpost_id"] == "post_123"
+        assert result[0]["confidence"] == 0.85
+
+    def test_serializes_datetime_fields_to_iso(self, mock_sync_session):
+        """datetime fields (timestamp, prediction_created_at) are converted to ISO strings."""
+        since = datetime(2026, 1, 1)
+        ts = datetime(2026, 3, 15, 10, 0, 0)
+        created = datetime(2026, 3, 15, 10, 5, 0)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (ts, "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", created),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result[0]["timestamp"] == "2026-03-15T10:00:00"
+        assert result[0]["prediction_created_at"] == "2026-03-15T10:05:00"
+
+    def test_non_datetime_timestamp_not_converted(self, mock_sync_session):
+        """If timestamp is already a string, it is left as-is."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("2026-03-15T10:00:00", "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", "2026-03-15T10:05:00"),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result[0]["timestamp"] == "2026-03-15T10:00:00"
+
+    def test_returns_empty_list_when_no_predictions(self, mock_sync_session):
+        """Returns empty list when no predictions match the criteria."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result == []
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Query timeout")
+
+        result = get_new_predictions_since(datetime(2026, 1, 1))
+
+        assert result == []
+
+
+# ============================================================
+# get_prediction_stats
+# ============================================================
+
+
+class TestGetPredictionStats:
+    """Tests for get_prediction_stats()."""
+
+    def test_returns_computed_stats(self, mock_sync_session):
+        """Returns a dict with computed win_rate and total_return_pct."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(100, 60, 80, 0.15)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["total_predictions"] == 100
+        assert result["evaluated"] == 80
+        assert result["correct"] == 60
+        assert result["win_rate"] == 75.0  # 60/80 * 100
+        assert result["total_return_pct"] == 15.0  # 0.15 * 100
+
+    def test_zero_evaluated_avoids_division_by_zero(self, mock_sync_session):
+        """When evaluated_count is 0, win_rate is 0.0 (no ZeroDivisionError)."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(5, 0, 0, 0)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["win_rate"] == 0.0
+        assert result["total_predictions"] == 5
+
+    def test_handles_none_values_from_db(self, mock_sync_session):
+        """None values from SUM/COUNT are treated as 0."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(None, None, None, None)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["total_predictions"] == 0
+        assert result["win_rate"] == 0.0
+        assert result["total_return_pct"] == 0.0
+
+    def test_returns_empty_dict_when_no_rows(self, mock_sync_session):
+        """Returns empty dict when _row_to_dict returns None."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result == {}
+
+    def test_returns_empty_dict_on_database_error(self, mock_sync_session):
+        """Returns empty dict when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_prediction_stats()
+
+        assert result == {}
+
+
+# ============================================================
+# get_latest_predictions
+# ============================================================
+
+
+class TestGetLatestPredictions:
+    """Tests for get_latest_predictions()."""
+
+    def test_returns_list_of_predictions_with_outcomes(self, mock_sync_session):
+        """Returns prediction dicts with LEFT JOINed outcome data."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, '["AAPL"]', 0.9, '{"AAPL": "bullish"}', "Strong buy",
+             datetime(2026, 3, 15), "bullish", True, 0.05, "AAPL"),
+        ]
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_latest_predictions(limit=5)
+
+        assert len(result) == 1
+        assert result[0]["prediction_id"] == 1
+        assert result[0]["confidence"] == 0.9
+        # created_at should be serialized to ISO string
+        assert result[0]["created_at"] == "2026-03-15T00:00:00"
+
+    def test_serializes_created_at_to_iso(self, mock_sync_session):
+        """datetime created_at is converted to ISO string."""
+        dt = datetime(2026, 3, 20, 14, 30, 0)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "[]", 0.8, "{}", "thesis", dt, None, None, None, None),
+        ]
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_latest_predictions(limit=1)
+
+        assert result[0]["created_at"] == "2026-03-20T14:30:00"
+
+    def test_passes_limit_to_query(self, mock_sync_session):
+        """The limit parameter is passed through to the SQL query."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        get_latest_predictions(limit=10)
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["limit"] == 10
+
+    def test_default_limit_is_five(self, mock_sync_session):
+        """Default limit is 5 when not specified."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        get_latest_predictions()
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["limit"] == 5
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Timeout")
+
+        result = get_latest_predictions()
+
+        assert result == []
+
+
+# ============================================================
+# get_last_alert_check
+# ============================================================
+
+
+class TestGetLastAlertCheck:
+    """Tests for get_last_alert_check()."""
+
+    def test_returns_datetime_when_found(self, mock_sync_session):
+        """Returns a datetime when active subscriptions have a last_alert_at."""
+        expected_dt = datetime(2026, 3, 25, 15, 30, 0)
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (expected_dt,)
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result == expected_dt
+
+    def test_returns_none_when_no_alerts_sent(self, mock_sync_session):
+        """Returns None when MAX(last_alert_at) is NULL (no alerts ever sent)."""
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (None,)
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result is None
+
+    def test_returns_none_when_no_rows(self, mock_sync_session):
+        """Returns None when fetchone returns None (no rows at all)."""
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = None
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result is None
+
+    def test_returns_none_on_database_error(self, mock_sync_session):
+        """Returns None when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_last_alert_check()
+
+        assert result is None
+```
+
+**Total test count**: 64 tests (9 existing + 55 new).
+
+### Step 2: Run the tests and verify they all pass
+
+Run:
+```bash
+./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v
+```
+
+All 64 tests must pass before proceeding to the refactor step.
+
+### Step 3: Extract query helper functions in `notifications/db.py`
+
+Now that we have a comprehensive test safety net, refactor the duplicated try/session/except blocks.
+
+#### 3a. Add `_execute_read` and `_execute_write` helpers
+
+**Add after line 33** (after `_rows_to_dicts`), before the `_UPDATABLE_COLUMNS` declaration:
+
+```python
+def _execute_read(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+    processor=_rows_to_dicts,
+    default: Any = None,
+) -> Any:
+    """
+    Execute a read query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+        processor: Function to process the result (default: _rows_to_dicts).
+                   Use _row_to_dict for single-row queries.
+        default: Value to return on error or empty result.
+
+    Returns:
+        Processed query result, or default on error.
+    """
+    try:
+        with get_session() as session:
+            result = session.execute(text(query_str), params or {})
+            return processor(result)
+    except Exception as e:
+        logger.error(f"Read query error: {e}")
+        return default
+
+
+def _execute_write(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """
+    Execute a write query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+
+    Returns:
+        True if successful, False on error.
+    """
+    try:
+        with get_session() as session:
+            session.execute(text(query_str), params or {})
+        return True
+    except Exception as e:
+        logger.error(f"Write query error: {e}")
+        return False
+```
+
+#### 3b. Refactor each function to use the helpers
+
+Below are before/after for **every function** that changes. Functions are listed in order of appearance in the file.
+
+---
+
+**`get_subscription` (line 61-87) — read-single pattern**
+
+Before:
+```python
+def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Get a Telegram subscription by chat_id.
+
+    Args:
+        chat_id: Telegram chat ID.
+
+    Returns:
+        Subscription dict or None if not found.
+    """
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    id, chat_id, chat_type, username, first_name, last_name,
+                    title, is_active, subscribed_at, unsubscribed_at,
+                    alert_preferences, last_alert_at, alerts_sent_count,
+                    last_interaction_at, consecutive_errors, last_error,
+                    created_at, updated_at
+                FROM telegram_subscriptions
+                WHERE chat_id = :chat_id
+            """)
+            result = session.execute(query, {"chat_id": str(chat_id)})
+            return _row_to_dict(result)
+    except Exception as e:
+        logger.error(f"Error getting subscription for chat_id {chat_id}: {e}")
+        return None
+```
+
+After:
+```python
+def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Get a Telegram subscription by chat_id.
+
+    Args:
+        chat_id: Telegram chat ID.
+
+    Returns:
+        Subscription dict or None if not found.
+    """
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, unsubscribed_at,
+            alert_preferences, last_alert_at, alerts_sent_count,
+            last_interaction_at, consecutive_errors, last_error,
+            created_at, updated_at
+        FROM telegram_subscriptions
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+        processor=_row_to_dict,
+        default=None,
+    )
+```
+
+---
+
+**`get_active_subscriptions` (line 90-113) — read-list pattern**
+
+Before:
+```python
+def get_active_subscriptions() -> List[Dict[str, Any]]:
+    """
+    Get all active Telegram subscriptions.
+
+    Returns:
+        List of subscription dicts.
+    """
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    id, chat_id, chat_type, username, first_name, last_name,
+                    title, is_active, subscribed_at, alert_preferences,
+                    last_alert_at, alerts_sent_count, consecutive_errors
+                FROM telegram_subscriptions
+                WHERE is_active = true
+                    AND consecutive_errors < 5
+                ORDER BY subscribed_at ASC
+            """)
+            result = session.execute(query)
+            return _rows_to_dicts(result)
+    except Exception as e:
+        logger.error(f"Error getting active subscriptions: {e}")
+        return []
+```
+
+After:
+```python
+def get_active_subscriptions() -> List[Dict[str, Any]]:
+    """
+    Get all active Telegram subscriptions.
+
+    Returns:
+        List of subscription dicts.
+    """
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, alert_preferences,
+            last_alert_at, alerts_sent_count, consecutive_errors
+        FROM telegram_subscriptions
+        WHERE is_active = true
+            AND consecutive_errors < 5
+        ORDER BY subscribed_at ASC
+        """,
+        default=[],
+    )
+```
+
+---
+
+**`create_subscription` (line 116-186) — mixed read+write, requires custom logic**
+
+This function has branching logic (check existing, reactivate, or insert). Only the INSERT portion at the end can use `_execute_write`. The function's outer try/except still wraps the entire flow because `get_subscription` is called first.
+
+Before (lines 138-186, the try block body):
+```python
+    try:
+        existing = get_subscription(chat_id)
+        if existing:
+            if not existing.get("is_active"):
+                return update_subscription(
+                    chat_id, is_active=True, unsubscribed_at=None
+                )
+            return True
+
+        default_prefs = {
+            "min_confidence": 0.7,
+            "assets_of_interest": [],
+            "sentiment_filter": "all",
+            "quiet_hours_enabled": False,
+            "quiet_hours_start": "22:00",
+            "quiet_hours_end": "08:00",
+        }
+
+        with get_session() as session:
+            query = text("""
+                INSERT INTO telegram_subscriptions (
+                    chat_id, chat_type, username, first_name, last_name, title,
+                    is_active, subscribed_at, alert_preferences,
+                    alerts_sent_count, consecutive_errors,
+                    created_at, updated_at
+                ) VALUES (
+                    :chat_id, :chat_type, :username, :first_name, :last_name, :title,
+                    true, NOW(), :alert_preferences,
+                    0, 0,
+                    NOW(), NOW()
+                )
+            """)
+            session.execute(
+                query,
+                {
+                    "chat_id": str(chat_id),
+                    "chat_type": chat_type,
+                    "username": username,
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "title": title,
+                    "alert_preferences": json.dumps(default_prefs),
+                },
+            )
+        logger.info(f"Created Telegram subscription for chat_id {chat_id}")
+        return True
+    except Exception as e:
+        logger.error(f"Error creating subscription for chat_id {chat_id}: {e}")
+        return False
+```
+
+After:
+```python
+    try:
+        existing = get_subscription(chat_id)
+        if existing:
+            if not existing.get("is_active"):
+                return update_subscription(
+                    chat_id, is_active=True, unsubscribed_at=None
+                )
+            return True
+
+        default_prefs = {
+            "min_confidence": 0.7,
+            "assets_of_interest": [],
+            "sentiment_filter": "all",
+            "quiet_hours_enabled": False,
+            "quiet_hours_start": "22:00",
+            "quiet_hours_end": "08:00",
+        }
+
+        success = _execute_write(
+            """
+            INSERT INTO telegram_subscriptions (
+                chat_id, chat_type, username, first_name, last_name, title,
+                is_active, subscribed_at, alert_preferences,
+                alerts_sent_count, consecutive_errors,
+                created_at, updated_at
+            ) VALUES (
+                :chat_id, :chat_type, :username, :first_name, :last_name, :title,
+                true, NOW(), :alert_preferences,
+                0, 0,
+                NOW(), NOW()
+            )
+            """,
+            params={
+                "chat_id": str(chat_id),
+                "chat_type": chat_type,
+                "username": username,
+                "first_name": first_name,
+                "last_name": last_name,
+                "title": title,
+                "alert_preferences": json.dumps(default_prefs),
+            },
+        )
+        if success:
+            logger.info(f"Created Telegram subscription for chat_id {chat_id}")
+        return success
+    except Exception as e:
+        logger.error(f"Error creating subscription for chat_id {chat_id}: {e}")
+        return False
+```
+
+---
+
+**`update_subscription` (line 189-228) — write with validation, keeps custom logic**
+
+This function has the `_UPDATABLE_COLUMNS` validation and dynamic SET clause construction. The validation logic cannot be moved into a generic helper without losing clarity. **Leave this function unchanged.** It already has thorough test coverage.
+
+---
+
+**`record_alert_sent` (line 238-254) — write pattern**
+
+Before:
+```python
+def record_alert_sent(chat_id: str) -> bool:
+    """Record that an alert was sent to this subscription."""
+    try:
+        with get_session() as session:
+            query = text("""
+                UPDATE telegram_subscriptions
+                SET last_alert_at = NOW(),
+                    alerts_sent_count = alerts_sent_count + 1,
+                    consecutive_errors = 0,
+                    updated_at = NOW()
+                WHERE chat_id = :chat_id
+            """)
+            session.execute(query, {"chat_id": str(chat_id)})
+        return True
+    except Exception as e:
+        logger.error(f"Error recording alert sent for chat_id {chat_id}: {e}")
+        return False
+```
+
+After:
+```python
+def record_alert_sent(chat_id: str) -> bool:
+    """Record that an alert was sent to this subscription."""
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET last_alert_at = NOW(),
+            alerts_sent_count = alerts_sent_count + 1,
+            consecutive_errors = 0,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+    )
+```
+
+---
+
+**`record_error` (line 257-274) — write pattern**
+
+Before:
+```python
+def record_error(chat_id: str, error_message: str) -> bool:
+    """Record an error for this subscription."""
+    try:
+        with get_session() as session:
+            query = text("""
+                UPDATE telegram_subscriptions
+                SET consecutive_errors = consecutive_errors + 1,
+                    last_error = :error_message,
+                    updated_at = NOW()
+                WHERE chat_id = :chat_id
+            """)
+            session.execute(
+                query, {"chat_id": str(chat_id), "error_message": error_message}
+            )
+        return True
+    except Exception as e:
+        logger.error(f"Error recording error for chat_id {chat_id}: {e}")
+        return False
+```
+
+After:
+```python
+def record_error(chat_id: str, error_message: str) -> bool:
+    """Record an error for this subscription."""
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET consecutive_errors = consecutive_errors + 1,
+            last_error = :error_message,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id), "error_message": error_message},
+    )
+```
+
+---
+
+**`get_subscription_stats` (line 277-295) — read-single with fallback**
+
+Before:
+```python
+def get_subscription_stats() -> Dict[str, Any]:
+    """Get statistics about Telegram subscriptions."""
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    COUNT(*) as total,
+                    COUNT(CASE WHEN is_active = true THEN 1 END) as active,
+                    COUNT(CASE WHEN chat_type = 'private' THEN 1 END) as private_chats,
+                    COUNT(CASE WHEN chat_type IN ('group', 'supergroup') THEN 1 END) as groups,
+                    COUNT(CASE WHEN chat_type = 'channel' THEN 1 END) as channels,
+                    SUM(alerts_sent_count) as total_alerts_sent
+                FROM telegram_subscriptions
+            """)
+            result = session.execute(query)
+            return _row_to_dict(result) or {}
+    except Exception as e:
+        logger.error(f"Error getting subscription stats: {e}")
+        return {}
+```
+
+After:
+```python
+def get_subscription_stats() -> Dict[str, Any]:
+    """Get statistics about Telegram subscriptions."""
+    result = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total,
+            COUNT(CASE WHEN is_active = true THEN 1 END) as active,
+            COUNT(CASE WHEN chat_type = 'private' THEN 1 END) as private_chats,
+            COUNT(CASE WHEN chat_type IN ('group', 'supergroup') THEN 1 END) as groups,
+            COUNT(CASE WHEN chat_type = 'channel' THEN 1 END) as channels,
+            SUM(alerts_sent_count) as total_alerts_sent
+        FROM telegram_subscriptions
+        """,
+        processor=_row_to_dict,
+        default=None,
+    )
+    return result or {}
+```
+
+---
+
+**`get_new_predictions_since` (line 303-350) — read-list with post-processing**
+
+This function does post-processing (datetime serialization) after the query. It cannot fully collapse into `_execute_read` without a custom processor. Use `_execute_read` for the query, then do the post-processing outside.
+
+Before:
+```python
+def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
+    """
+    Get new completed predictions created after the given timestamp.
+
+    Args:
+        since: Only return predictions created after this timestamp.
+
+    Returns:
+        List of prediction dicts with associated shitpost data.
+    """
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    tss.timestamp,
+                    tss.text,
+                    tss.shitpost_id,
+                    p.id as prediction_id,
+                    p.assets,
+                    p.market_impact,
+                    p.confidence,
+                    p.thesis,
+                    p.analysis_status,
+                    p.created_at as prediction_created_at
+                FROM predictions p
+                INNER JOIN truth_social_shitposts tss
+                    ON tss.shitpost_id = p.shitpost_id
+                WHERE p.analysis_status = 'completed'
+                    AND p.created_at > :since
+                    AND p.confidence IS NOT NULL
+                    AND p.assets IS NOT NULL
+                    AND p.assets::jsonb <> '[]'::jsonb
+                ORDER BY p.created_at DESC
+                LIMIT 50
+            """)
+            result = session.execute(query, {"since": since})
+            results = _rows_to_dicts(result)
+            for row_dict in results:
+                if isinstance(row_dict.get("timestamp"), datetime):
+                    row_dict["timestamp"] = row_dict["timestamp"].isoformat()
+                if isinstance(row_dict.get("prediction_created_at"), datetime):
+                    row_dict["prediction_created_at"] = row_dict[
+                        "prediction_created_at"
+                    ].isoformat()
+            return results
+    except Exception as e:
+        logger.error(f"Error loading new predictions: {e}")
+        return []
+```
+
+After:
+```python
+def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
+    """
+    Get new completed predictions created after the given timestamp.
+
+    Args:
+        since: Only return predictions created after this timestamp.
+
+    Returns:
+        List of prediction dicts with associated shitpost data.
+    """
+    results = _execute_read(
+        """
+        SELECT
+            tss.timestamp,
+            tss.text,
+            tss.shitpost_id,
+            p.id as prediction_id,
+            p.assets,
+            p.market_impact,
+            p.confidence,
+            p.thesis,
+            p.analysis_status,
+            p.created_at as prediction_created_at
+        FROM predictions p
+        INNER JOIN truth_social_shitposts tss
+            ON tss.shitpost_id = p.shitpost_id
+        WHERE p.analysis_status = 'completed'
+            AND p.created_at > :since
+            AND p.confidence IS NOT NULL
+            AND p.assets IS NOT NULL
+            AND p.assets::jsonb <> '[]'::jsonb
+        ORDER BY p.created_at DESC
+        LIMIT 50
+        """,
+        params={"since": since},
+        default=[],
+    )
+    if results is None:
+        return []
+    for row_dict in results:
+        if isinstance(row_dict.get("timestamp"), datetime):
+            row_dict["timestamp"] = row_dict["timestamp"].isoformat()
+        if isinstance(row_dict.get("prediction_created_at"), datetime):
+            row_dict["prediction_created_at"] = row_dict[
+                "prediction_created_at"
+            ].isoformat()
+    return results
+```
+
+---
+
+**`get_prediction_stats` (line 353-389) — read-single with computation**
+
+Before:
+```python
+def get_prediction_stats() -> Dict[str, Any]:
+    """
+    Get overall prediction accuracy statistics from prediction_outcomes.
+
+    Returns:
+        Dict with accuracy, win_rate, total_pnl, total_predictions.
+    """
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    COUNT(*) as total_predictions,
+                    COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_count,
+                    COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_count,
+                    COALESCE(SUM(return_t7), 0) as total_return
+                FROM prediction_outcomes
+            """)
+            result = session.execute(query)
+            row = _row_to_dict(result)
+            if row:
+                total = row.get("total_predictions", 0) or 0
+                correct = row.get("correct_count", 0) or 0
+                evaluated = row.get("evaluated_count", 0) or 0
+                total_return = float(row.get("total_return", 0) or 0)
+
+                win_rate = (correct / evaluated * 100) if evaluated > 0 else 0.0
+                return {
+                    "total_predictions": total,
+                    "evaluated": evaluated,
+                    "correct": correct,
+                    "win_rate": round(win_rate, 1),
+                    "total_return_pct": round(total_return * 100, 2),
+                }
+            return {}
+    except Exception as e:
+        logger.error(f"Error getting prediction stats: {e}")
+        return {}
+```
+
+After:
+```python
+def get_prediction_stats() -> Dict[str, Any]:
+    """
+    Get overall prediction accuracy statistics from prediction_outcomes.
+
+    Returns:
+        Dict with accuracy, win_rate, total_pnl, total_predictions.
+    """
+    row = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total_predictions,
+            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_count,
+            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_count,
+            COALESCE(SUM(return_t7), 0) as total_return
+        FROM prediction_outcomes
+        """,
+        processor=_row_to_dict,
+        default=None,
+    )
+    if not row:
+        return {}
+
+    total = row.get("total_predictions", 0) or 0
+    correct = row.get("correct_count", 0) or 0
+    evaluated = row.get("evaluated_count", 0) or 0
+    total_return = float(row.get("total_return", 0) or 0)
+
+    win_rate = (correct / evaluated * 100) if evaluated > 0 else 0.0
+    return {
+        "total_predictions": total,
+        "evaluated": evaluated,
+        "correct": correct,
+        "win_rate": round(win_rate, 1),
+        "total_return_pct": round(total_return * 100, 2),
+    }
+```
+
+---
+
+**`get_latest_predictions` (line 392-431) — read-list with post-processing**
+
+Before:
+```python
+def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
+    """
+    Get the most recent completed predictions with outcome data.
+
+    Args:
+        limit: Number of predictions to return.
+
+    Returns:
+        List of prediction dicts with outcome status.
+    """
+    try:
+        with get_session() as session:
+            query = text("""
+                SELECT
+                    p.id as prediction_id,
+                    p.assets,
+                    p.confidence,
+                    p.market_impact,
+                    p.thesis,
+                    p.created_at,
+                    po.prediction_sentiment,
+                    po.correct_t7,
+                    po.return_t7,
+                    po.symbol
+                FROM predictions p
+                LEFT JOIN prediction_outcomes po ON po.prediction_id = p.id
+                WHERE p.analysis_status = 'completed'
+                    AND p.confidence IS NOT NULL
+                ORDER BY p.created_at DESC
+                LIMIT :limit
+            """)
+            result = session.execute(query, {"limit": limit})
+            results = _rows_to_dicts(result)
+            for row_dict in results:
+                if isinstance(row_dict.get("created_at"), datetime):
+                    row_dict["created_at"] = row_dict["created_at"].isoformat()
+            return results
+    except Exception as e:
+        logger.error(f"Error getting latest predictions: {e}")
+        return []
+```
+
+After:
+```python
+def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
+    """
+    Get the most recent completed predictions with outcome data.
+
+    Args:
+        limit: Number of predictions to return.
+
+    Returns:
+        List of prediction dicts with outcome status.
+    """
+    results = _execute_read(
+        """
+        SELECT
+            p.id as prediction_id,
+            p.assets,
+            p.confidence,
+            p.market_impact,
+            p.thesis,
+            p.created_at,
+            po.prediction_sentiment,
+            po.correct_t7,
+            po.return_t7,
+            po.symbol
+        FROM predictions p
+        LEFT JOIN prediction_outcomes po ON po.prediction_id = p.id
+        WHERE p.analysis_status = 'completed'
+            AND p.confidence IS NOT NULL
+        ORDER BY p.created_at DESC
+        LIMIT :limit
+        """,
+        params={"limit": limit},
+        default=[],
+    )
+    if results is None:
+        return []
+    for row_dict in results:
+        if isinstance(row_dict.get("created_at"), datetime):
+            row_dict["created_at"] = row_dict["created_at"].isoformat()
+    return results
+```
+
+---
+
+**`get_last_alert_check` (line 439-461) — custom read (uses fetchone, not fetchall)**
+
+This function uses `result.fetchone()` directly instead of `_row_to_dict` or `_rows_to_dicts`. It requires a custom processor to work with `_execute_read`.
+
+Before:
+```python
+def get_last_alert_check() -> Optional[datetime]:
+    """
+    Get the timestamp of the last alert check from the database.
+
+    Uses a simple key-value approach in a notification_state table,
+    falling back to None if the table doesn't exist yet.
+    """
+    try:
+        with get_session() as session:
+            # Use the most recent alert sent across all subscriptions as a proxy
+            query = text("""
+                SELECT MAX(last_alert_at) as last_check
+                FROM telegram_subscriptions
+                WHERE is_active = true
+            """)
+            result = session.execute(query)
+            row = result.fetchone()
+            if row and row[0]:
+                return row[0]
+            return None
+    except Exception as e:
+        logger.error(f"Error getting last alert check: {e}")
+        return None
+```
+
+After:
+```python
+def _extract_scalar(result) -> Any:
+    """Extract a single scalar value from a query result."""
+    row = result.fetchone()
+    if row and row[0]:
+        return row[0]
+    return None
+
+
+def get_last_alert_check() -> Optional[datetime]:
+    """
+    Get the timestamp of the last alert check from the database.
+
+    Uses the most recent last_alert_at across all active subscriptions as a proxy.
+    """
+    return _execute_read(
+        """
+        SELECT MAX(last_alert_at) as last_check
+        FROM telegram_subscriptions
+        WHERE is_active = true
+        """,
+        processor=_extract_scalar,
+        default=None,
+    )
+```
+
+Note: `_extract_scalar` is added as a private helper alongside `_row_to_dict` and `_rows_to_dicts`. Place it right after `_rows_to_dicts` (after line 33) and before `_execute_read`.
+
+### Step 4: Run the tests again after refactoring
+
+Run:
+```bash
+./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v
+```
+
+All 64 tests must still pass. If any fail, the refactor introduced a regression -- fix before proceeding.
+
+### Step 5: Run the full test suite
+
+Run:
+```bash
+./venv/bin/python -m pytest -v
+```
+
+Verify no tests outside `shit_tests/notifications/` broke.
+
+### Step 6: Run linting and formatting
+
+```bash
+./venv/bin/python -m ruff check notifications/db.py shit_tests/notifications/test_db.py
+./venv/bin/python -m ruff format notifications/db.py shit_tests/notifications/test_db.py
+```
+
+---
+
+## Complete Final State of `notifications/db.py`
+
+For absolute clarity, here is the full file after all changes:
+
+```python
+"""
+Database operations for the notifications module.
+
+Handles subscription CRUD, alert history, and last-check timestamp persistence.
+Uses the project's sync session pattern from shit/db/sync_session.py.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import text
+
+from shit.db.sync_session import get_session
+from shit.logging import get_service_logger
+
+logger = get_service_logger("notifications_db")
+
+
+def _row_to_dict(result) -> Optional[Dict[str, Any]]:
+    """Convert a single query result row to a dictionary."""
+    rows = result.fetchall()
+    if not rows:
+        return None
+    columns = result.keys()
+    return dict(zip(columns, rows[0]))
+
+
+def _rows_to_dicts(result) -> List[Dict[str, Any]]:
+    """Convert query result rows to a list of dictionaries."""
+    rows = result.fetchall()
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def _extract_scalar(result) -> Any:
+    """Extract a single scalar value from a query result."""
+    row = result.fetchone()
+    if row and row[0]:
+        return row[0]
+    return None
+
+
+def _execute_read(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+    processor=_rows_to_dicts,
+    default: Any = None,
+) -> Any:
+    """
+    Execute a read query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+        processor: Function to process the result (default: _rows_to_dicts).
+                   Use _row_to_dict for single-row queries.
+        default: Value to return on error or empty result.
+
+    Returns:
+        Processed query result, or default on error.
+    """
+    try:
+        with get_session() as session:
+            result = session.execute(text(query_str), params or {})
+            return processor(result)
+    except Exception as e:
+        logger.error(f"Read query error: {e}")
+        return default
+
+
+def _execute_write(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """
+    Execute a write query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+
+    Returns:
+        True if successful, False on error.
+    """
+    try:
+        with get_session() as session:
+            session.execute(text(query_str), params or {})
+        return True
+    except Exception as e:
+        logger.error(f"Write query error: {e}")
+        return False
+
+
+# Whitelist of columns that can be updated via update_subscription().
+# Prevents SQL injection through dynamic kwargs keys.
+_UPDATABLE_COLUMNS = frozenset({
+    "chat_type",
+    "username",
+    "first_name",
+    "last_name",
+    "title",
+    "is_active",
+    "subscribed_at",
+    "unsubscribed_at",
+    "alert_preferences",
+    "last_alert_at",
+    "alerts_sent_count",
+    "consecutive_errors",
+    "last_error",
+    "last_interaction_at",
+})
+
+
+# ============================================================
+# Subscription CRUD
+# ============================================================
+
+
+def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Get a Telegram subscription by chat_id.
+
+    Args:
+        chat_id: Telegram chat ID.
+
+    Returns:
+        Subscription dict or None if not found.
+    """
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, unsubscribed_at,
+            alert_preferences, last_alert_at, alerts_sent_count,
+            last_interaction_at, consecutive_errors, last_error,
+            created_at, updated_at
+        FROM telegram_subscriptions
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+        processor=_row_to_dict,
+        default=None,
+    )
+
+
+def get_active_subscriptions() -> List[Dict[str, Any]]:
+    """
+    Get all active Telegram subscriptions.
+
+    Returns:
+        List of subscription dicts.
+    """
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, alert_preferences,
+            last_alert_at, alerts_sent_count, consecutive_errors
+        FROM telegram_subscriptions
+        WHERE is_active = true
+            AND consecutive_errors < 5
+        ORDER BY subscribed_at ASC
+        """,
+        default=[],
+    )
+
+
+def create_subscription(
+    chat_id: str,
+    chat_type: str,
+    username: Optional[str] = None,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+    title: Optional[str] = None,
+) -> bool:
+    """
+    Create a new Telegram subscription or reactivate an existing one.
+
+    Args:
+        chat_id: Telegram chat ID.
+        chat_type: Type of chat (private, group, supergroup, channel).
+        username: Optional username.
+        first_name: Optional first name.
+        last_name: Optional last name.
+        title: Optional group/channel title.
+
+    Returns:
+        True if created successfully.
+    """
+    try:
+        existing = get_subscription(chat_id)
+        if existing:
+            if not existing.get("is_active"):
+                return update_subscription(
+                    chat_id, is_active=True, unsubscribed_at=None
+                )
+            return True
+
+        default_prefs = {
+            "min_confidence": 0.7,
+            "assets_of_interest": [],
+            "sentiment_filter": "all",
+            "quiet_hours_enabled": False,
+            "quiet_hours_start": "22:00",
+            "quiet_hours_end": "08:00",
+        }
+
+        success = _execute_write(
+            """
+            INSERT INTO telegram_subscriptions (
+                chat_id, chat_type, username, first_name, last_name, title,
+                is_active, subscribed_at, alert_preferences,
+                alerts_sent_count, consecutive_errors,
+                created_at, updated_at
+            ) VALUES (
+                :chat_id, :chat_type, :username, :first_name, :last_name, :title,
+                true, NOW(), :alert_preferences,
+                0, 0,
+                NOW(), NOW()
+            )
+            """,
+            params={
+                "chat_id": str(chat_id),
+                "chat_type": chat_type,
+                "username": username,
+                "first_name": first_name,
+                "last_name": last_name,
+                "title": title,
+                "alert_preferences": json.dumps(default_prefs),
+            },
+        )
+        if success:
+            logger.info(f"Created Telegram subscription for chat_id {chat_id}")
+        return success
+    except Exception as e:
+        logger.error(f"Error creating subscription for chat_id {chat_id}: {e}")
+        return False
+
+
+def update_subscription(chat_id: str, **kwargs: Any) -> bool:
+    """
+    Update a Telegram subscription.
+
+    Args:
+        chat_id: Telegram chat ID.
+        **kwargs: Fields to update.
+
+    Returns:
+        True if updated successfully.
+    """
+    try:
+        if not kwargs:
+            return True
+
+        set_clauses = []
+        params: Dict[str, Any] = {"chat_id": str(chat_id)}
+
+        for key, value in kwargs.items():
+            if key not in _UPDATABLE_COLUMNS:
+                raise ValueError(f"Invalid column name for subscription update: {key}")
+            if key == "alert_preferences" and isinstance(value, dict):
+                value = json.dumps(value)
+            set_clauses.append(f"{key} = :{key}")
+            params[key] = value
+
+        set_clauses.append("updated_at = NOW()")
+
+        with get_session() as session:
+            query = text(f"""
+                UPDATE telegram_subscriptions
+                SET {", ".join(set_clauses)}
+                WHERE chat_id = :chat_id
+            """)
+            session.execute(query, params)
+        logger.info(f"Updated Telegram subscription for chat_id {chat_id}")
+        return True
+    except Exception as e:
+        logger.error(f"Error updating subscription for chat_id {chat_id}: {e}")
+        return False
+
+
+def deactivate_subscription(chat_id: str) -> bool:
+    """Deactivate (unsubscribe) a Telegram subscription."""
+    return update_subscription(
+        chat_id, is_active=False, unsubscribed_at=datetime.utcnow()
+    )
+
+
+def record_alert_sent(chat_id: str) -> bool:
+    """Record that an alert was sent to this subscription."""
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET last_alert_at = NOW(),
+            alerts_sent_count = alerts_sent_count + 1,
+            consecutive_errors = 0,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+    )
+
+
+def record_error(chat_id: str, error_message: str) -> bool:
+    """Record an error for this subscription."""
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET consecutive_errors = consecutive_errors + 1,
+            last_error = :error_message,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id), "error_message": error_message},
+    )
+
+
+def get_subscription_stats() -> Dict[str, Any]:
+    """Get statistics about Telegram subscriptions."""
+    result = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total,
+            COUNT(CASE WHEN is_active = true THEN 1 END) as active,
+            COUNT(CASE WHEN chat_type = 'private' THEN 1 END) as private_chats,
+            COUNT(CASE WHEN chat_type IN ('group', 'supergroup') THEN 1 END) as groups,
+            COUNT(CASE WHEN chat_type = 'channel' THEN 1 END) as channels,
+            SUM(alerts_sent_count) as total_alerts_sent
+        FROM telegram_subscriptions
+        """,
+        processor=_row_to_dict,
+        default=None,
+    )
+    return result or {}
+
+
+# ============================================================
+# Alert queries
+# ============================================================
+
+
+def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
+    """
+    Get new completed predictions created after the given timestamp.
+
+    Args:
+        since: Only return predictions created after this timestamp.
+
+    Returns:
+        List of prediction dicts with associated shitpost data.
+    """
+    results = _execute_read(
+        """
+        SELECT
+            tss.timestamp,
+            tss.text,
+            tss.shitpost_id,
+            p.id as prediction_id,
+            p.assets,
+            p.market_impact,
+            p.confidence,
+            p.thesis,
+            p.analysis_status,
+            p.created_at as prediction_created_at
+        FROM predictions p
+        INNER JOIN truth_social_shitposts tss
+            ON tss.shitpost_id = p.shitpost_id
+        WHERE p.analysis_status = 'completed'
+            AND p.created_at > :since
+            AND p.confidence IS NOT NULL
+            AND p.assets IS NOT NULL
+            AND p.assets::jsonb <> '[]'::jsonb
+        ORDER BY p.created_at DESC
+        LIMIT 50
+        """,
+        params={"since": since},
+        default=[],
+    )
+    if results is None:
+        return []
+    for row_dict in results:
+        if isinstance(row_dict.get("timestamp"), datetime):
+            row_dict["timestamp"] = row_dict["timestamp"].isoformat()
+        if isinstance(row_dict.get("prediction_created_at"), datetime):
+            row_dict["prediction_created_at"] = row_dict[
+                "prediction_created_at"
+            ].isoformat()
+    return results
+
+
+def get_prediction_stats() -> Dict[str, Any]:
+    """
+    Get overall prediction accuracy statistics from prediction_outcomes.
+
+    Returns:
+        Dict with accuracy, win_rate, total_pnl, total_predictions.
+    """
+    row = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total_predictions,
+            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_count,
+            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_count,
+            COALESCE(SUM(return_t7), 0) as total_return
+        FROM prediction_outcomes
+        """,
+        processor=_row_to_dict,
+        default=None,
+    )
+    if not row:
+        return {}
+
+    total = row.get("total_predictions", 0) or 0
+    correct = row.get("correct_count", 0) or 0
+    evaluated = row.get("evaluated_count", 0) or 0
+    total_return = float(row.get("total_return", 0) or 0)
+
+    win_rate = (correct / evaluated * 100) if evaluated > 0 else 0.0
+    return {
+        "total_predictions": total,
+        "evaluated": evaluated,
+        "correct": correct,
+        "win_rate": round(win_rate, 1),
+        "total_return_pct": round(total_return * 100, 2),
+    }
+
+
+def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
+    """
+    Get the most recent completed predictions with outcome data.
+
+    Args:
+        limit: Number of predictions to return.
+
+    Returns:
+        List of prediction dicts with outcome status.
+    """
+    results = _execute_read(
+        """
+        SELECT
+            p.id as prediction_id,
+            p.assets,
+            p.confidence,
+            p.market_impact,
+            p.thesis,
+            p.created_at,
+            po.prediction_sentiment,
+            po.correct_t7,
+            po.return_t7,
+            po.symbol
+        FROM predictions p
+        LEFT JOIN prediction_outcomes po ON po.prediction_id = p.id
+        WHERE p.analysis_status = 'completed'
+            AND p.confidence IS NOT NULL
+        ORDER BY p.created_at DESC
+        LIMIT :limit
+        """,
+        params={"limit": limit},
+        default=[],
+    )
+    if results is None:
+        return []
+    for row_dict in results:
+        if isinstance(row_dict.get("created_at"), datetime):
+            row_dict["created_at"] = row_dict["created_at"].isoformat()
+    return results
+
+
+# ============================================================
+# Last check timestamp persistence
+# ============================================================
+
+
+def get_last_alert_check() -> Optional[datetime]:
+    """
+    Get the timestamp of the last alert check from the database.
+
+    Uses the most recent last_alert_at across all active subscriptions as a proxy.
+    """
+    return _execute_read(
+        """
+        SELECT MAX(last_alert_at) as last_check
+        FROM telegram_subscriptions
+        WHERE is_active = true
+        """,
+        processor=_extract_scalar,
+        default=None,
+    )
+```
+
+---
+
+## Test Plan
+
+### New tests added (55 tests across 13 test classes)
+
+| Class | Tests | What it verifies |
+|---|---|---|
+| `TestRowToDict` | 4 | Single row, multiple rows (first returned), empty, None values |
+| `TestRowsToDicts` | 3 | Multiple rows, empty, single row |
+| `TestGetSubscription` | 4 | Found, not found, database error, int→str coercion |
+| `TestGetActiveSubscriptions` | 3 | List returned, empty, database error |
+| `TestCreateSubscription` | 5 | New creation, reactivation, already active, DB error, default None params |
+| `TestUpdateSubscription` | 5 | JSON serialization, string pass-through, multi-column, DB error, invalid column |
+| `TestDeactivateSubscription` | 2 | Sets is_active=False, error case |
+| `TestRecordAlertSent` | 3 | Success, int→str coercion, DB error |
+| `TestRecordError` | 3 | Success, params passed correctly, DB error |
+| `TestGetSubscriptionStats` | 3 | Stats dict, empty table, DB error |
+| `TestGetNewPredictionsSince` | 5 | Results returned, datetime serialization, string not converted, empty, DB error |
+| `TestGetPredictionStats` | 5 | Computed stats, zero-division safety, None values, no rows, DB error |
+| `TestGetLatestPredictions` | 5 | Results with outcomes, datetime serialization, limit param, default limit, DB error |
+| `TestGetLastAlertCheck` | 4 | datetime returned, NULL → None, no rows → None, DB error |
+
+### Existing tests preserved (9 tests across 2 test classes)
+
+| Class | Tests |
+|---|---|
+| `TestUpdatableColumnsWhitelist` | 3 |
+| `TestUpdateSubscriptionInjectionPrevention` | 6 |
+
+### Coverage expectations
+
+Before: ~15% coverage of `notifications/db.py` (only `update_subscription` and `_UPDATABLE_COLUMNS`)
+
+After: ~95%+ coverage. Every public function has at least:
+- Happy path test
+- Error/exception test
+- Edge case test (empty results, None values, type coercion)
+
+### Running tests
+
+```bash
+# Just the notifications tests
+./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v
+
+# Full test suite
+./venv/bin/python -m pytest -v
+
+# With coverage for notifications/db.py
+./venv/bin/python -m pytest shit_tests/notifications/test_db.py --cov=notifications.db --cov-report=term-missing
+```
+
+---
+
+## Documentation Updates
+
+### Inline comments
+- The new `_execute_read` and `_execute_write` helpers have full docstrings explaining args and return values.
+- The `_extract_scalar` helper has a docstring.
+- The `get_last_alert_check` docstring is updated (removed reference to "notification_state table").
+
+### No external documentation changes needed
+- This is an internal refactor with test additions. No README, API doc, or user-facing documentation changes.
+
+---
+
+## Stress Testing & Edge Cases
+
+### Edge cases handled by tests
+
+1. **`_row_to_dict` with multiple rows**: Only the first row is returned (matches current behavior).
+2. **`get_subscription` with int chat_id**: Coerced to string before query.
+3. **`create_subscription` for already-active sub**: Returns True immediately, no INSERT.
+4. **`create_subscription` for inactive sub**: Calls `update_subscription` to reactivate.
+5. **`update_subscription` with dict alert_preferences**: JSON-serialized before query.
+6. **`update_subscription` with string alert_preferences**: Passed as-is (no double-serialization).
+7. **`get_prediction_stats` with zero evaluated**: Division by zero avoided, returns 0.0.
+8. **`get_prediction_stats` with None DB values**: `or 0` fallback prevents TypeError.
+9. **`get_new_predictions_since` with string timestamps**: Left as-is (isinstance check).
+10. **`get_last_alert_check` with NULL max**: Returns None, not an error.
+
+### Error scenarios
+
+Every function that touches the database is tested with a mock that raises `Exception`. The expected behavior is:
+- Read functions return their default (None, [], or {})
+- Write functions return False
+- Errors are logged (verified by the fact that no exception propagates)
+
+---
+
+## Verification Checklist
+
+- [ ] All 64 tests pass: `./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v`
+- [ ] Full test suite passes: `./venv/bin/python -m pytest -v`
+- [ ] Linting passes: `./venv/bin/python -m ruff check notifications/db.py shit_tests/notifications/test_db.py`
+- [ ] Formatting passes: `./venv/bin/python -m ruff format --check notifications/db.py shit_tests/notifications/test_db.py`
+- [ ] No new imports added to conftest (existing `mock_sync_session` autouse fixture is sufficient)
+- [ ] `_execute_read` and `_execute_write` are private (underscore prefix)
+- [ ] `_extract_scalar` is private (underscore prefix)
+- [ ] `update_subscription` is NOT refactored (keeps its custom validation logic)
+- [ ] `create_subscription` outer try/except is preserved (wraps get_subscription + _execute_write)
+- [ ] All public function signatures are unchanged (no breaking changes)
+- [ ] All return types are unchanged (no behavioral changes)
+- [ ] Coverage of `notifications/db.py` is 95%+ (run with `--cov=notifications.db`)
+
+---
+
+## What NOT To Do
+
+1. **Do NOT refactor `update_subscription` to use `_execute_write`.** It has custom validation logic (column whitelist, dynamic SET clause) that does not fit the generic helper pattern. The dynamic `text(f"...")` construction requires the session to be in the same scope as the validation. Leave it as-is.
+
+2. **Do NOT make `_execute_read`/`_execute_write` public.** They are internal helpers for this module only. Other modules (`api/dependencies.py`, `shitty_ui/data/base.py`) have their own query execution patterns.
+
+3. **Do NOT change the `mock_sync_session` conftest fixture.** It works correctly as-is. The fixture yields the mock session, and `__enter__` returns the same mock, so `session.execute(...)` calls land on the mock. Adding complexity here will break existing tests.
+
+4. **Do NOT add `_execute_read`/`_execute_write` to test imports.** Tests should test public function behavior, not internal helpers. The helpers are tested implicitly through the public functions that use them.
+
+5. **Do NOT change default return values.** Each function has a specific default (`None`, `[]`, `{}`, `False`). The refactored versions must return the same defaults. Pay special attention to `get_subscription_stats()` which returns `{}` on error, and `get_new_predictions_since()` which returns `[]`.
+
+6. **Do NOT remove the `text()` import.** Even though most functions no longer call `text()` directly, `update_subscription` still uses it, and `_execute_read`/`_execute_write` use it internally.
+
+7. **Do NOT add type annotations to the `processor` parameter of `_execute_read`.** The processors (`_row_to_dict`, `_rows_to_dicts`, `_extract_scalar`) have different return types. Using `Callable` with a union would add complexity without value. The default `_rows_to_dicts` is sufficient documentation.
+
+8. **Do NOT write tests before reading the file.** Step 1 says to write tests, but the implementation plan assumes you have already read the source. If implementing, read `notifications/db.py` first to understand current behavior, then write tests, then refactor.
+
+9. **Do NOT change the order of functions in `db.py`.** Keep the same logical grouping: helpers at top, subscription CRUD in the middle, alert queries below, last-check at the bottom. The new helpers (`_extract_scalar`, `_execute_read`, `_execute_write`) go between the existing helpers and `_UPDATABLE_COLUMNS`.

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
@@ -1,0 +1,340 @@
+# Phase 03: Remove Unused Dependencies, Bump Safe Minors
+
+## Header
+
+| Field | Value |
+|-------|-------|
+| **PR Title** | `chore: remove unused dependencies, bump safe minors` |
+| **Risk** | Low |
+| **Effort** | Low |
+| **Files Modified** | 1 (`requirements.txt`) |
+| **Files Created** | 0 |
+| **Files Deleted** | 0 |
+
+---
+
+## Context
+
+The `requirements.txt` file has accumulated four completely unused packages (`asyncio-mqtt`, `apscheduler`, `structlog`, `asyncio-throttle`) that are installed on every Railway deploy and in every developer environment for no reason. They add install time, increase the attack surface, and confuse new contributors who may assume they are in use.
+
+Additionally, several safe minor version bumps are available (`sqlalchemy`, `psycopg`, `click`, `rich`) that should be taken now. The file also has misleading "Phase 2" section labels from early project planning that no longer apply -- these should be reorganized for clarity.
+
+This is a low-risk, low-effort PR that touches only `requirements.txt`.
+
+---
+
+## Dependencies
+
+- **Depends on**: None (this phase touches only `requirements.txt` and is independent of all other phases)
+- **Unlocks**: None
+- **Parallel safe**: Yes -- no other phase in this session modifies `requirements.txt`
+
+---
+
+## Detailed Implementation Plan
+
+### Step 1: Understand the current file
+
+The current `requirements.txt` is at `/Users/chris/Projects/shitpost-alpha/requirements.txt` (65 lines including trailing newline).
+
+**COMPLETE current file (before):**
+
+```
+# Core dependencies
+pydantic>=2.0.0
+sqlalchemy[asyncio]>=2.0.47
+aiosqlite>=0.19.0
+asyncio-mqtt>=0.16.0
+
+# HTTP and web scraping
+aiohttp>=3.8.0
+requests>=2.31.0
+certifi>=2026.1.4
+urllib3>=2.6.3
+
+# AWS S3
+boto3>=1.42.0
+
+# LLM providers
+openai>=2.0.0,<3.0.0
+anthropic>=0.83.0
+
+# Database
+psycopg[binary]>=3.2.0  # For PostgreSQL async support
+psycopg2-binary>=2.9.0  # For PostgreSQL sync support (dashboard)
+asyncpg>=0.29.0  # For PostgreSQL async support (dashboard)
+
+# Testing
+pytest>=8.4.0
+pytest-asyncio>=0.25.0
+pytest-cov>=6.2.0
+vcrpy>=7.0.0
+
+# Development and utilities
+python-dotenv>=1.0.0
+pydantic-settings>=2.0.0
+click>=8.1.0
+rich>=13.0.0
+
+# SMS/Alerting (Phase 2)
+twilio>=8.0.0
+
+# Job scheduling (Phase 2)
+apscheduler>=3.10.0
+
+# Logging and monitoring
+structlog>=23.0.0
+
+# Data processing
+pandas>=2.0.0
+numpy>=1.24.0
+
+# Market data
+yfinance>=0.2.48
+exchange_calendars>=4.5.0
+
+# Dashboard dependencies
+dash>=4.0.0,<5.0.0
+plotly>=5.15.0
+dash-bootstrap-components>=2.0.0,<3.0.0
+
+# Async utilities
+asyncio-throttle>=1.0.0
+
+# FastAPI web server (new React frontend API)
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+```
+
+### Step 2: Apply all changes
+
+The following changes are applied simultaneously in a single edit:
+
+1. **Remove `asyncio-mqtt>=0.16.0`** (line 5) -- zero imports in entire codebase.
+2. **Remove `apscheduler>=3.10.0`** (line 41) -- zero imports, labeled "Phase 2" but never implemented.
+3. **Remove `structlog>=23.0.0`** (line 44) -- zero imports; project uses custom `shit.logging` module.
+4. **Remove `asyncio-throttle>=1.0.0`** (line 60) -- zero imports in entire codebase.
+5. **Remove the misleading "Phase 2" section headers** (lines 37, 40) and the orphaned "Logging and monitoring" + "Async utilities" section headers (lines 43, 59).
+6. **Move `twilio` under a new "Notifications" section** with an accurate comment explaining the lazy import.
+7. **Update `psycopg2-binary` comment** to explain its actual consumer and retirement plan.
+8. **Update `asyncpg` comment** -- the current comment says "For PostgreSQL async support (dashboard)" but the async driver is actually `psycopg[binary]` (the codebase uses `postgresql+psycopg://` URLs). The `asyncpg` package is referenced only in URL string cleanup in `sync_session.py:22` for backwards compatibility. Update the comment to reflect this.
+9. **Bump `sqlalchemy[asyncio]`**: `>=2.0.47` to `>=2.0.48` (patch bump, no breaking changes).
+10. **Bump `psycopg[binary]`**: `>=3.2.0` to `>=3.3.0` (minor bump within same major, async driver improvements).
+11. **Bump `click`**: `>=8.1.0` to `>=8.3.0` (minor bump, bug fixes only).
+12. **Bump `rich`**: `>=13.0.0` to `>=14.3.0` (minor bump to match installed `14.1.0`; floor should be at or near installed version).
+
+### Step 3: Write the new file
+
+**COMPLETE new file (after):**
+
+```
+# Core dependencies
+pydantic>=2.0.0
+sqlalchemy[asyncio]>=2.0.48
+aiosqlite>=0.19.0
+
+# HTTP and web scraping
+aiohttp>=3.8.0
+requests>=2.31.0
+certifi>=2026.1.4
+urllib3>=2.6.3
+
+# AWS S3
+boto3>=1.42.0
+
+# LLM providers
+openai>=2.0.0,<3.0.0
+anthropic>=0.83.0
+
+# Database
+psycopg[binary]>=3.3.0  # Async PostgreSQL driver (used by shit/db/database_client.py)
+psycopg2-binary>=2.9.0  # Sync PostgreSQL driver for shit/db/sync_session.py — remove when Dash UI retired
+asyncpg>=0.29.0  # Legacy: only referenced in URL cleanup (sync_session.py:22), not directly imported
+
+# Testing
+pytest>=8.4.0
+pytest-asyncio>=0.25.0
+pytest-cov>=6.2.0
+vcrpy>=7.0.0
+
+# Development and utilities
+python-dotenv>=1.0.0
+pydantic-settings>=2.0.0
+click>=8.3.0
+rich>=14.3.0
+
+# Notifications
+twilio>=8.0.0  # Lazy import in notifications/dispatcher.py:331 for SMS delivery
+
+# Data processing
+pandas>=2.0.0
+numpy>=1.24.0
+
+# Market data
+yfinance>=0.2.48
+exchange_calendars>=4.5.0
+
+# Dashboard dependencies
+dash>=4.0.0,<5.0.0
+plotly>=5.15.0
+dash-bootstrap-components>=2.0.0,<3.0.0
+
+# FastAPI web server (new React frontend API)
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+```
+
+### Exact diff summary
+
+| Line(s) in old file | Change | Reason |
+|---|---|---|
+| 3 | `>=2.0.47` to `>=2.0.48` | Patch bump for SQLAlchemy |
+| 5 | **Deleted** `asyncio-mqtt>=0.16.0` | Zero imports in codebase |
+| 21 | Comment updated, `>=3.2.0` to `>=3.3.0` | Minor bump + accurate comment |
+| 22 | Comment rewritten | Explains consumer + retirement plan |
+| 23 | Comment rewritten | Clarifies `asyncpg` is legacy/not directly imported |
+| 34 | `>=8.1.0` to `>=8.3.0` | Minor bump for Click |
+| 35 | `>=13.0.0` to `>=14.3.0` | Minor bump for Rich (matches installed) |
+| 37-38 | Section renamed from "SMS/Alerting (Phase 2)" to "Notifications" | Accurate section name |
+| 38 | Comment added to `twilio` | Explains lazy import location |
+| 40-41 | **Deleted** `apscheduler>=3.10.0` + section header | Zero imports |
+| 43-44 | **Deleted** `structlog>=23.0.0` + section header | Zero imports, project uses `shit.logging` |
+| 59-60 | **Deleted** `asyncio-throttle>=1.0.0` + section header | Zero imports |
+
+---
+
+## Test Plan
+
+This phase does not add or change any source code, so no new tests are needed. The verification is entirely about confirming that the remaining dependencies still install correctly and the test suite still passes.
+
+### Existing tests to run
+
+All existing tests -- there are no test modifications, but we need to confirm nothing breaks:
+
+```bash
+source venv/bin/activate && pytest -v
+```
+
+Or using the venv python directly:
+
+```bash
+./venv/bin/python -m pytest -v
+```
+
+### Manual verification steps
+
+1. **Reinstall from updated requirements.txt:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Confirm: no errors, all packages resolve.
+
+2. **Verify removed packages are no longer required by confirming zero imports:**
+   ```bash
+   grep -rn "import asyncio_mqtt\|from asyncio_mqtt\|import apscheduler\|from apscheduler\|import structlog\|from structlog\|import asyncio_throttle\|from asyncio_throttle" --include="*.py" .
+   ```
+   Expected: zero matches (excluding `venv/` and `.claude/`).
+
+3. **Verify twilio lazy import still works:**
+   ```bash
+   python -c "from twilio.rest import Client; print('twilio OK')"
+   ```
+
+4. **Run full test suite:**
+   ```bash
+   pytest -v
+   ```
+   Expected: same pass/fail counts as before (approximately 2,338 passing, 5 pre-existing config failures).
+
+5. **Verify bumped packages install correctly:**
+   ```bash
+   pip install "sqlalchemy[asyncio]>=2.0.48" "psycopg[binary]>=3.3.0" "click>=8.3.0" "rich>=14.3.0"
+   ```
+
+---
+
+## Documentation Updates
+
+### CLAUDE.md
+
+No changes needed. The `requirements.txt` structure is not documented in CLAUDE.md beyond general references to `pip install -r requirements.txt`.
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Removed
+- **Unused dependencies** - Removed `asyncio-mqtt`, `apscheduler`, `structlog`, `asyncio-throttle` from requirements.txt (zero imports in codebase)
+- **Misleading "Phase 2" labels** - Reorganized requirements.txt sections for clarity
+
+### Changed
+- **Dependency version bumps** - Bumped minimum versions for `sqlalchemy[asyncio]` (2.0.48), `psycopg[binary]` (3.3.0), `click` (8.3.0), `rich` (14.3.0)
+- **Dependency comments** - Added context comments to `twilio`, `psycopg2-binary`, and `asyncpg` explaining their usage and retirement plans
+```
+
+---
+
+## Stress Testing & Edge Cases
+
+### Edge case: Railway build with new version floors
+
+The bumped version floors (`>=2.0.48`, `>=3.3.0`, `>=8.3.0`, `>=14.3.0`) are all below or equal to the currently installed versions in production (sqlalchemy 2.0.47->2.0.48, psycopg 3.2.10->3.3.0 minimum, click 8.2.1->8.3.0 minimum, rich 14.1.0->14.3.0 minimum). On Railway's next deploy, `pip install` will pull the latest compatible versions, which are the same or newer than what is already running.
+
+**Risk**: psycopg `>=3.3.0` raises the floor above the currently installed `3.2.10`. This means pip will upgrade to `3.3.x` on next install. The psycopg 3.3.x series is backwards compatible with 3.2.x (same major version, non-breaking minor). The SQLAlchemy integration (`postgresql+psycopg://`) is stable across both.
+
+**Risk**: rich `>=14.3.0` raises the floor above the currently installed `14.1.0`. Rich 14.x is backwards compatible within the major version. Our usage is limited to CLI output formatting.
+
+### Edge case: asyncpg as a transitive dependency
+
+Even though `asyncpg` is not directly imported, it may be pulled in as a transitive dependency by other packages. Keeping it in `requirements.txt` with an explanatory comment is the right call -- it documents why the package exists and when it can be removed.
+
+### Edge case: structlog as a transitive dependency
+
+`structlog` is NOT a transitive dependency of any package in our dependency tree. It was added speculatively and never used. Safe to remove.
+
+---
+
+## Verification Checklist
+
+- [ ] `requirements.txt` matches the "COMPLETE new file (after)" exactly
+- [ ] `asyncio-mqtt` line is gone
+- [ ] `apscheduler` line is gone
+- [ ] `structlog` line is gone
+- [ ] `asyncio-throttle` line is gone
+- [ ] No "Phase 2" text anywhere in the file
+- [ ] `twilio` has a comment referencing `notifications/dispatcher.py:331`
+- [ ] `psycopg2-binary` comment mentions `sync_session.py` and Dash UI retirement
+- [ ] `asyncpg` comment mentions it is legacy / not directly imported
+- [ ] `sqlalchemy[asyncio]>=2.0.48` (was `>=2.0.47`)
+- [ ] `psycopg[binary]>=3.3.0` (was `>=3.2.0`)
+- [ ] `click>=8.3.0` (was `>=8.1.0`)
+- [ ] `rich>=14.3.0` (was `>=13.0.0`)
+- [ ] `pip install -r requirements.txt` succeeds with no errors
+- [ ] `pytest -v` passes (same results as before)
+- [ ] Zero grep hits for imports of removed packages
+- [ ] CHANGELOG.md updated with Removed and Changed entries
+
+---
+
+## What NOT To Do
+
+1. **Do NOT remove `twilio`**. It has a lazy import at `notifications/dispatcher.py:331`. It is a real dependency, just loaded at runtime rather than at module level. The `except ImportError` guard (line 345) means the app degrades gracefully, but the package should remain in requirements.
+
+2. **Do NOT remove `asyncpg`**. Although it is not directly imported anywhere, it is referenced in URL cleanup logic (`sync_session.py:22`) and may be a transitive dependency expectation. The correct action is to annotate it with a comment, not remove it. A separate PR can evaluate full removal after the Dash UI is retired.
+
+3. **Do NOT remove `psycopg2-binary`**. It is the sync PostgreSQL driver used by `shit/db/sync_session.py` for the Dash dashboard and notifications module. It will be removed when the Dash UI is retired, not before.
+
+4. **Do NOT bump major versions**. The following upgrades are available but require their own dedicated PRs due to breaking API changes:
+   - `pandas` 2.x to 3.x (breaking DataFrame API changes)
+   - `pytest` 8.x to 9.x (potential test runner behavior changes)
+   - `protobuf` 6.x to 7.x (breaking serialization changes)
+   - `vcrpy` 7.x to 8.x (breaking cassette format changes)
+
+5. **Do NOT reorganize the entire file**. Keep the existing section groupings intact (Core, HTTP, AWS, LLM, Database, Testing, etc.). Only rename/remove the "Phase 2" sections and the orphaned section headers for removed packages.
+
+6. **Do NOT pin exact versions** (e.g., `==2.0.48`). The project uses `>=` minimum floor pins throughout, which is the correct pattern for an application (not a library). Maintain this convention.
+
+7. **Do NOT add new dependencies**. This PR is strictly about cleanup and minor bumps. Any new packages belong in their own PRs.
+
+8. **Do NOT forget to update CHANGELOG.md**. Every PR in this project requires a changelog entry per CLAUDE.md conventions.

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/04_outcome-calculator-decomposition.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/04_outcome-calculator-decomposition.md
@@ -1,0 +1,1466 @@
+# Phase 04: Decompose outcome_calculator + Split market_data CLI
+
+- **PR Title**: `refactor: decompose outcome_calculator + split market_data CLI`
+- **Risk**: Medium (refactoring actively-used production code, but 725-line test file provides safety net)
+- **Estimated Effort**: Medium
+- **Files Modified**: 2 (`shit/market_data/outcome_calculator.py`, `shit/market_data/cli.py`)
+- **Files Created**: 3 (`shit/market_data/cli_fetch.py`, `shit/market_data/cli_outcomes.py`, `shit/market_data/cli_registry.py`)
+- **Files Deleted**: 0
+
+---
+
+## Context
+
+### Why This Change Matters
+
+`_calculate_single_outcome` in `shit/market_data/outcome_calculator.py` is 245 lines with 8 parameters. It handles three distinct responsibilities in a single method:
+
+1. **Base price resolution** (lines 170-244) — fetching the T+0 reference price with retry logic
+2. **Trading-day timeframe filling** (lines 248-311) — iterating T+1/T+3/T+7/T+30 and computing returns/correctness/PnL
+3. **Intraday price filling** (lines 313-381) — same_day and 1h price snapshots
+
+Similarly, `shit/market_data/cli.py` is 754 lines containing 14 Click commands that serve three unrelated domains: price fetching, outcome calculation, and ticker registry management. Finding a specific command requires scrolling through the entire file.
+
+Both files are actively used in production (Railway cron workers call the outcome calculator; developers use the CLI for ad-hoc operations). The existing 725-line test file (`test_outcome_calculator.py`) and 354-line CLI test file (`test_market_data_cli.py`) provide a comprehensive safety net for this refactoring.
+
+### Goal
+
+Reduce cognitive load and improve maintainability by:
+- Breaking `_calculate_single_outcome` into 3 focused helper methods (~50-80 lines each)
+- Reducing the main method to ~40-50 lines of orchestration
+- Splitting the CLI into domain-specific submodules while preserving the single Click group entry point
+
+---
+
+## Dependencies
+
+- **Depends on**: None (standalone refactoring)
+- **Unlocks**: None (quality-of-life improvement)
+- **Parallel-safe**: Yes, this phase touches files not modified by other phases in this session
+
+---
+
+## Detailed Implementation Plan
+
+### Part 1: Decompose `_calculate_single_outcome`
+
+The current method at lines 158-402 of `outcome_calculator.py` will be split into three private helpers plus a slimmed-down orchestrator.
+
+#### Step 1A: Extract `_resolve_base_price`
+
+This helper extracts lines 170-244 of the current `_calculate_single_outcome` — the logic that checks the failed symbols cache, looks up existing outcomes, creates/reuses the outcome object, and fetches the T+0 price with retry.
+
+**New method** — add immediately after `_calculate_single_outcome` (which will be rewritten in Step 1D):
+
+```python
+def _resolve_base_price(
+    self,
+    symbol: str,
+    prediction_date: date,
+    prediction_id: int,
+) -> Optional[float]:
+    """Fetch the closing price on the prediction date, with retry.
+
+    Tries the local database first.  If no price is found, fetches
+    a 7-day window from the market data provider and retries.
+
+    Args:
+        symbol: Ticker symbol (e.g. "AAPL").
+        prediction_date: Date of the source post/signal.
+        prediction_id: For logging context only.
+
+    Returns:
+        The closing price as a float, or None if unavailable
+        (also adds the symbol to ``_failed_symbols`` on failure).
+    """
+    price_t0 = self.market_client.get_price_on_date(symbol, prediction_date)
+    if not price_t0:
+        # Try to fetch it
+        try:
+            self.market_client.fetch_price_history(
+                symbol,
+                start_date=prediction_date - timedelta(days=7),
+                end_date=prediction_date,
+            )
+            price_t0 = self.market_client.get_price_on_date(symbol, prediction_date)
+        except Exception as e:
+            logger.warning(
+                f"Could not fetch price for {symbol} on {prediction_date}: {e}",
+                extra={
+                    "symbol": symbol,
+                    "date": str(prediction_date),
+                    "error": str(e),
+                },
+            )
+            return None
+
+    if not price_t0:
+        self._failed_symbols.add(symbol)
+        logger.warning(
+            f"No price found for {symbol} on {prediction_date}",
+            extra={"symbol": symbol, "date": str(prediction_date)},
+        )
+        return None
+
+    return price_t0.close
+```
+
+#### Step 1B: Extract `_fill_timeframe_prices`
+
+This helper extracts lines 248-311 — the loop over T+1/T+3/T+7/T+30 trading-day offsets that fills price, return, correctness, and PnL fields.
+
+**New method** — add after `_resolve_base_price`:
+
+```python
+def _fill_timeframe_prices(
+    self,
+    outcome: PredictionOutcome,
+    symbol: str,
+    prediction_date: date,
+    base_price: float,
+    sentiment: Optional[str],
+) -> None:
+    """Fill trading-day timeframe fields (T+1, T+3, T+7, T+30) on an outcome.
+
+    For each timeframe, calculates the target trading day, fetches the
+    closing price, and sets the price/return/correctness/PnL attributes.
+    Sets ``outcome.is_complete = False`` if any target date is in the
+    future or if the price cannot be fetched.
+
+    Mutates ``outcome`` in place; returns nothing.
+
+    Args:
+        outcome: The PredictionOutcome row to fill.
+        symbol: Ticker symbol.
+        prediction_date: Date of the source post/signal.
+        base_price: Closing price on the prediction date (T+0).
+        sentiment: Predicted sentiment string (e.g. "bullish").
+    """
+    timeframes = [
+        (1, "price_t1", "return_t1", "correct_t1", "pnl_t1"),
+        (3, "price_t3", "return_t3", "correct_t3", "pnl_t3"),
+        (7, "price_t7", "return_t7", "correct_t7", "pnl_t7"),
+        (30, "price_t30", "return_t30", "correct_t30", "pnl_t30"),
+    ]
+
+    outcome.is_complete = True  # Assume complete until we find missing data
+
+    for trading_days, price_attr, return_attr, correct_attr, pnl_attr in timeframes:
+        target_date = self._calendar.trading_day_offset(
+            prediction_date, trading_days
+        )
+
+        # Skip future dates
+        if target_date > date.today():
+            outcome.is_complete = False
+            continue
+
+        # Skip timeframes that are already filled (avoid redundant API calls)
+        if getattr(outcome, price_attr) is not None:
+            continue
+
+        # Get price at T+N (trading days)
+        price_tn = self.market_client.get_price_on_date(symbol, target_date)
+
+        if not price_tn:
+            # Try to fetch it -- use calendar-aware window for the fetch range
+            fetch_start = self._calendar.previous_trading_day(target_date)
+            try:
+                self.market_client.fetch_price_history(
+                    symbol,
+                    start_date=fetch_start,
+                    end_date=target_date,
+                )
+                price_tn = self.market_client.get_price_on_date(symbol, target_date)
+            except Exception as e:
+                logger.debug(
+                    f"Could not fetch price for {symbol} on {target_date}: {e}",
+                    extra={"symbol": symbol, "date": str(target_date)},
+                )
+
+        if price_tn:
+            # Set price
+            setattr(outcome, price_attr, price_tn.close)
+
+            # Calculate return
+            return_pct = outcome.calculate_return(base_price, price_tn.close)
+            setattr(outcome, return_attr, return_pct)
+
+            # Determine if prediction was correct
+            is_correct = (
+                outcome.is_correct(sentiment, return_pct) if sentiment else None
+            )
+            setattr(outcome, correct_attr, is_correct)
+
+            # Calculate P&L for $1000 position
+            pnl = outcome.calculate_pnl(return_pct, position_size=1000.0)
+            setattr(outcome, pnl_attr, pnl)
+        else:
+            outcome.is_complete = False
+```
+
+#### Step 1C: Extract `_fill_intraday_prices`
+
+This helper extracts lines 313-381 — the intraday snapshot logic for same_day and 1h returns.
+
+**New method** — add after `_fill_timeframe_prices`:
+
+```python
+def _fill_intraday_prices(
+    self,
+    outcome: PredictionOutcome,
+    symbol: str,
+    post_published_at: datetime,
+    sentiment: Optional[str],
+) -> None:
+    """Fill intraday price fields (same-day close, +1 hour) on an outcome.
+
+    Only fetches intraday data when ``outcome.price_at_post`` is still
+    None (avoids redundant API calls on re-evaluation).
+
+    Mutates ``outcome`` in place; returns nothing.
+
+    Args:
+        outcome: The PredictionOutcome row to fill.
+        symbol: Ticker symbol.
+        post_published_at: Full timezone-aware datetime of the source post.
+        sentiment: Predicted sentiment string (e.g. "bullish").
+    """
+    outcome.post_published_at = post_published_at
+
+    # Only fetch intraday for outcomes that don't already have it
+    if outcome.price_at_post is None:
+        try:
+            snapshot = fetch_intraday_snapshot(symbol, post_published_at)
+            outcome.price_at_post = snapshot.price_at_post
+            outcome.price_1h_after = snapshot.price_1h_after
+            # Prefer daily close from MarketPrice over intraday last bar
+            if outcome.price_at_next_close is None:
+                # Get the next trading day's close for "same-day close"
+                next_close_date = self._calendar.nearest_trading_day(
+                    post_published_at.date()
+                )
+                # If post is after market close, next close is next trading day
+                if self._calendar.is_trading_day(post_published_at.date()):
+                    close_time = self._calendar.session_close_time(
+                        post_published_at.date()
+                    )
+                    if close_time and post_published_at >= close_time:
+                        next_close_date = self._calendar.next_trading_day(
+                            post_published_at.date()
+                        )
+                next_close_price = self.market_client.get_price_on_date(
+                    symbol, next_close_date
+                )
+                if next_close_price:
+                    outcome.price_at_next_close = next_close_price.close
+                elif snapshot.price_at_next_close:
+                    outcome.price_at_next_close = snapshot.price_at_next_close
+        except Exception as e:
+            logger.debug(
+                f"Intraday snapshot failed for {symbol}: {e}",
+                extra={"symbol": symbol, "error": str(e)},
+            )
+
+    # Calculate intraday returns (from price_at_post, not price_at_prediction)
+    base_price = outcome.price_at_post
+    if base_price and base_price > 0:
+        # Same-day close return
+        if outcome.price_at_next_close is not None:
+            outcome.return_same_day = outcome.calculate_return(
+                base_price, outcome.price_at_next_close
+            )
+            outcome.correct_same_day = (
+                outcome.is_correct(sentiment, outcome.return_same_day)
+                if sentiment
+                else None
+            )
+            outcome.pnl_same_day = outcome.calculate_pnl(
+                outcome.return_same_day, position_size=1000.0
+            )
+
+        # 1-hour return
+        if outcome.price_1h_after is not None:
+            outcome.return_1h = outcome.calculate_return(
+                base_price, outcome.price_1h_after
+            )
+            outcome.correct_1h = (
+                outcome.is_correct(sentiment, outcome.return_1h)
+                if sentiment
+                else None
+            )
+            outcome.pnl_1h = outcome.calculate_pnl(
+                outcome.return_1h, position_size=1000.0
+            )
+```
+
+#### Step 1D: Rewrite `_calculate_single_outcome` as Orchestrator
+
+Replace the **entire** current `_calculate_single_outcome` method (lines 158-402) with this slim orchestrator that calls the three helpers:
+
+```python
+def _calculate_single_outcome(
+    self,
+    prediction_id: int,
+    symbol: str,
+    prediction_date: date,
+    sentiment: Optional[str],
+    confidence: Optional[float],
+    force_refresh: bool = False,
+    post_datetime: Optional[datetime] = None,
+) -> Optional[PredictionOutcome]:
+    """Calculate outcome for a single asset prediction."""
+
+    # Skip symbols that already failed price fetch (avoids repeated 7s+ retry delays)
+    if symbol in self._failed_symbols:
+        logger.debug(
+            f"Skipping known-bad symbol {symbol}",
+            extra={"symbol": symbol, "prediction_id": prediction_id},
+        )
+        return None
+
+    # Check if outcome already exists
+    existing = (
+        self.session.query(PredictionOutcome)
+        .filter(
+            and_(
+                PredictionOutcome.prediction_id == prediction_id,
+                PredictionOutcome.symbol == symbol,
+            )
+        )
+        .first()
+    )
+
+    if existing and not force_refresh:
+        if existing.is_complete:
+            logger.debug(
+                f"Outcome already complete for prediction {prediction_id}, symbol {symbol}",
+                extra={"prediction_id": prediction_id, "symbol": symbol},
+            )
+            return existing
+        else:
+            logger.debug(
+                f"Outcome incomplete for prediction {prediction_id}, symbol {symbol} — re-evaluating",
+                extra={"prediction_id": prediction_id, "symbol": symbol},
+            )
+
+    # Create or update outcome
+    outcome = (
+        existing
+        if existing
+        else PredictionOutcome(
+            prediction_id=prediction_id,
+            symbol=symbol,
+            prediction_date=prediction_date,
+            prediction_sentiment=sentiment,
+            prediction_confidence=confidence,
+        )
+    )
+
+    # Step 1: Resolve base price (T+0)
+    base_price = self._resolve_base_price(symbol, prediction_date, prediction_id)
+    if base_price is None:
+        return None
+
+    outcome.price_at_prediction = base_price
+
+    # Step 2: Fill trading-day timeframe prices (T+1, T+3, T+7, T+30)
+    self._fill_timeframe_prices(
+        outcome, symbol, prediction_date, base_price, sentiment
+    )
+
+    # Step 3: Fill intraday prices (same-day close, +1 hour)
+    if post_datetime and base_price:
+        self._fill_intraday_prices(outcome, symbol, post_datetime, sentiment)
+
+    outcome.last_price_update = date.today()
+
+    # Save to database
+    if not existing:
+        self.session.add(outcome)
+
+    self.session.commit()
+
+    logger.info(
+        f"Calculated outcome for {symbol} in prediction {prediction_id}",
+        extra={
+            "prediction_id": prediction_id,
+            "symbol": symbol,
+            "sentiment": sentiment,
+            "return_t7": outcome.return_t7,
+            "correct_t7": outcome.correct_t7,
+        },
+    )
+
+    return outcome
+```
+
+#### Summary of Line Ranges in Current File
+
+| Current line range | What it does | Extracted to |
+|---|---|---|
+| 158-167 | Method signature + docstring | Stays in `_calculate_single_outcome` |
+| 170-176 | Failed symbol cache check | Stays in `_calculate_single_outcome` |
+| 178-214 | Existing outcome lookup + create/update | Stays in `_calculate_single_outcome` |
+| 216-244 | Base price fetch + retry | `_resolve_base_price` |
+| 246-256 | Price_at_prediction assignment + timeframes list | Split: assignment stays, list moves to `_fill_timeframe_prices` |
+| 258-311 | Timeframe loop (T+1/3/7/30) | `_fill_timeframe_prices` |
+| 313-381 | Intraday snapshot logic | `_fill_intraday_prices` |
+| 383-401 | Save + log | Stays in `_calculate_single_outcome` |
+
+#### Full File Edit Sequence
+
+The edit is a single replacement of the `_calculate_single_outcome` method body (lines 158-402) with the new orchestrator, followed by inserting the three helper methods between `_calculate_single_outcome` and `calculate_outcomes_for_all_predictions`.
+
+**Concrete edit**: Replace lines 158-402 of `outcome_calculator.py` with:
+
+1. The new slim `_calculate_single_outcome` (~60 lines)
+2. The new `_resolve_base_price` method (~40 lines)
+3. The new `_fill_timeframe_prices` method (~55 lines)
+4. The new `_fill_intraday_prices` method (~60 lines)
+
+The method order in the class after refactoring will be:
+
+```
+class OutcomeCalculator:
+    __init__
+    __enter__
+    __exit__
+    calculate_outcome_for_prediction   (unchanged)
+    _calculate_single_outcome          (rewritten as orchestrator)
+    _resolve_base_price                (NEW)
+    _fill_timeframe_prices             (NEW)
+    _fill_intraday_prices              (NEW)
+    calculate_outcomes_for_all_predictions  (unchanged)
+    mature_outcomes                     (unchanged)
+    get_accuracy_stats                  (unchanged)
+    _get_source_datetime               (unchanged)
+    _get_source_date                   (unchanged)
+    _extract_sentiment                 (unchanged)
+```
+
+**No imports change.** The existing imports at lines 1-27 already include everything needed (`date`, `datetime`, `timedelta`, `timezone`, `Optional`, `Session`, `and_`, `PredictionOutcome`, `MarketDataClient`, `MarketCalendar`, `fetch_intraday_snapshot`, `get_session`, `get_service_logger`, `Prediction`, `Signal`).
+
+---
+
+### Part 2: Split `shit/market_data/cli.py`
+
+The 754-line CLI file with 14 commands will be split into a thin entry-point module plus 3 domain submodules.
+
+#### Command Assignment
+
+| Command | Current lines | Target file |
+|---|---|---|
+| `fetch-prices` | 28-71 | `cli_fetch.py` |
+| `update-all-prices` | 73-146 | `cli_fetch.py` |
+| `backfill-all-missing` | 635-671 | `cli_fetch.py` |
+| `auto-backfill` | 606-632 | `cli_fetch.py` |
+| `price-stats` | 407-461 | `cli_fetch.py` |
+| `calculate-outcomes` | 149-181 | `cli_outcomes.py` |
+| `fix-sentiments` | 184-243 | `cli_outcomes.py` |
+| `mature-outcomes` | 246-283 | `cli_outcomes.py` |
+| `accuracy-report` | 286-404 | `cli_outcomes.py` |
+| `auto-pipeline` | 540-603 | `cli_outcomes.py` |
+| `health-check` | 464-537 | `cli_outcomes.py` |
+| `ticker-registry` | 674-728 | `cli_registry.py` |
+| `register-tickers` | 731-750 | `cli_registry.py` |
+
+#### Step 2A: Create `shit/market_data/cli_fetch.py`
+
+```python
+"""
+Market Data CLI — Price Fetching Commands
+Commands for fetching, backfilling, and inspecting market prices.
+"""
+
+import click
+from datetime import date, timedelta
+from typing import Optional
+from rich.console import Console
+from rich.table import Table
+from rich import print as rprint
+
+from shit.market_data.client import MarketDataClient
+from shit.logging import print_success, print_error, print_info
+from shit.db.sync_session import get_session
+
+console = Console()
+
+
+@click.command()
+@click.option("--symbol", "-s", required=True, help="Ticker symbol (e.g., AAPL, TSLA)")
+@click.option("--days", "-d", default=30, help="Number of days of history to fetch")
+@click.option("--force", "-f", is_flag=True, help="Force refresh even if data exists")
+def fetch_prices(symbol: str, days: int, force: bool):
+    """Fetch historical prices for a symbol."""
+    start_date = date.today() - timedelta(days=days)
+    end_date = date.today()
+
+    print_info(f"Fetching {days} days of price data for {symbol}...")
+
+    try:
+        with MarketDataClient() as client:
+            prices = client.fetch_price_history(
+                symbol=symbol,
+                start_date=start_date,
+                end_date=end_date,
+                force_refresh=force,
+            )
+
+            if prices:
+                print_success(f"✅ Fetched {len(prices)} prices for {symbol}")
+
+                # Show recent prices
+                table = Table(title=f"Recent Prices for {symbol}")
+                table.add_column("Date", style="cyan")
+                table.add_column("Close", style="green", justify="right")
+                table.add_column("Volume", style="yellow", justify="right")
+
+                for price in prices[-10:]:  # Last 10 prices
+                    table.add_row(
+                        str(price.date),
+                        f"${price.close:.2f}",
+                        f"{price.volume:,}" if price.volume else "N/A",
+                    )
+
+                console.print(table)
+            else:
+                print_error(f"❌ No prices found for {symbol}")
+
+    except Exception as e:
+        print_error(f"❌ Error fetching prices: {e}")
+        raise click.Abort()
+
+
+@click.command()
+@click.option(
+    "--days", "-d", default=30, help="Fetch prices for assets mentioned in last N days"
+)
+@click.option("--limit", "-l", type=int, help="Limit number of predictions to process")
+def update_all_prices(days: int, limit: Optional[int]):
+    """Update prices for all assets mentioned in predictions."""
+    from shitvault.shitpost_models import Prediction
+    from shitvault.signal_models import Signal  # noqa: F401 - registers Signal with SQLAlchemy mapper
+    from sqlalchemy import func, distinct
+
+    print_info(f"Finding assets mentioned in predictions (last {days} days)...")
+
+    try:
+        with get_session() as session:
+            # Get unique assets from predictions
+            cutoff_date = date.today() - timedelta(days=days)
+
+            query = session.query(
+                func.jsonb_array_elements_text(Prediction.assets).label("asset")
+            ).distinct()
+
+            if limit:
+                query = query.limit(limit)
+
+            # This is PostgreSQL specific - for SQLite we'll need a different approach
+            try:
+                assets = [row[0] for row in query.all()]
+            except Exception:
+                # Fallback: jsonb_array_elements_text fails when column is JSON (not JSONB)
+                session.rollback()
+                predictions = (
+                    session.query(Prediction).filter(Prediction.assets != None).all()
+                )
+
+                if limit:
+                    predictions = predictions[:limit]
+
+                assets = set()
+                for pred in predictions:
+                    if pred.assets:
+                        assets.update(pred.assets)
+                assets = list(assets)
+
+            if not assets:
+                print_info("No assets found in predictions")
+                return
+
+            print_info(f"Found {len(assets)} unique assets: {', '.join(assets)}")
+
+            # Update prices for each asset
+            client = MarketDataClient(session=session)
+            start_date = date.today() - timedelta(days=days)
+
+            results = client.update_prices_for_symbols(
+                symbols=assets, start_date=start_date
+            )
+
+            # Print results
+            table = Table(title="Price Update Results")
+            table.add_column("Symbol", style="cyan")
+            table.add_column("Prices Fetched", style="green", justify="right")
+
+            total_fetched = 0
+            for symbol, count in sorted(results.items()):
+                table.add_row(symbol, str(count))
+                total_fetched += count
+
+            console.print(table)
+            print_success(f"✅ Fetched {total_fetched} total price records")
+
+    except Exception as e:
+        print_error(f"❌ Error updating prices: {e}")
+        raise click.Abort()
+
+
+@click.command()
+@click.option("--symbol", "-s", help="Show stats for specific symbol")
+def price_stats(symbol: Optional[str]):
+    """Show statistics about stored price data."""
+    try:
+        with MarketDataClient() as client:
+            if symbol:
+                # Stats for specific symbol
+                stats = client.get_price_stats(symbol)
+
+                if stats["count"] == 0:
+                    print_info(f"No price data found for {symbol}")
+                    return
+
+                rprint(f"\n[bold]Price Data for {symbol}:[/bold]")
+                rprint(f"  Total Records: {stats['count']}")
+                rprint(
+                    f"  Date Range: {stats['earliest_date']} to {stats['latest_date']}"
+                )
+                rprint(f"  Latest Price: ${stats['latest_price']:.2f}")
+
+            else:
+                # Stats for all symbols
+                from shit.market_data.models import MarketPrice
+                from sqlalchemy import func
+
+                with get_session() as session:
+                    symbols = (
+                        session.query(
+                            MarketPrice.symbol,
+                            func.count(MarketPrice.id).label("count"),
+                            func.max(MarketPrice.date).label("latest_date"),
+                        )
+                        .group_by(MarketPrice.symbol)
+                        .all()
+                    )
+
+                    if not symbols:
+                        print_info("No price data found in database")
+                        return
+
+                    table = Table(title="Price Data Summary")
+                    table.add_column("Symbol", style="cyan")
+                    table.add_column("Records", style="green", justify="right")
+                    table.add_column("Latest Date", style="yellow")
+
+                    for symbol, count, latest_date in sorted(symbols):
+                        table.add_row(symbol, str(count), str(latest_date))
+
+                    console.print(table)
+                    print_info(f"\nTotal symbols: {len(symbols)}")
+
+    except Exception as e:
+        print_error(f"❌ Error getting stats: {e}")
+        raise click.Abort()
+
+
+@click.command()
+@click.option("--days", "-d", default=7, help="Process predictions from last N days")
+@click.option("--limit", "-l", type=int, help="Limit number of predictions to process")
+def auto_backfill(days: int, limit: Optional[int]):
+    """Automatically backfill assets for recent predictions."""
+    from shit.market_data.auto_backfill_service import AutoBackfillService
+
+    print_info(f"Auto-backfilling assets for predictions from last {days} days...")
+
+    try:
+        service = AutoBackfillService()
+        stats = service.process_new_predictions(days_back=days, limit=limit)
+
+        rprint("\n[bold]Auto-Backfill Results:[/bold]")
+        rprint(f"  Predictions processed: {stats['predictions_processed']}")
+        rprint(f"  Assets backfilled: {stats['assets_backfilled']}")
+        rprint(f"  Outcomes calculated: {stats['outcomes_calculated']}")
+        rprint(f"  Errors: {stats['errors']}")
+
+        if stats["assets_backfilled"] > 0:
+            print_success(f"✅ Backfilled {stats['assets_backfilled']} assets")
+        else:
+            print_info("No new assets needed backfilling")
+
+    except Exception as e:
+        print_error(f"❌ Error during auto-backfill: {e}")
+        raise click.Abort()
+
+
+@click.command()
+def backfill_all_missing():
+    """One-time backfill of ALL missing assets (initial setup)."""
+    from shit.market_data.auto_backfill_service import AutoBackfillService
+
+    print_info("Starting comprehensive backfill of all missing assets...")
+    print_info("This may take 10-20 minutes depending on number of assets...")
+
+    try:
+        service = AutoBackfillService()
+        stats = service.process_all_missing_assets()
+
+        rprint("\n[bold]Comprehensive Backfill Results:[/bold]")
+        rprint(f"  Total unique assets: {stats['total_assets']}")
+        rprint(f"  Missing assets found: {stats['missing_assets']}")
+        rprint(f"  Successfully backfilled: {stats['backfilled']}")
+        rprint(f"  Failed: {stats['failed']}")
+
+        success_rate = (
+            (stats["backfilled"] / stats["missing_assets"] * 100)
+            if stats["missing_assets"] > 0
+            else 0
+        )
+        rprint(f"\n  [bold magenta]Success Rate: {success_rate:.1f}%[/bold magenta]")
+
+        if stats["backfilled"] > 0:
+            print_success(f"✅ Backfilled {stats['backfilled']} assets")
+
+            # Suggest next step
+            print_info("\nNext step: Calculate outcomes for all predictions")
+            print_info("Run: python -m shit.market_data calculate-outcomes --days 365")
+        else:
+            print_info("No assets needed backfilling")
+
+    except Exception as e:
+        print_error(f"❌ Error during backfill: {e}")
+        raise click.Abort()
+```
+
+#### Step 2B: Create `shit/market_data/cli_outcomes.py`
+
+```python
+"""
+Market Data CLI — Outcome Calculation Commands
+Commands for calculating, maturing, and reporting on prediction outcomes.
+"""
+
+import click
+from datetime import date, timedelta
+from typing import Optional
+from rich.console import Console
+from rich.table import Table
+from rich import print as rprint
+
+from shit.market_data.outcome_calculator import OutcomeCalculator
+from shit.logging import print_success, print_error, print_info
+from shit.db.sync_session import get_session
+
+console = Console()
+
+
+@click.command()
+@click.option("--limit", "-l", type=int, help="Limit number of predictions to process")
+@click.option(
+    "--days", "-d", type=int, help="Only process predictions from last N days"
+)
+@click.option("--force", "-f", is_flag=True, help="Recalculate existing outcomes")
+def calculate_outcomes(limit: Optional[int], days: Optional[int], force: bool):
+    """Calculate outcomes for predictions."""
+    print_info("Calculating prediction outcomes...")
+
+    try:
+        with OutcomeCalculator() as calculator:
+            stats = calculator.calculate_outcomes_for_all_predictions(
+                limit=limit, days_back=days, force_refresh=force
+            )
+
+            # Print statistics
+            rprint("\n[bold]Outcome Calculation Results:[/bold]")
+            rprint(f"  Total predictions: {stats['total_predictions']}")
+            rprint(f"  Processed: {stats['processed']}")
+            rprint(f"  Outcomes created: {stats['outcomes_created']}")
+            rprint(f"  Errors: {stats['errors']}")
+
+            if stats["outcomes_created"] > 0:
+                print_success(
+                    f"✅ Successfully calculated {stats['outcomes_created']} outcomes"
+                )
+            else:
+                print_info("No new outcomes created")
+
+    except Exception as e:
+        print_error(f"❌ Error calculating outcomes: {e}")
+        raise click.Abort()
+
+
+@click.command(name="fix-sentiments")
+@click.option("--dry-run", is_flag=True, help="Show what would be recalculated without making changes")
+def fix_sentiments(dry_run: bool):
+    """Recalculate outcomes for multi-asset predictions with incorrect sentiment.
+
+    Finds predictions with multiple assets where market_impact has per-asset
+    sentiment data, then force-refreshes their outcomes so each asset gets
+    its correct sentiment from the market_impact dict.
+    """
+    from shitvault.shitpost_models import Prediction
+    from sqlalchemy import func
+
+    print_info("Finding multi-asset predictions to fix sentiment...")
+
+    try:
+        with OutcomeCalculator() as calculator:
+            preds = (
+                calculator.session.query(Prediction)
+                .filter(
+                    Prediction.analysis_status == "completed",
+                    Prediction.assets.isnot(None),
+                    Prediction.market_impact.isnot(None),
+                    func.jsonb_array_length(Prediction.assets) > 1,
+                )
+                .all()
+            )
+
+            rprint(f"\n  Found [bold]{len(preds)}[/bold] multi-asset predictions")
+
+            if dry_run:
+                for pred in preds:
+                    rprint(
+                        f"  Would recalculate prediction {pred.id}: "
+                        f"assets={pred.assets}, market_impact={pred.market_impact}"
+                    )
+                print_info("Dry run complete — no changes made")
+                return
+
+            recalculated = 0
+            errors = 0
+
+            for pred in preds:
+                try:
+                    outcomes = calculator.calculate_outcome_for_prediction(
+                        pred.id, force_refresh=True
+                    )
+                    recalculated += len(outcomes)
+                except Exception as e:
+                    errors += 1
+                    rprint(f"  [red]Error recalculating prediction {pred.id}: {e}[/red]")
+
+            rprint(f"\n  Recalculated: [green]{recalculated}[/green] outcomes")
+            if errors:
+                rprint(f"  Errors: [red]{errors}[/red]")
+
+            print_success(f"✅ Fixed sentiments for {len(preds)} predictions")
+
+    except Exception as e:
+        print_error(f"❌ Error fixing sentiments: {e}")
+        raise click.Abort()
+
+
+@click.command(name="mature-outcomes")
+@click.option("--limit", "-l", type=int, help="Limit number of incomplete outcomes to process")
+@click.option("--emit-event", is_flag=True, help="Emit outcomes_matured event when done")
+def mature_outcomes(limit: Optional[int], emit_event: bool):
+    """Re-evaluate incomplete prediction outcomes to fill matured timeframes.
+
+    Finds all prediction_outcomes where is_complete=False and re-runs
+    outcome calculation for any timeframes that have now matured.
+    This fills in T+7 and T+30 values that were NULL at initial creation.
+    """
+    print_info("Maturing incomplete prediction outcomes...")
+
+    try:
+        with OutcomeCalculator() as calculator:
+            stats = calculator.mature_outcomes(
+                limit=limit, emit_event=emit_event
+            )
+
+            # Print statistics
+            rprint("\n[bold]Outcome Maturation Results:[/bold]")
+            rprint(f"  Incomplete outcomes found: {stats['total_incomplete']}")
+            rprint(f"  Outcomes re-evaluated: {stats['matured']}")
+            rprint(f"  Newly complete: [green]{stats['newly_complete']}[/green]")
+            rprint(f"  Still incomplete: [yellow]{stats['still_incomplete']}[/yellow]")
+            rprint(f"  Errors: [red]{stats['errors']}[/red]")
+
+            if stats["newly_complete"] > 0:
+                print_success(
+                    f"✅ {stats['newly_complete']} outcomes are now fully complete"
+                )
+            elif stats["matured"] > 0:
+                print_info("Some outcomes updated but still have future timeframes pending")
+            else:
+                print_info("No incomplete outcomes found to mature")
+
+    except Exception as e:
+        print_error(f"❌ Error maturing outcomes: {e}")
+        raise click.Abort()
+
+
+@click.command()
+@click.option(
+    "--timeframe",
+    "-t",
+    default="t7",
+    type=click.Choice(["t1", "t3", "t7", "t30"]),
+    help="Timeframe to analyze (t1=1 day, t7=7 days, etc.)",
+)
+@click.option(
+    "--min-confidence", "-c", type=float, help="Minimum confidence threshold (0.0-1.0)"
+)
+@click.option(
+    "--by-confidence", "-b", is_flag=True, help="Show breakdown by confidence levels"
+)
+def accuracy_report(
+    timeframe: str, min_confidence: Optional[float], by_confidence: bool
+):
+    """Generate accuracy report for predictions."""
+    print_info(f"Generating accuracy report for {timeframe}...")
+
+    try:
+        with OutcomeCalculator() as calculator:
+            if by_confidence:
+                # Show accuracy by confidence levels
+                confidence_levels = [
+                    (0.0, 0.6, "Low"),
+                    (0.6, 0.75, "Medium"),
+                    (0.75, 1.0, "High"),
+                ]
+
+                table = Table(title=f"Accuracy by Confidence Level ({timeframe})")
+                table.add_column("Confidence Level", style="cyan")
+                table.add_column("Total", style="white", justify="right")
+                table.add_column("Correct", style="green", justify="right")
+                table.add_column("Incorrect", style="red", justify="right")
+                table.add_column("Pending", style="yellow", justify="right")
+                table.add_column("Accuracy", style="bold magenta", justify="right")
+
+                for min_conf, max_conf, label in confidence_levels:
+                    # Filter outcomes in this confidence range
+                    from shit.market_data.models import PredictionOutcome
+
+                    with get_session() as session:
+                        outcomes = (
+                            session.query(PredictionOutcome)
+                            .filter(
+                                PredictionOutcome.prediction_confidence >= min_conf,
+                                PredictionOutcome.prediction_confidence < max_conf,
+                            )
+                            .all()
+                        )
+
+                        if len(outcomes) == 0:
+                            table.add_row(
+                                f"{label} ({min_conf:.0%}-{max_conf:.0%})",
+                                "0",
+                                "0",
+                                "0",
+                                "0",
+                                "N/A",
+                            )
+                            continue
+
+                        correct_attr = f"correct_{timeframe}"
+                        total = len(outcomes)
+                        correct = sum(
+                            1 for o in outcomes if getattr(o, correct_attr) is True
+                        )
+                        incorrect = sum(
+                            1 for o in outcomes if getattr(o, correct_attr) is False
+                        )
+                        pending = sum(
+                            1 for o in outcomes if getattr(o, correct_attr) is None
+                        )
+                        accuracy = (
+                            (correct / (correct + incorrect) * 100)
+                            if (correct + incorrect) > 0
+                            else 0.0
+                        )
+
+                        table.add_row(
+                            f"{label} ({min_conf:.0%}-{max_conf:.0%})",
+                            str(total),
+                            str(correct),
+                            str(incorrect),
+                            str(pending),
+                            f"{accuracy:.1f}%",
+                        )
+
+                console.print(table)
+
+            else:
+                # Show overall accuracy
+                stats = calculator.get_accuracy_stats(
+                    timeframe=timeframe, min_confidence=min_confidence
+                )
+
+                rprint("\n[bold]Prediction Accuracy Report:[/bold]")
+                rprint(f"  Timeframe: {timeframe}")
+                if min_confidence:
+                    rprint(f"  Min Confidence: {min_confidence:.0%}")
+                rprint(f"\n  Total Predictions: {stats['total']}")
+                rprint(f"  Correct: [green]{stats['correct']}[/green]")
+                rprint(f"  Incorrect: [red]{stats['incorrect']}[/red]")
+                rprint(f"  Pending: [yellow]{stats['pending']}[/yellow]")
+                rprint(
+                    f"\n  [bold magenta]Accuracy: {stats['accuracy']:.1f}%[/bold magenta]"
+                )
+
+                if stats["accuracy"] >= 60:
+                    print_success("✅ Above random chance!")
+                elif stats["accuracy"] >= 50:
+                    print_info("📊 Around random chance")
+                else:
+                    print_error("❌ Below random chance")
+
+    except Exception as e:
+        print_error(f"❌ Error generating report: {e}")
+        raise click.Abort()
+
+
+@click.command(name="health-check")
+@click.option("--providers/--no-providers", default=True, help="Check provider connectivity")
+@click.option("--freshness/--no-freshness", default=True, help="Check data freshness")
+@click.option("--alert/--no-alert", default=False, help="Send Telegram alert if unhealthy")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def health_check(providers: bool, freshness: bool, alert: bool, as_json: bool):
+    """Run health check on market data pipeline."""
+    from shit.market_data.health import run_health_check
+
+    print_info("Running market data health check...")
+
+    try:
+        report = run_health_check(
+            check_providers=providers,
+            check_freshness=freshness,
+            send_alert_on_failure=alert,
+        )
+
+        if as_json:
+            import json
+            rprint(json.dumps(report.to_dict(), indent=2, default=str))
+            return
+
+        # Pretty print the report
+        status_icon = "\u2705" if report.overall_healthy else "\u274c"
+        rprint(f"\n{status_icon} [bold]Market Data Health: {'HEALTHY' if report.overall_healthy else 'UNHEALTHY'}[/bold]")
+
+        if report.providers:
+            rprint("\n[bold]Provider Status:[/bold]")
+            provider_table = Table()
+            provider_table.add_column("Provider", style="cyan")
+            provider_table.add_column("Available", justify="center")
+            provider_table.add_column("Can Fetch", justify="center")
+            provider_table.add_column("Latency", justify="right")
+            provider_table.add_column("Error", style="red")
+
+            for p in report.providers:
+                provider_table.add_row(
+                    p.name,
+                    "\u2705" if p.available else "\u274c",
+                    "\u2705" if p.can_fetch else "\u274c",
+                    f"{p.response_time_ms:.0f}ms" if p.response_time_ms else "N/A",
+                    p.error or "",
+                )
+            console.print(provider_table)
+
+        if report.freshness:
+            rprint("\n[bold]Data Freshness:[/bold]")
+            fresh_table = Table()
+            fresh_table.add_column("Symbol", style="cyan")
+            fresh_table.add_column("Latest Date", style="yellow")
+            fresh_table.add_column("Days Stale", justify="right")
+            fresh_table.add_column("Status", justify="center")
+
+            for f in report.freshness:
+                status = "\u2705 Fresh" if not f.is_stale else "\u26a0\ufe0f Stale"
+                fresh_table.add_row(
+                    f.symbol,
+                    str(f.latest_date) if f.latest_date else "No data",
+                    str(f.days_stale),
+                    status,
+                )
+            console.print(fresh_table)
+
+        rprint(f"\n[bold]Summary:[/bold] {report.summary}")
+
+        if not report.overall_healthy:
+            raise SystemExit(1)
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        print_error(f"\u274c Error running health check: {e}")
+        raise click.Abort()
+
+
+@click.command(name="auto-pipeline")
+@click.option(
+    "--days-back",
+    "-d",
+    default=7,
+    help="Backfill prices for predictions from last N days",
+)
+@click.option("--limit", "-l", type=int, help="Limit number of predictions to process")
+def auto_pipeline(days_back: int, limit: Optional[int]):
+    """Run the full market data pipeline: backfill prices then calculate outcomes."""
+    from shit.market_data.auto_backfill_service import auto_backfill_recent
+    from shit.logging import get_service_logger
+
+    logger = get_service_logger("market_data_pipeline")
+
+    logger.info(
+        "Starting market data pipeline", extra={"days_back": days_back, "limit": limit}
+    )
+    print_info(
+        f"Starting market data pipeline (days_back={days_back}, limit={limit})..."
+    )
+
+    try:
+        # Step 1: Backfill prices for recent predictions
+        print_info("Step 1: Backfilling prices for recent predictions...")
+        backfill_stats = auto_backfill_recent(days=days_back)
+        logger.info("Backfill complete", extra=backfill_stats)
+
+        rprint("\n[bold]Backfill Results:[/bold]")
+        rprint(
+            f"  Predictions processed: {backfill_stats.get('predictions_processed', 0)}"
+        )
+        rprint(f"  Assets backfilled: {backfill_stats.get('assets_backfilled', 0)}")
+        rprint(f"  Errors: {backfill_stats.get('errors', 0)}")
+
+        # Step 2: Calculate/refresh outcomes for all predictions
+        print_info("\nStep 2: Calculating outcomes for predictions...")
+        with OutcomeCalculator() as calculator:
+            outcome_stats = calculator.calculate_outcomes_for_all_predictions(
+                limit=limit, days_back=days_back
+            )
+        logger.info("Outcome calculation complete", extra=outcome_stats)
+
+        rprint("\n[bold]Outcome Calculation Results:[/bold]")
+        rprint(f"  Total predictions: {outcome_stats.get('total_predictions', 0)}")
+        rprint(f"  Processed: {outcome_stats.get('processed', 0)}")
+        rprint(f"  Outcomes created: {outcome_stats.get('outcomes_created', 0)}")
+        rprint(f"  Errors: {outcome_stats.get('errors', 0)}")
+
+        total_errors = backfill_stats.get("errors", 0) + outcome_stats.get("errors", 0)
+        if total_errors > 0:
+            print_info(f"\n⚠️  Pipeline completed with {total_errors} errors")
+        else:
+            print_success("\n✅ Market data pipeline completed successfully")
+
+        logger.info(
+            "Pipeline complete",
+            extra={"backfill_stats": backfill_stats, "outcome_stats": outcome_stats},
+        )
+
+    except Exception as e:
+        logger.error(f"Pipeline failed: {e}", exc_info=True)
+        print_error(f"❌ Market data pipeline failed: {e}")
+        raise SystemExit(1)
+```
+
+#### Step 2C: Create `shit/market_data/cli_registry.py`
+
+```python
+"""
+Market Data CLI — Ticker Registry Commands
+Commands for managing the ticker registry.
+"""
+
+import click
+from rich.console import Console
+from rich.table import Table
+from rich import print as rprint
+
+from shit.logging import print_success, print_error, print_info
+from shit.db.sync_session import get_session
+
+console = Console()
+
+
+@click.command(name="ticker-registry")
+@click.option(
+    "--status",
+    "-s",
+    type=click.Choice(["active", "inactive", "invalid", "all"]),
+    default="all",
+    help="Filter by ticker status",
+)
+def ticker_registry_cmd(status: str):
+    """Show all tracked tickers in the registry."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+    from shit.market_data.models import TickerRegistry
+
+    try:
+        service = TickerRegistryService()
+        stats = service.get_registry_stats()
+
+        rprint(f"\n[bold]Ticker Registry Stats:[/bold]")
+        rprint(f"  Total: {stats['total']}")
+        rprint(f"  Active: [green]{stats['active']}[/green]")
+        rprint(f"  Invalid: [red]{stats['invalid']}[/red]")
+        rprint(f"  Inactive: [yellow]{stats['inactive']}[/yellow]")
+
+        with get_session() as session:
+            query = session.query(TickerRegistry)
+            if status != "all":
+                query = query.filter(TickerRegistry.status == status)
+            query = query.order_by(TickerRegistry.first_seen_date.desc())
+            tickers = query.all()
+
+            if not tickers:
+                print_info("No tickers found matching filter")
+                return
+
+            table = Table(title=f"Ticker Registry ({status})")
+            table.add_column("Symbol", style="cyan")
+            table.add_column("Status", style="green")
+            table.add_column("First Seen", style="yellow")
+            table.add_column("Last Update", style="white")
+            table.add_column("Records", style="magenta", justify="right")
+
+            for t in tickers:
+                table.add_row(
+                    t.symbol,
+                    t.status,
+                    str(t.first_seen_date),
+                    str(t.last_price_update.date()) if t.last_price_update else "Never",
+                    str(t.total_price_records),
+                )
+
+            console.print(table)
+
+    except Exception as e:
+        print_error(f"Error reading ticker registry: {e}")
+        raise click.Abort()
+
+
+@click.command(name="register-tickers")
+@click.argument("symbols", nargs=-1, required=True)
+def register_tickers_cmd(symbols: tuple):
+    """Manually register tickers for tracking (e.g., register-tickers AAPL TSLA BTC-USD)."""
+    from shit.market_data.ticker_registry import TickerRegistryService
+
+    try:
+        service = TickerRegistryService()
+        newly_registered, already_known = service.register_tickers(list(symbols))
+
+        if newly_registered:
+            print_success(
+                f"Registered {len(newly_registered)} new tickers: {', '.join(newly_registered)}"
+            )
+        if already_known:
+            print_info(f"Already registered: {', '.join(already_known)}")
+
+    except Exception as e:
+        print_error(f"Error registering tickers: {e}")
+        raise click.Abort()
+```
+
+#### Step 2D: Rewrite `shit/market_data/cli.py` as Entry Point
+
+Replace the **entire** contents of `cli.py` with this thin entry point:
+
+```python
+"""
+Market Data CLI
+Command-line interface for market data operations.
+
+Commands are organized into submodules:
+- cli_fetch.py — Price fetching, backfilling, and stats
+- cli_outcomes.py — Outcome calculation, maturation, accuracy, health, pipeline
+- cli_registry.py — Ticker registry management
+"""
+
+import click
+
+from shit.market_data.cli_fetch import (
+    fetch_prices,
+    update_all_prices,
+    price_stats,
+    auto_backfill,
+    backfill_all_missing,
+)
+from shit.market_data.cli_outcomes import (
+    calculate_outcomes,
+    fix_sentiments,
+    mature_outcomes,
+    accuracy_report,
+    health_check,
+    auto_pipeline,
+)
+from shit.market_data.cli_registry import (
+    ticker_registry_cmd,
+    register_tickers_cmd,
+)
+
+
+@click.group()
+def cli():
+    """Market data commands for tracking prices and prediction outcomes."""
+    pass
+
+
+# Price fetching commands
+cli.add_command(fetch_prices)
+cli.add_command(update_all_prices)
+cli.add_command(price_stats)
+cli.add_command(auto_backfill)
+cli.add_command(backfill_all_missing)
+
+# Outcome commands
+cli.add_command(calculate_outcomes)
+cli.add_command(fix_sentiments)
+cli.add_command(mature_outcomes)
+cli.add_command(accuracy_report)
+cli.add_command(health_check)
+cli.add_command(auto_pipeline)
+
+# Registry commands
+cli.add_command(ticker_registry_cmd)
+cli.add_command(register_tickers_cmd)
+
+
+if __name__ == "__main__":
+    cli()
+```
+
+**Critical**: The `cli` group object stays in `cli.py`, which is what `__main__.py` imports (`from shit.market_data.cli import cli`). The Click group interface is unchanged — all commands remain registered on the same `cli` group, just via `cli.add_command()` instead of `@cli.command()` decorators.
+
+---
+
+## Test Plan
+
+### No New Tests Needed
+
+Both existing test files provide comprehensive coverage:
+
+- **`shit_tests/shit/market_data/test_outcome_calculator.py`** (725 lines) — Tests `_calculate_single_outcome` behavior end-to-end through the public `calculate_outcome_for_prediction` method. Since the three new helpers are private methods called by `_calculate_single_outcome`, and the method signature and behavior are identical, all existing tests pass without modification.
+
+- **`shit_tests/shit/market_data/test_market_data_cli.py`** (354 lines) — Tests the CLI through the Click `CliRunner` by invoking `cli` and command names (e.g., `runner.invoke(cli, ["auto-pipeline"])`). Since `cli` remains the same object in `shit/market_data/cli.py` and all commands are registered on it via `cli.add_command()`, the test imports and invocations are unchanged.
+
+### Existing Tests Must Pass Unchanged
+
+After refactoring, run:
+
+```bash
+./venv/bin/python -m pytest shit_tests/shit/market_data/test_outcome_calculator.py -v
+./venv/bin/python -m pytest shit_tests/shit/market_data/test_market_data_cli.py -v
+```
+
+Both must produce zero failures and zero errors.
+
+### Test Patch Paths Still Valid
+
+The CLI test file uses these patch paths, all of which remain correct after the split:
+
+```python
+BACKFILL_PATCH = "shit.market_data.auto_backfill_service.auto_backfill_recent"  # still valid (source module)
+LOGGER_PATCH = "shit.logging.get_service_logger"  # still valid
+CALC_PATCH = "shit.market_data.cli.OutcomeCalculator"  # NEEDS UPDATE — see below
+```
+
+**Important**: The `CALC_PATCH` in `test_market_data_cli.py` patches `shit.market_data.cli.OutcomeCalculator`. After the split, `OutcomeCalculator` is imported in `cli_outcomes.py`, not `cli.py`. The `auto-pipeline` command lives in `cli_outcomes.py`, so the patch path must change to:
+
+```python
+CALC_PATCH = "shit.market_data.cli_outcomes.OutcomeCalculator"
+```
+
+**This is the one test file change required.** Edit line 24 of `test_market_data_cli.py`:
+
+**Before** (line 24):
+```python
+CALC_PATCH = "shit.market_data.cli.OutcomeCalculator"
+```
+
+**After**:
+```python
+CALC_PATCH = "shit.market_data.cli_outcomes.OutcomeCalculator"
+```
+
+No other test changes are needed. The `runner.invoke(cli, ["auto-pipeline"])` calls still work because `cli` is still imported from `shit.market_data.cli` and the `auto_pipeline` command is registered on it.
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Changed
+- **Outcome Calculator** - Decomposed 245-line `_calculate_single_outcome` into 3 focused helpers: `_resolve_base_price`, `_fill_timeframe_prices`, `_fill_intraday_prices`
+- **Market Data CLI** - Split 754-line CLI into domain submodules: `cli_fetch.py`, `cli_outcomes.py`, `cli_registry.py`; entry point preserved at `cli.py`
+```
+
+### No README Changes
+
+The `shit/market_data/` directory does not have its own README. The module's public API (`__init__.py`) is unchanged.
+
+### Inline Comments
+
+No new inline comments needed. The docstrings on the three new helper methods provide sufficient documentation.
+
+---
+
+## Stress Testing & Edge Cases
+
+### Edge Cases Handled by Existing Tests
+
+The 725-line test file already covers:
+- **Missing prices** — `_resolve_base_price` returns None, caller gets None
+- **Failed symbols cache** — symbols that fail once are skipped on retry
+- **Incomplete outcomes** — `_fill_timeframe_prices` sets `is_complete = False` for future dates
+- **No intraday data** — `_fill_intraday_prices` gracefully handles exceptions from `fetch_intraday_snapshot`
+- **Force refresh** — existing outcomes are recalculated when `force_refresh=True`
+
+### Performance
+
+No performance change. The method call overhead of 3 extra function calls per outcome is negligible compared to the network I/O of price fetches (each taking 100ms-7s).
+
+### Error Handling
+
+Each helper method preserves the exact same error handling as the original monolithic method:
+- `_resolve_base_price`: catches fetch exceptions, logs warning, returns None
+- `_fill_timeframe_prices`: catches per-timeframe fetch exceptions, logs debug, marks incomplete
+- `_fill_intraday_prices`: catches intraday snapshot exceptions, logs debug, continues
+
+The outer `_calculate_single_outcome` still commits/logs at the end, and the outer `calculate_outcome_for_prediction` still has its per-asset try/except with session rollback.
+
+---
+
+## Verification Checklist
+
+1. [ ] All 3 new files created: `cli_fetch.py`, `cli_outcomes.py`, `cli_registry.py`
+2. [ ] `outcome_calculator.py` has 3 new private methods and slimmed-down `_calculate_single_outcome`
+3. [ ] `cli.py` reduced to ~50 lines (group + imports + `add_command` calls)
+4. [ ] `__main__.py` unchanged (still imports `cli` from `shit.market_data.cli`)
+5. [ ] `__init__.py` unchanged (does not import CLI symbols)
+6. [ ] `CALC_PATCH` in `test_market_data_cli.py` updated to `"shit.market_data.cli_outcomes.OutcomeCalculator"`
+7. [ ] Run: `./venv/bin/python -m pytest shit_tests/shit/market_data/test_outcome_calculator.py -v` — all pass
+8. [ ] Run: `./venv/bin/python -m pytest shit_tests/shit/market_data/test_market_data_cli.py -v` — all pass
+9. [ ] Run: `./venv/bin/python -m pytest shit_tests/shit/market_data/ -v` — full market_data test suite passes
+10. [ ] Run: `./venv/bin/python -m ruff check shit/market_data/` — no lint errors
+11. [ ] Run: `./venv/bin/python -m ruff format shit/market_data/` — formatting clean
+12. [ ] Verify `python -m shit.market_data --help` still lists all 14 commands (import check)
+13. [ ] Verify command names are unchanged: `fetch-prices`, `update-all-prices`, `calculate-outcomes`, `fix-sentiments`, `mature-outcomes`, `accuracy-report`, `price-stats`, `health-check`, `auto-pipeline`, `auto-backfill`, `backfill-all-missing`, `ticker-registry`, `register-tickers`
+14. [ ] CHANGELOG.md updated
+
+---
+
+## What NOT To Do
+
+1. **Do NOT change the `cli` group object's location.** It must remain in `cli.py` because `__main__.py` imports it from there, and tests import it from `shit.market_data.cli`. Moving it would break both.
+
+2. **Do NOT use `@cli.command()` decorators in the submodules.** The submodule files define standalone `@click.command()` functions. The main `cli.py` uses `cli.add_command()` to register them. If you use `@cli.command()` in the submodules, you create a circular import (submodule imports `cli` from `cli.py`, which imports submodule).
+
+3. **Do NOT change the method signatures of `_calculate_single_outcome`.** The parameter list (7 params + self) stays exactly the same. Tests mock and call this method through `calculate_outcome_for_prediction`, which passes these exact parameters.
+
+4. **Do NOT make the new helper methods public (no leading underscore).** They are implementation details of `_calculate_single_outcome` and should remain private (`_resolve_base_price`, `_fill_timeframe_prices`, `_fill_intraday_prices`).
+
+5. **Do NOT add the new CLI submodules to `__init__.py`'s `__all__`.** CLI modules are not part of the public API. They are only used via `python -m shit.market_data`.
+
+6. **Do NOT forget to update `CALC_PATCH` in the test file.** After the split, `OutcomeCalculator` is imported in `cli_outcomes.py`, not `cli.py`. Patching the old path will cause tests to fail because the mock won't intercept the real import.
+
+7. **Do NOT change the `price_t0` variable to just use `base_price` float everywhere in `_fill_timeframe_prices`.** The helper receives `base_price` as a float (the closing price), but the timeframe loop calls `outcome.calculate_return(base_price, price_tn.close)`. This is correct — `base_price` is already a float, and `price_tn.close` is also a float. Do NOT try to pass the full `MarketPrice` object.
+
+8. **Do NOT split the test files.** The tests are organized by the class they test (`OutcomeCalculator`), not by internal method. Splitting tests to mirror the helper decomposition would be over-engineering.
+
+9. **Do NOT import `Signal` in the CLI submodules unless needed.** The current `cli.py` has `from shitvault.signal_models import Signal  # noqa: F401` at the top level to register the SQLAlchemy mapper. This import only needs to happen once per process. Keep it in `cli.py` (the entry point that always runs first) and in `cli_fetch.py`'s `update_all_prices` function body where it's already present. Do NOT add it to every submodule.

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
@@ -1,0 +1,258 @@
+# Phase 05: Resolve TODOs, Add Legacy Documentation
+
+**PR Title**: `chore: resolve TODOs, add legacy documentation`
+**Risk**: Low (comment-only changes, no behavior changes)
+**Estimated Effort**: Low (~30 minutes)
+**Files Modified**: 4
+**Files Created**: 0
+**Files Deleted**: 0
+
+---
+
+## Context
+
+The codebase contains 5 TODO comments spread across 4 files. These TODOs create the false impression that work is pending when in reality the decisions have already been made:
+
+- The dual-write in `s3_processor.py` stays until the signals migration is complete (documented in `SIGNALS_MIGRATION.md`)
+- The Twitter harvester is a skeleton with no concrete implementation timeline
+- Error reporting and metrics collection are not warranted at current scale
+- The `shitty_ui/data/__init__.py` re-export layer serves a retiring dashboard but has no deprecation notice
+
+Resolving these TODOs replaces vague future intent with concrete decision records, improving codebase clarity for any developer reading the code.
+
+---
+
+## Dependencies
+
+- **Depends on**: None
+- **Unlocks**: None
+- **Parallel-safe with**: All other phases (this phase touches only comments/docstrings, no code changes)
+
+---
+
+## Detailed Implementation Plan
+
+### Change 1: `shitvault/s3_processor.py` (line 217)
+
+**Why**: The TODO says "Remove after full migration is complete" but gives no context about what migration, what the blocker is, or where to find the plan. Replace with a decision record comment that links to the migration plan.
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitvault/s3_processor.py`
+
+**Before** (lines 216-219):
+```python
+                # Also store in legacy table for backward compatibility
+                # TODO: Remove after full migration is complete
+                legacy_data = DatabaseUtils.transform_s3_data_to_shitpost(s3_data)
+                await self.shitpost_ops.store_shitpost(legacy_data)
+```
+
+**After** (lines 216-221):
+```python
+                # Dual-write to legacy truth_social_shitposts table.
+                # This stays until api/queries/feed_queries.py and shitty_ui/data/
+                # migrate their reads to the signals table. Tracked in:
+                # documentation/planning/SIGNALS_MIGRATION.md
+                legacy_data = DatabaseUtils.transform_s3_data_to_shitpost(s3_data)
+                await self.shitpost_ops.store_shitpost(legacy_data)
+```
+
+### Change 2: `shitposts/twitter_harvester.py` (lines 66 and 92)
+
+**Why**: These TODOs imply the Twitter integration is planned work. It is not — the file is explicitly documented as a skeleton template. Replace with notes clarifying the status.
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitposts/twitter_harvester.py`
+
+**Before** (line 66, inside `_test_connection` docstring):
+```python
+    async def _test_connection(self) -> None:
+        """Test Twitter API v2 connection.
+
+        TODO: Implement with real Twitter API call.
+        """
+```
+
+**After**:
+```python
+    async def _test_connection(self) -> None:
+        """Test Twitter API v2 connection.
+
+        NOTE: Skeleton -- implement when Twitter/X API access is obtained.
+        Not currently planned.
+        """
+```
+
+**Before** (line 92, inside `_fetch_batch` docstring):
+```python
+    async def _fetch_batch(
+        self, cursor: Optional[str] = None
+    ) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of tweets.
+
+        TODO: Implement with Twitter API v2 search or user timeline.
+        """
+```
+
+**After**:
+```python
+    async def _fetch_batch(
+        self, cursor: Optional[str] = None
+    ) -> tuple[List[Dict], Optional[str]]:
+        """Fetch a batch of tweets.
+
+        NOTE: Skeleton -- implement when Twitter/X API access is obtained.
+        Not currently planned.
+        """
+```
+
+### Change 3: `shit/utils/error_handling.py` (lines 26-27)
+
+**Why**: These TODOs suggest Sentry and metrics are upcoming. At current scale, Railway service logs and orchestrator log files provide sufficient error visibility. Replace with a concrete deferred-decision note.
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shit/utils/error_handling.py`
+
+**Before** (lines 26-27):
+```python
+    # TODO: Add error reporting to external services (Sentry, etc.)
+    # TODO: Add metrics collection for error rates
+```
+
+**After** (lines 26-28):
+```python
+    # Deferred: Error reporting (Sentry) and metrics collection.
+    # Currently tracked via Railway service logs and the orchestrator
+    # log files. Re-evaluate when error volume warrants external tooling.
+```
+
+### Change 4: `shitty_ui/data/__init__.py` (after the docstring)
+
+**Why**: This file is a backward-compatibility re-export layer for the legacy Dash dashboard (`shitty_ui/`). The Dash dashboard is being retired in favor of the React frontend (`api/` + `frontend/`). Without a deprecation notice, developers may add new query functions here instead of in `api/queries/`.
+
+**File**: `/Users/chris/Projects/shitpost-alpha/shitty_ui/data/__init__.py`
+
+**Before** (lines 1-16):
+```python
+"""
+Database access layer for Shitty UI Dashboard.
+
+This package re-exports all query functions for backward compatibility.
+All existing `from data import X` statements continue to work unchanged.
+
+Internal structure:
+    data/base.py              -- execute_query, ttl_cache, logger
+    data/signal_queries.py    -- Signal loading, feed, filtering
+    data/performance_queries.py -- KPIs, accuracy, P&L, streaks
+    data/asset_queries.py     -- Screener, sparklines, asset stats
+    data/insight_queries.py   -- Dynamic insight cards
+    data/timeframe.py         -- Timeframe column mapping helper
+"""
+
+# --- Timeframe helpers ---
+```
+
+**After** (lines 1-21):
+```python
+"""
+Database access layer for Shitty UI Dashboard.
+
+This package re-exports all query functions for backward compatibility.
+All existing `from data import X` statements continue to work unchanged.
+
+Internal structure:
+    data/base.py              -- execute_query, ttl_cache, logger
+    data/signal_queries.py    -- Signal loading, feed, filtering
+    data/performance_queries.py -- KPIs, accuracy, P&L, streaks
+    data/asset_queries.py     -- Screener, sparklines, asset stats
+    data/insight_queries.py   -- Dynamic insight cards
+    data/timeframe.py         -- Timeframe column mapping helper
+"""
+
+# DEPRECATED: This module re-exports query functions for the legacy Dash
+# dashboard (shitty_ui/). The Dash dashboard is being retired in favor of
+# the React frontend (api/ + frontend/). Do not add new functions here.
+# New query work should go in api/queries/.
+
+# --- Timeframe helpers ---
+```
+
+---
+
+## Test Plan
+
+### No new tests required
+
+This phase changes only comments and docstrings. There are no behavioral changes, no new functions, no modified signatures, and no altered control flow. Existing tests cover all four files and should continue to pass without modification.
+
+### Verification steps
+
+1. Run the full test suite to confirm no regressions:
+   ```bash
+   source venv/bin/activate && pytest -v
+   ```
+
+2. Run the linter to confirm no style issues introduced:
+   ```bash
+   source venv/bin/activate && ruff check shitvault/s3_processor.py shitposts/twitter_harvester.py shit/utils/error_handling.py shitty_ui/data/__init__.py
+   ```
+
+3. Grep for remaining TODOs to confirm all 5 are resolved:
+   ```bash
+   grep -rn "TODO" shitvault/s3_processor.py shitposts/twitter_harvester.py shit/utils/error_handling.py
+   ```
+   Expected output: no matches.
+
+---
+
+## Documentation Updates
+
+### CHANGELOG.md
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Changed
+- **TODO resolution** -- Replaced 5 vague TODO comments with concrete decision records
+  - `shitvault/s3_processor.py`: Dual-write stays until signals migration (linked to plan)
+  - `shitposts/twitter_harvester.py`: Twitter skeleton marked as not currently planned
+  - `shit/utils/error_handling.py`: Sentry/metrics deferred until error volume warrants it
+  - `shitty_ui/data/__init__.py`: Added deprecation notice for legacy Dash re-export layer
+```
+
+### CLAUDE.md
+
+No changes needed. The `shitty_ui/data/__init__.py` deprecation notice is self-documenting in the file. The signals migration plan is already referenced in `documentation/planning/SIGNALS_MIGRATION.md`.
+
+---
+
+## Stress Testing & Edge Cases
+
+Not applicable. This phase modifies only comments and docstrings. There are no code paths, error scenarios, or performance considerations to evaluate.
+
+---
+
+## Verification Checklist
+
+- [ ] `shitvault/s3_processor.py` line 217: TODO replaced with decision record linking to `SIGNALS_MIGRATION.md`
+- [ ] `shitposts/twitter_harvester.py` line 66: TODO replaced with "NOTE: Skeleton" note
+- [ ] `shitposts/twitter_harvester.py` line 92: TODO replaced with "NOTE: Skeleton" note
+- [ ] `shit/utils/error_handling.py` lines 26-27: TODOs replaced with deferred-decision note
+- [ ] `shitty_ui/data/__init__.py`: Deprecation notice added after docstring, before imports
+- [ ] `grep -rn "TODO"` across all 4 files returns zero matches
+- [ ] `pytest -v` passes with no new failures
+- [ ] `ruff check` passes on all 4 files
+- [ ] CHANGELOG.md updated with entry under `## [Unreleased]`
+
+---
+
+## What NOT To Do
+
+1. **Do NOT delete or modify any code.** This phase is strictly comment/docstring changes. The dual-write in `s3_processor.py` must remain functional. The `NotImplementedError` raises in `twitter_harvester.py` must remain. The empty block after the error handling TODOs must remain.
+
+2. **Do NOT remove the `twitter_harvester.py` file.** It serves as a template demonstrating the `SignalHarvester` interface pattern. The module docstring already explains this purpose.
+
+3. **Do NOT add `# type: ignore` or `# noqa` comments.** The existing `# noqa: F401` comments in `shitty_ui/data/__init__.py` are intentional (re-exports). Do not add new suppression comments.
+
+4. **Do NOT change the deprecation notice into a runtime `warnings.warn()`.** The Dash dashboard is still in production. A runtime warning would spam logs on every import. A static comment is the correct approach until the dashboard is fully retired.
+
+5. **Do NOT move the deprecation notice inside the docstring.** It belongs as a standalone comment between the docstring and the first import, where it is immediately visible to developers adding new imports. Inside the docstring it would only appear in `help()` output, which nobody runs on `__init__.py` modules.
+
+6. **Do NOT reformat or restructure any of the 4 files.** Touch only the specific lines identified above. Do not reorganize imports, adjust whitespace, or "clean up" adjacent code.

--- a/shit_tests/api/conftest.py
+++ b/shit_tests/api/conftest.py
@@ -1,0 +1,288 @@
+"""
+Conftest for API tests.
+Provides TestClient, mock execute_query, and sample data fixtures.
+"""
+
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is on path
+project_root = os.path.join(os.path.dirname(__file__), "..", "..")
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Set DATABASE_URL env var so sync_session module can import
+os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+
+
+@pytest.fixture
+def mock_execute_query():
+    """Mock execute_query at all usage sites to return controlled data.
+
+    feed_queries and price_queries both do `from api.dependencies import execute_query`
+    at module level, creating separate name bindings. We share a single MagicMock
+    across both patch sites so side_effect/return_value set once works everywhere.
+
+    Usage in tests:
+        def test_something(client, mock_execute_query):
+            mock_execute_query.return_value = (rows, columns)
+            response = client.get("/api/feed/latest")
+    """
+    mock_eq = MagicMock()
+    mock_eq.return_value = ([], [])
+    with patch("api.queries.feed_queries.execute_query", mock_eq):
+        with patch("api.queries.price_queries.execute_query", mock_eq):
+            yield mock_eq
+
+
+@pytest.fixture
+def client(mock_execute_query):
+    """FastAPI TestClient with mocked database.
+
+    The mock_execute_query fixture is automatically active.
+    Access it via the mock_execute_query fixture if you need to
+    configure return values.
+    """
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def sample_post_row() -> tuple[list[tuple], list[str]]:
+    """A single analyzed post row as returned by execute_query.
+
+    Returns (rows, columns) matching get_analyzed_post_at_offset's SQL.
+    """
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_abc123",
+        "Big tariff announcement coming!",
+        "<p>Big tariff announcement coming!</p>",
+        datetime(2026, 3, 25, 14, 30, 0),
+        "realDonaldTrump",
+        "https://truthsocial.com/@realDonaldTrump/post_abc123",
+        42,
+        150,
+        500,
+        300,
+        10,
+        101,
+        ["AAPL", "TSLA"],
+        {"AAPL": "bearish", "TSLA": "bullish"},
+        0.85,
+        "Tariffs on China will hurt Apple supply chain but benefit Tesla domestic production.",
+        "completed",
+        0.7,
+        0.8,
+        -0.3,
+        0.9,
+    )
+    return ([row], columns)
+
+
+@pytest.fixture
+def sample_post_row_json_strings() -> tuple[list[tuple], list[str]]:
+    """A post row where assets and market_impact are JSON strings (not parsed).
+
+    This simulates what some database drivers return.
+    """
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_json456",
+        "Trade deal signed!",
+        "<p>Trade deal signed!</p>",
+        datetime(2026, 3, 24, 10, 0, 0),
+        "realDonaldTrump",
+        None,
+        10,
+        50,
+        200,
+        100,
+        5,
+        202,
+        '["SPY", "DIA"]',
+        '{"SPY": "bullish", "DIA": "bullish"}',
+        0.72,
+        "Trade deal boosts market indices.",
+        "completed",
+        0.5,
+        0.6,
+        0.4,
+        0.3,
+    )
+    return ([row], columns)
+
+
+@pytest.fixture
+def sample_outcomes_rows() -> tuple[list[tuple], list[str]]:
+    """Outcome rows as returned by get_outcomes_for_prediction's SQL."""
+    columns = [
+        "symbol",
+        "prediction_sentiment",
+        "prediction_confidence",
+        "price_at_prediction",
+        "price_at_post",
+        "price_at_next_close",
+        "price_1h_after",
+        "price_t1",
+        "price_t3",
+        "price_t7",
+        "price_t30",
+        "return_t1",
+        "return_t3",
+        "return_t7",
+        "return_t30",
+        "return_same_day",
+        "return_1h",
+        "correct_t1",
+        "correct_t3",
+        "correct_t7",
+        "correct_t30",
+        "correct_same_day",
+        "correct_1h",
+        "pnl_t1",
+        "pnl_t3",
+        "pnl_t7",
+        "pnl_t30",
+        "pnl_same_day",
+        "pnl_1h",
+        "is_complete",
+    ]
+    row_aapl = (
+        "AAPL",
+        "bearish",
+        0.85,
+        178.50,
+        178.20,
+        177.80,
+        178.00,
+        176.50,
+        175.00,
+        174.00,
+        180.00,
+        -1.12,
+        -1.96,
+        -2.52,
+        0.84,
+        -0.39,
+        -0.11,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        11.20,
+        19.60,
+        25.20,
+        -8.40,
+        3.90,
+        1.10,
+        True,
+    )
+    row_tsla = (
+        "TSLA",
+        "bullish",
+        0.85,
+        245.00,
+        244.80,
+        246.50,
+        245.50,
+        248.00,
+        252.00,
+        260.00,
+        240.00,
+        1.22,
+        2.86,
+        6.12,
+        -2.04,
+        0.69,
+        0.20,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        12.20,
+        28.60,
+        61.20,
+        -20.40,
+        6.90,
+        2.00,
+        True,
+    )
+    return ([row_aapl, row_tsla], columns)
+
+
+@pytest.fixture
+def sample_total_count_row() -> tuple[list[tuple], list[str]]:
+    """Total count row as returned by get_total_analyzed_posts."""
+    return ([(42,)], ["total"])
+
+
+@pytest.fixture
+def sample_candle_rows() -> tuple[list[tuple], list[str]]:
+    """Price candle rows as returned from the database fallback query."""
+    from datetime import date
+
+    columns = ["date", "open", "high", "low", "close", "volume"]
+    rows = [
+        (date(2026, 3, 20), 175.0, 178.0, 174.5, 177.0, 50000000),
+        (date(2026, 3, 21), 177.0, 179.5, 176.0, 178.5, 45000000),
+        (date(2026, 3, 24), 178.5, 180.0, 177.0, 179.0, 55000000),
+        (date(2026, 3, 25), 179.0, 181.0, 178.0, 180.5, 60000000),
+    ]
+    return (rows, columns)

--- a/shit_tests/api/test_feed_queries.py
+++ b/shit_tests/api/test_feed_queries.py
@@ -1,0 +1,346 @@
+"""Tests for feed query functions (api/queries/feed_queries.py).
+
+Unit tests for the query layer, mocking execute_query at the
+api.dependencies level.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — returns dict on success
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_returns_dict():
+    """get_analyzed_post_at_offset returns a dict with all expected keys."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_1",
+        "Hello",
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "user",
+        None,
+        1,
+        2,
+        3,
+        4,
+        5,
+        100,
+        ["AAPL"],
+        {"AAPL": "bullish"},
+        0.9,
+        "Thesis",
+        "completed",
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result is not None
+    assert result["shitpost_id"] == "post_1"
+    assert result["prediction_id"] == 100
+    assert result["confidence"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — returns None when empty
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_returns_none_when_empty():
+    """get_analyzed_post_at_offset returns None when no rows match."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(9999)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — parses JSON string assets
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_parses_json_string_assets():
+    """When assets is a JSON string, it gets parsed to a list."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_json",
+        "Text",
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "user",
+        None,
+        0,
+        0,
+        0,
+        0,
+        0,
+        200,
+        '["TSLA", "NVDA"]',
+        '{"TSLA": "bullish"}',
+        0.8,
+        "Thesis",
+        "completed",
+        None,
+        None,
+        None,
+        None,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result["assets"] == ["TSLA", "NVDA"]
+    assert isinstance(result["assets"], list)
+    assert result["market_impact"] == {"TSLA": "bullish"}
+    assert isinstance(result["market_impact"], dict)
+
+
+# ---------------------------------------------------------------------------
+# get_analyzed_post_at_offset — leaves list/dict assets as-is
+# ---------------------------------------------------------------------------
+
+
+def test_get_analyzed_post_at_offset_leaves_native_types():
+    """When assets is already a list and market_impact a dict, they are not re-parsed."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_native",
+        "Text",
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "user",
+        None,
+        0,
+        0,
+        0,
+        0,
+        0,
+        300,
+        ["AAPL"],
+        {"AAPL": "bearish"},
+        0.7,
+        "Thesis",
+        "completed",
+        None,
+        None,
+        None,
+        None,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_analyzed_post_at_offset
+
+        result = get_analyzed_post_at_offset(0)
+
+    assert result["assets"] == ["AAPL"]
+    assert result["market_impact"] == {"AAPL": "bearish"}
+
+
+# ---------------------------------------------------------------------------
+# get_outcomes_for_prediction — returns list of dicts
+# ---------------------------------------------------------------------------
+
+
+def test_get_outcomes_for_prediction_returns_list():
+    """get_outcomes_for_prediction returns a list of outcome dicts."""
+    columns = [
+        "symbol",
+        "prediction_sentiment",
+        "prediction_confidence",
+        "price_at_prediction",
+        "price_at_post",
+        "price_at_next_close",
+        "price_1h_after",
+        "price_t1",
+        "price_t3",
+        "price_t7",
+        "price_t30",
+        "return_t1",
+        "return_t3",
+        "return_t7",
+        "return_t30",
+        "return_same_day",
+        "return_1h",
+        "correct_t1",
+        "correct_t3",
+        "correct_t7",
+        "correct_t30",
+        "correct_same_day",
+        "correct_1h",
+        "pnl_t1",
+        "pnl_t3",
+        "pnl_t7",
+        "pnl_t30",
+        "pnl_same_day",
+        "pnl_1h",
+        "is_complete",
+    ]
+    row = (
+        "AAPL",
+        "bearish",
+        0.85,
+        178.5,
+        178.2,
+        177.8,
+        178.0,
+        176.5,
+        175.0,
+        174.0,
+        180.0,
+        -1.12,
+        -1.96,
+        -2.52,
+        0.84,
+        -0.39,
+        -0.11,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        11.2,
+        19.6,
+        25.2,
+        -8.4,
+        3.9,
+        1.1,
+        True,
+    )
+
+    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+        from api.queries.feed_queries import get_outcomes_for_prediction
+
+        result = get_outcomes_for_prediction(101)
+
+    assert len(result) == 1
+    assert result[0]["symbol"] == "AAPL"
+    assert result[0]["return_t1"] == -1.12
+    assert result[0]["is_complete"] is True
+
+
+# ---------------------------------------------------------------------------
+# get_outcomes_for_prediction — empty results
+# ---------------------------------------------------------------------------
+
+
+def test_get_outcomes_for_prediction_empty():
+    """get_outcomes_for_prediction returns empty list when no outcomes exist."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_outcomes_for_prediction
+
+        result = get_outcomes_for_prediction(9999)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_total_analyzed_posts — returns integer count
+# ---------------------------------------------------------------------------
+
+
+def test_get_total_analyzed_posts_returns_count():
+    """get_total_analyzed_posts returns the integer count."""
+    with patch(
+        "api.queries.feed_queries.execute_query", return_value=([(42,)], ["total"])
+    ):
+        from api.queries.feed_queries import get_total_analyzed_posts
+
+        result = get_total_analyzed_posts()
+
+    assert result == 42
+
+
+# ---------------------------------------------------------------------------
+# get_total_analyzed_posts — empty result returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_get_total_analyzed_posts_empty_returns_zero():
+    """get_total_analyzed_posts returns 0 when query returns no rows."""
+    with patch("api.queries.feed_queries.execute_query", return_value=([], [])):
+        from api.queries.feed_queries import get_total_analyzed_posts
+
+        result = get_total_analyzed_posts()
+
+    assert result == 0

--- a/shit_tests/api/test_feed_router.py
+++ b/shit_tests/api/test_feed_router.py
@@ -1,0 +1,611 @@
+"""Tests for the feed API router (api/routers/feed.py).
+
+Covers:
+- GET /api/feed/latest
+- GET /api/feed/at?offset=N
+- Navigation bounds
+- JSON field parsing
+- Error/edge cases
+- GET /api/health
+"""
+
+from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/latest — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_post_happy_path(
+    client,
+    mock_execute_query,
+    sample_post_row,
+    sample_outcomes_rows,
+    sample_total_count_row,
+):
+    """GET /api/feed/latest returns a complete FeedResponse with post, prediction, outcomes."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["post"]["shitpost_id"] == "post_abc123"
+    assert data["post"]["text"] == "Big tariff announcement coming!"
+    assert data["post"]["username"] == "realDonaldTrump"
+    assert data["post"]["engagement"]["replies"] == 42
+    assert data["post"]["engagement"]["favourites"] == 500
+
+    assert data["prediction"]["prediction_id"] == 101
+    assert data["prediction"]["confidence"] == 0.85
+    assert data["prediction"]["assets"] == ["AAPL", "TSLA"]
+    assert data["prediction"]["market_impact"] == {"AAPL": "bearish", "TSLA": "bullish"}
+    assert data["prediction"]["scores"]["urgency"] == 0.9
+
+    assert len(data["outcomes"]) == 2
+    assert data["outcomes"][0]["symbol"] == "AAPL"
+    assert data["outcomes"][0]["returns"]["t1"] == -1.12
+    assert data["outcomes"][0]["correct"]["t1"] is True
+    assert data["outcomes"][0]["pnl"]["t1"] == 11.20
+    assert data["outcomes"][1]["symbol"] == "TSLA"
+
+    assert data["navigation"]["current_offset"] == 0
+    assert data["navigation"]["total_posts"] == 42
+    assert data["navigation"]["has_newer"] is False
+    assert data["navigation"]["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/latest — empty database
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_post_empty_database(client, mock_execute_query):
+    """GET /api/feed/latest returns 404 when no analyzed posts exist."""
+    mock_execute_query.return_value = ([], [])
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 404
+    assert "No post found" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=0 — same as latest
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_zero(
+    client,
+    mock_execute_query,
+    sample_post_row,
+    sample_outcomes_rows,
+    sample_total_count_row,
+):
+    """GET /api/feed/at?offset=0 behaves identically to /api/feed/latest."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=0")
+    assert response.status_code == 200
+    assert response.json()["post"]["shitpost_id"] == "post_abc123"
+    assert response.json()["navigation"]["current_offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=5 — returns 5th post
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_five(
+    client,
+    mock_execute_query,
+    sample_post_row,
+    sample_outcomes_rows,
+    sample_total_count_row,
+):
+    """GET /api/feed/at?offset=5 returns the 5th most recent analyzed post."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=5")
+    assert response.status_code == 200
+    assert response.json()["navigation"]["current_offset"] == 5
+    assert response.json()["navigation"]["has_newer"] is True
+
+    first_call_params = mock_execute_query.call_args_list[0]
+    assert first_call_params[0][1] == {"offset": 5}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=9999 — out of range returns 404
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_offset_out_of_range(client, mock_execute_query):
+    """GET /api/feed/at?offset=9999 returns 404 when offset exceeds total posts."""
+    mock_execute_query.return_value = ([], [])
+
+    response = client.get("/api/feed/at?offset=9999")
+    assert response.status_code == 404
+    assert "No post found" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feed/at?offset=-1 — validation error (ge=0 constraint)
+# ---------------------------------------------------------------------------
+
+
+def test_get_post_at_negative_offset(client, mock_execute_query):
+    """GET /api/feed/at?offset=-1 returns 422 validation error."""
+    response = client.get("/api/feed/at?offset=-1")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Navigation bounds: has_newer=False when offset=0
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_has_newer_false_at_offset_zero(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At offset=0, has_newer must be False (already at the newest post)."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=0")
+    assert response.status_code == 200
+    assert response.json()["navigation"]["has_newer"] is False
+    assert response.json()["navigation"]["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# Navigation bounds: has_older=False when at last post
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_has_older_false_at_last_post(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At offset = total - 1, has_older must be False (already at the oldest post)."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=9")
+    assert response.status_code == 200
+
+    nav = response.json()["navigation"]
+    assert nav["has_older"] is False
+    assert nav["has_newer"] is True
+    assert nav["total_posts"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Navigation: mid-range has both directions
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_mid_range_has_both_directions(
+    client, mock_execute_query, sample_post_row, sample_outcomes_rows
+):
+    """At a mid-range offset, both has_newer and has_older must be True."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        ([(10,)], ["total"]),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at?offset=5")
+    assert response.status_code == 200
+
+    nav = response.json()["navigation"]
+    assert nav["has_newer"] is True
+    assert nav["has_older"] is True
+
+
+# ---------------------------------------------------------------------------
+# JSON field parsing: assets as JSON string gets parsed to list
+# ---------------------------------------------------------------------------
+
+
+def test_assets_json_string_parsed_to_list(
+    client, mock_execute_query, sample_post_row_json_strings, sample_total_count_row
+):
+    """When assets comes back as a JSON string from the DB, it gets parsed to a list."""
+    post_rows, post_cols = sample_post_row_json_strings
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["prediction"]["assets"] == ["SPY", "DIA"]
+    assert isinstance(data["prediction"]["assets"], list)
+
+
+# ---------------------------------------------------------------------------
+# JSON field parsing: market_impact as JSON string gets parsed to dict
+# ---------------------------------------------------------------------------
+
+
+def test_market_impact_json_string_parsed_to_dict(
+    client, mock_execute_query, sample_post_row_json_strings, sample_total_count_row
+):
+    """When market_impact comes back as a JSON string, it gets parsed to a dict."""
+    post_rows, post_cols = sample_post_row_json_strings
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["prediction"]["market_impact"] == {"SPY": "bullish", "DIA": "bullish"}
+    assert isinstance(data["prediction"]["market_impact"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Post with None text gets default empty string
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_none_text_defaults_to_empty_string(
+    client, mock_execute_query, sample_total_count_row
+):
+    """When text is None in the DB row, the response should use an empty string."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_null_text",
+        None,
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump",
+        None,
+        0,
+        0,
+        0,
+        0,
+        0,
+        303,
+        ["SPY"],
+        {"SPY": "bullish"},
+        0.6,
+        "Some thesis",
+        "completed",
+        None,
+        None,
+        None,
+        None,
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+    assert response.json()["post"]["text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Post with None engagement fields default to 0
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_none_engagement_defaults_to_zero(
+    client, mock_execute_query, sample_total_count_row
+):
+    """When engagement counts are None, the response should default them to 0."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_none_eng",
+        "Test post",
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        404,
+        ["AAPL"],
+        {"AAPL": "bullish"},
+        0.5,
+        "Thesis",
+        "completed",
+        None,
+        None,
+        None,
+        None,
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    eng = response.json()["post"]["engagement"]
+    assert eng["replies"] == 0
+    assert eng["reblogs"] == 0
+    assert eng["favourites"] == 0
+    assert eng["upvotes"] == 0
+    assert eng["downvotes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Outcomes are empty list when prediction has no outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_feed_response_with_no_outcomes(
+    client, mock_execute_query, sample_post_row, sample_total_count_row
+):
+    """When there are no outcomes for a prediction, outcomes list is empty."""
+    post_rows, post_cols = sample_post_row
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+    assert response.json()["outcomes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Scores with None values are returned as null in JSON
+# ---------------------------------------------------------------------------
+
+
+def test_scores_with_none_values(client, mock_execute_query, sample_total_count_row):
+    """When score fields are None, they serialize as null in the JSON response."""
+    columns = [
+        "shitpost_id",
+        "text",
+        "content_html",
+        "timestamp",
+        "username",
+        "url",
+        "replies_count",
+        "reblogs_count",
+        "favourites_count",
+        "upvotes_count",
+        "downvotes_count",
+        "prediction_id",
+        "assets",
+        "market_impact",
+        "confidence",
+        "thesis",
+        "analysis_status",
+        "engagement_score",
+        "viral_score",
+        "sentiment_score",
+        "urgency_score",
+    ]
+    row = (
+        "post_no_scores",
+        "Test",
+        None,
+        datetime(2026, 3, 25, 12, 0, 0),
+        "realDonaldTrump",
+        None,
+        5,
+        10,
+        20,
+        15,
+        1,
+        505,
+        ["AAPL"],
+        {"AAPL": "bullish"},
+        0.7,
+        "Thesis",
+        "completed",
+        None,
+        None,
+        None,
+        None,
+    )
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        ([row], columns),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    scores = response.json()["prediction"]["scores"]
+    assert scores["engagement"] is None
+    assert scores["viral"] is None
+    assert scores["sentiment"] is None
+    assert scores["urgency"] is None
+
+
+# ---------------------------------------------------------------------------
+# Default offset for /at endpoint is 0
+# ---------------------------------------------------------------------------
+
+
+def test_at_endpoint_default_offset_is_zero(
+    client,
+    mock_execute_query,
+    sample_post_row,
+    sample_outcomes_rows,
+    sample_total_count_row,
+):
+    """GET /api/feed/at without offset param defaults to offset=0."""
+    post_rows, post_cols = sample_post_row
+    outcome_rows, outcome_cols = sample_outcomes_rows
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        (outcome_rows, outcome_cols),
+    ]
+
+    response = client.get("/api/feed/at")
+    assert response.status_code == 200
+    assert response.json()["navigation"]["current_offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Timestamp is serialized as ISO string
+# ---------------------------------------------------------------------------
+
+
+def test_timestamp_serialized_as_iso_string(
+    client, mock_execute_query, sample_post_row, sample_total_count_row
+):
+    """The post timestamp should be an ISO-format string in the response."""
+    post_rows, post_cols = sample_post_row
+    count_rows, count_cols = sample_total_count_row
+
+    mock_execute_query.side_effect = [
+        (post_rows, post_cols),
+        (count_rows, count_cols),
+        ([], []),
+    ]
+
+    response = client.get("/api/feed/latest")
+    assert response.status_code == 200
+
+    ts = response.json()["post"]["timestamp"]
+    assert "2026" in ts
+    assert "T" in ts or "-" in ts
+
+
+# ---------------------------------------------------------------------------
+# GET /api/health — returns ok
+# ---------------------------------------------------------------------------
+
+
+def test_health_check(client, mock_execute_query):
+    """GET /api/health returns {"ok": true, "service": "shitpost-alpha-api"}."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["service"] == "shitpost-alpha-api"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/health — does not require database
+# ---------------------------------------------------------------------------
+
+
+def test_health_check_no_db_dependency(client, mock_execute_query):
+    """GET /api/health returns 200 even if execute_query would fail."""
+    mock_execute_query.side_effect = ConnectionError("DB down")
+
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True

--- a/shit_tests/api/test_price_queries.py
+++ b/shit_tests/api/test_price_queries.py
@@ -1,0 +1,221 @@
+"""Tests for price query functions (api/queries/price_queries.py).
+
+Unit tests for the query/cache layer, mocking yfinance and execute_query.
+"""
+
+import time
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_happy_path():
+    """_fetch_from_yfinance returns formatted candle dicts from YFinanceProvider."""
+    mock_record = MagicMock()
+    mock_record.date = date(2026, 3, 25)
+    mock_record.open = 180.0
+    mock_record.high = 182.0
+    mock_record.low = 179.0
+    mock_record.close = 181.5
+    mock_record.volume = 50000000
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.return_value = [mock_record]
+
+    with patch(
+        "shit.market_data.yfinance_provider.YFinanceProvider",
+        return_value=mock_provider,
+    ):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("AAPL", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert len(result) == 1
+    assert result[0]["date"] == "2026-03-25"
+    assert result[0]["close"] == 181.5
+    assert result[0]["volume"] == 50000000
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — ProviderError returns empty
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_provider_error():
+    """_fetch_from_yfinance returns empty list when YFinanceProvider raises ProviderError."""
+    from shit.market_data.price_provider import ProviderError
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.side_effect = ProviderError("yfinance", "No data")
+
+    with patch(
+        "shit.market_data.yfinance_provider.YFinanceProvider",
+        return_value=mock_provider,
+    ):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("INVALID", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_yfinance — None values default to 0
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_yfinance_none_values_default():
+    """_fetch_from_yfinance converts None OHLCV values to 0."""
+    mock_record = MagicMock()
+    mock_record.date = date(2026, 3, 25)
+    mock_record.open = None
+    mock_record.high = None
+    mock_record.low = None
+    mock_record.close = None
+    mock_record.volume = None
+
+    mock_provider = MagicMock()
+    mock_provider.fetch_prices.return_value = [mock_record]
+
+    with patch(
+        "shit.market_data.yfinance_provider.YFinanceProvider",
+        return_value=mock_provider,
+    ):
+        from api.queries.price_queries import _fetch_from_yfinance
+
+        result = _fetch_from_yfinance("AAPL", date(2026, 3, 20), date(2026, 3, 25))
+
+    assert result[0]["open"] == 0
+    assert result[0]["close"] == 0
+    assert result[0]["volume"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_database — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_database_happy_path():
+    """_fetch_from_database returns formatted candle dicts from DB rows."""
+    columns = ["date", "open", "high", "low", "close", "volume"]
+    rows = [
+        (date(2026, 3, 25), 180.0, 182.0, 179.0, 181.5, 50000000),
+    ]
+
+    with patch("api.queries.price_queries.execute_query", return_value=(rows, columns)):
+        from api.queries.price_queries import _fetch_from_database
+
+        result = _fetch_from_database("AAPL", date(2026, 3, 20))
+
+    assert len(result) == 1
+    assert result[0]["date"] == "2026-03-25"
+    assert result[0]["close"] == 181.5
+
+
+# ---------------------------------------------------------------------------
+# _fetch_from_database — empty results
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_from_database_empty():
+    """_fetch_from_database returns empty list when no rows found."""
+    with patch("api.queries.price_queries.execute_query", return_value=([], [])):
+        from api.queries.price_queries import _fetch_from_database
+
+        result = _fetch_from_database("FAKE", date(2026, 3, 20))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _get_candles — cache miss fetches from yfinance
+# ---------------------------------------------------------------------------
+
+
+def test_get_candles_cache_miss():
+    """_get_candles fetches from yfinance on cache miss."""
+    candles = [
+        {
+            "date": "2026-03-25",
+            "open": 180,
+            "high": 182,
+            "low": 179,
+            "close": 181,
+            "volume": 50000000,
+        }
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch(
+            "api.queries.price_queries._fetch_from_yfinance", return_value=candles
+        ):
+            from api.queries.price_queries import _get_candles
+
+            result = _get_candles("AAPL", 30)
+
+    assert result == candles
+
+
+# ---------------------------------------------------------------------------
+# _get_candles — cache hit returns cached data
+# ---------------------------------------------------------------------------
+
+
+def test_get_candles_cache_hit():
+    """_get_candles returns cached data without re-fetching when TTL is fresh."""
+    cached_candles = [
+        {
+            "date": "2026-03-25",
+            "open": 1,
+            "high": 2,
+            "low": 0,
+            "close": 1,
+            "volume": 100,
+        }
+    ]
+    cache = {("AAPL", 30): (cached_candles, time.time())}
+
+    with patch("api.queries.price_queries._price_cache", cache):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            from api.queries.price_queries import _get_candles
+
+            result = _get_candles("AAPL", 30)
+
+    mock_yf.assert_not_called()
+    assert result == cached_candles
+
+
+# ---------------------------------------------------------------------------
+# get_price_data — complete response structure
+# ---------------------------------------------------------------------------
+
+
+def test_get_price_data_response_structure():
+    """get_price_data returns dict with symbol, post_timestamp, candles, post_date_index."""
+    candles = [
+        {
+            "date": "2026-03-25",
+            "open": 180,
+            "high": 182,
+            "low": 179,
+            "close": 181,
+            "volume": 50000000,
+        }
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch(
+            "api.queries.price_queries._fetch_from_yfinance", return_value=candles
+        ):
+            from api.queries.price_queries import get_price_data
+
+            result = get_price_data("aapl", 30, None)
+
+    assert result["symbol"] == "AAPL"
+    assert result["post_timestamp"] is None
+    assert result["candles"] == candles
+    assert result["post_date_index"] is None

--- a/shit_tests/api/test_prices_router.py
+++ b/shit_tests/api/test_prices_router.py
@@ -1,0 +1,295 @@
+"""Tests for the prices API router (api/routers/prices.py).
+
+Covers:
+- GET /api/prices/{symbol}
+- Days parameter validation
+- post_timestamp handling
+- yfinance fallback to DB
+- TTL cache behavior
+- Edge cases
+"""
+
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_happy_path(client, mock_execute_query):
+    """GET /api/prices/AAPL returns PriceResponse with candles from yfinance."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {
+                    "date": "2026-03-25",
+                    "open": 180.0,
+                    "high": 182.0,
+                    "low": 179.0,
+                    "close": 181.5,
+                    "volume": 50000000,
+                }
+            ]
+
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "AAPL"
+    assert len(data["candles"]) == 1
+    assert data["candles"][0]["close"] == 181.5
+    assert data["post_date_index"] is None
+    assert data["post_timestamp"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=7 — respects days param
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_respects_days_param(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=7 passes days=7 to get_price_data."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {
+                    "date": "2026-03-24",
+                    "open": 1,
+                    "high": 2,
+                    "low": 0.5,
+                    "close": 1.5,
+                    "volume": 100,
+                },
+            ]
+
+            response = client.get("/api/prices/AAPL?days=7")
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=0 — validation error (ge=1)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_days_zero_validation_error(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=0 returns 422 (days must be >= 1)."""
+    response = client.get("/api/prices/AAPL?days=0")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?days=999 — validation error (le=365)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_days_too_large_validation_error(client, mock_execute_query):
+    """GET /api/prices/AAPL?days=999 returns 422 (days must be <= 365)."""
+    response = client.get("/api/prices/AAPL?days=999")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?post_timestamp=... — finds correct post_date_index
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_with_post_timestamp(client, mock_execute_query):
+    """post_timestamp locates the correct candle index in the response."""
+    candles = [
+        {
+            "date": "2026-03-20",
+            "open": 175,
+            "high": 178,
+            "low": 174,
+            "close": 177,
+            "volume": 50000000,
+        },
+        {
+            "date": "2026-03-21",
+            "open": 177,
+            "high": 179,
+            "low": 176,
+            "close": 178,
+            "volume": 45000000,
+        },
+        {
+            "date": "2026-03-24",
+            "open": 178,
+            "high": 180,
+            "low": 177,
+            "close": 179,
+            "volume": 55000000,
+        },
+        {
+            "date": "2026-03-25",
+            "open": 179,
+            "high": 181,
+            "low": 178,
+            "close": 180,
+            "volume": 60000000,
+        },
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+            response = client.get(
+                "/api/prices/AAPL?post_timestamp=2026-03-21T14:30:00Z"
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["post_date_index"] == 1
+    assert data["post_timestamp"] == "2026-03-21T14:30:00Z"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/AAPL?post_timestamp=invalid — gracefully handles bad timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_invalid_post_timestamp(client, mock_execute_query):
+    """An invalid post_timestamp is silently ignored; post_date_index is None."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = [
+                {
+                    "date": "2026-03-25",
+                    "open": 179,
+                    "high": 181,
+                    "low": 178,
+                    "close": 180,
+                    "volume": 60000000,
+                },
+            ]
+            response = client.get("/api/prices/AAPL?post_timestamp=not-a-date")
+
+    assert response.status_code == 200
+    assert response.json()["post_date_index"] is None
+
+
+# ---------------------------------------------------------------------------
+# Empty candles returned (yfinance + DB both fail)
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_both_sources_fail_returns_empty_candles(client, mock_execute_query):
+    """When yfinance returns [] and DB fallback also returns [], candles is empty."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    assert response.json()["candles"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cache hit: second request returns cached data
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_cache_hit(client, mock_execute_query):
+    """Second request within TTL returns cached data without re-fetching."""
+    candles = [
+        {
+            "date": "2026-03-25",
+            "open": 179,
+            "high": 181,
+            "low": 178,
+            "close": 180,
+            "volume": 60000000,
+        },
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+
+            response1 = client.get("/api/prices/AAPL?days=30")
+            assert response1.status_code == 200
+            assert mock_yf.call_count == 1
+
+            response2 = client.get("/api/prices/AAPL?days=30")
+            assert response2.status_code == 200
+            assert mock_yf.call_count == 1
+
+    assert response2.json()["candles"] == response1.json()["candles"]
+
+
+# ---------------------------------------------------------------------------
+# Symbol is uppercased in response
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_symbol_uppercased(client, mock_execute_query):
+    """Symbol is uppercased in the response regardless of input casing."""
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []
+            response = client.get("/api/prices/aapl")
+
+    assert response.status_code == 200
+    assert response.json()["symbol"] == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# yfinance fails, DB fallback succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_get_prices_yfinance_fails_db_fallback(
+    client, mock_execute_query, sample_candle_rows
+):
+    """When yfinance returns empty, falls back to database and returns those candles."""
+    db_rows, db_cols = sample_candle_rows
+    mock_execute_query.return_value = (db_rows, db_cols)
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = []
+            response = client.get("/api/prices/AAPL")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["candles"]) == 4
+    assert data["candles"][0]["date"] == "2026-03-20"
+
+
+# ---------------------------------------------------------------------------
+# post_timestamp between two candle dates picks the earlier one
+# ---------------------------------------------------------------------------
+
+
+def test_post_timestamp_between_dates_picks_earlier(client, mock_execute_query):
+    """When post_timestamp falls between two candle dates, the index of the earlier candle is used."""
+    candles = [
+        {
+            "date": "2026-03-20",
+            "open": 175,
+            "high": 178,
+            "low": 174,
+            "close": 177,
+            "volume": 50000000,
+        },
+        {
+            "date": "2026-03-24",
+            "open": 178,
+            "high": 180,
+            "low": 177,
+            "close": 179,
+            "volume": 55000000,
+        },
+    ]
+
+    with patch("api.queries.price_queries._price_cache", {}):
+        with patch("api.queries.price_queries._fetch_from_yfinance") as mock_yf:
+            mock_yf.return_value = candles
+            response = client.get(
+                "/api/prices/AAPL?post_timestamp=2026-03-22T12:00:00Z"
+            )
+
+    assert response.status_code == 200
+    assert response.json()["post_date_index"] == 0

--- a/shit_tests/api/test_telegram_router.py
+++ b/shit_tests/api/test_telegram_router.py
@@ -1,0 +1,189 @@
+"""Tests for the Telegram webhook router (api/routers/telegram.py).
+
+Covers:
+- POST /telegram/webhook
+- GET /telegram/health
+- Error handling
+
+NOTE: The telegram router uses lazy imports (inside function bodies), so
+mock targets point to the source modules, not api.routers.telegram.
+"""
+
+from unittest.mock import patch
+from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — valid update returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_valid_update(client, mock_execute_query):
+    """POST /telegram/webhook with a valid Telegram update returns 200 {"ok": true}."""
+    update_payload = {
+        "update_id": 123456,
+        "message": {
+            "message_id": 1,
+            "from": {"id": 789, "is_bot": False, "first_name": "Test"},
+            "chat": {"id": 789, "type": "private"},
+            "date": 1711000000,
+            "text": "/start",
+        },
+    }
+
+    with patch("notifications.telegram_bot.process_update") as mock_process:
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    mock_process.assert_called_once_with(update_payload)
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — invalid JSON returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_invalid_json(client, mock_execute_query):
+    """POST /telegram/webhook with invalid JSON returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"not valid json{{{",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert "Invalid JSON" in response.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — process_update exception still returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_process_update_exception_returns_200(
+    client, mock_execute_query
+):
+    """Even if process_update raises, the webhook returns 200 to prevent Telegram retries."""
+    update_payload = {"update_id": 999, "message": {"text": "/crash"}}
+
+    with patch(
+        "notifications.telegram_bot.process_update",
+        side_effect=RuntimeError("boom"),
+    ):
+        response = client.post("/telegram/webhook", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — returns health info
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_happy_path(client, mock_execute_query):
+    """GET /telegram/health returns full health info when everything works."""
+    mock_stats = {"total": 50, "active": 45, "total_alerts_sent": 1200}
+    mock_last_check = datetime(2026, 3, 25, 14, 0, 0)
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch(
+            "notifications.db.get_last_alert_check", return_value=mock_last_check
+        ):
+            with patch(
+                "notifications.telegram_sender.get_bot_token",
+                return_value="valid-token",
+            ):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["service"] == "telegram_alerts"
+    assert data["bot_configured"] is True
+    assert data["subscribers"]["total"] == 50
+    assert data["subscribers"]["active"] == 45
+    assert data["total_alerts_sent"] == 1200
+    assert data["last_alert_check"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — with missing bot token
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_missing_bot_token(client, mock_execute_query):
+    """GET /telegram/health reports bot_configured=False when token is missing."""
+    mock_stats = {"total": 10, "active": 8, "total_alerts_sent": 50}
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch("notifications.db.get_last_alert_check", return_value=None):
+            with patch(
+                "notifications.telegram_sender.get_bot_token", return_value=None
+            ):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["bot_configured"] is False
+    assert data["last_alert_check"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — when DB stats fail returns 503
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_db_failure_returns_503(client, mock_execute_query):
+    """GET /telegram/health returns 503 when database calls raise."""
+    with patch(
+        "notifications.db.get_subscription_stats",
+        side_effect=ConnectionError("DB unavailable"),
+    ):
+        response = client.get("/telegram/health")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+    assert "DB unavailable" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /telegram/webhook — empty body returns 400
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_webhook_empty_body(client, mock_execute_query):
+    """POST /telegram/webhook with empty body returns 400."""
+    response = client.post(
+        "/telegram/webhook",
+        content=b"",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /telegram/health — last_alert_check is None when no alerts sent
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_health_no_alerts_sent(client, mock_execute_query):
+    """GET /telegram/health handles the case where no alerts have ever been sent."""
+    mock_stats = {"total": 1, "active": 1, "total_alerts_sent": 0}
+
+    with patch("notifications.db.get_subscription_stats", return_value=mock_stats):
+        with patch("notifications.db.get_last_alert_check", return_value=None):
+            with patch(
+                "notifications.telegram_sender.get_bot_token", return_value="tok"
+            ):
+                response = client.get("/telegram/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["last_alert_check"] is None
+    assert data["total_alerts_sent"] == 0


### PR DESCRIPTION
## Summary
- **54 new tests** for the FastAPI API module (`api/`) which previously had zero test coverage
- **CORS hardening** — restrict `allow_origins` to Railway domain in production (was wildcard `*`)
- **Tech debt scan documentation** — 5-phase remediation plan generated from full codebase scan

## Test Coverage Added
| File | Tests | Coverage |
|------|-------|---------|
| `test_feed_router.py` | 17 | Feed endpoints, navigation, JSON parsing, health check |
| `test_prices_router.py` | 11 | Price endpoints, yfinance fallback, cache, validation |
| `test_telegram_router.py` | 8 | Webhook, error resilience, health check |
| `test_feed_queries.py` | 8 | Query layer unit tests |
| `test_price_queries.py` | 8 | yfinance provider, DB fallback, cache TTL |
| **Total** | **54** | |

## CORS Change
- `ALLOWED_ORIGINS` env var (comma-separated, defaults to Railway URL)
- `ENVIRONMENT=development` enables wildcard — all other values restrict to whitelist

## Tech Debt Plans (Phases 02-05, not yet implemented)
- Phase 02: Notifications test coverage + query dedup
- Phase 03: Dependency cleanup (remove 4 unused packages)
- Phase 04: outcome_calculator decomposition + CLI split
- Phase 05: TODO resolution + legacy documentation

## Test plan
- [x] `pytest shit_tests/api/ -v` — 54/54 pass
- [x] `pytest` — 2565 pass (5 pre-existing config failures only)
- [x] `ruff check` — clean
- [x] `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)