### PR TITLE
feat: notifications DB test coverage + query dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Notifications DB test coverage** — 62 tests for all 13 functions in `notifications/db.py`
+  - Subscription CRUD: get, create, update, deactivate, reactivation flows
+  - Alert operations: record_alert_sent, record_error, get_subscription_stats
+  - Prediction queries: get_new_predictions_since, get_prediction_stats, get_latest_predictions
+  - Edge cases: SQL injection prevention, None handling, int-to-string coercion, datetime serialization
+
+### Changed
+- **Notifications query dedup** — Extract `_execute_read`/`_execute_write` helpers in `notifications/db.py`
+  - Eliminates 11 duplicated try/session/except blocks
+  - `context` parameter preserves function-specific error logging
+  - `_extract_scalar` helper for single-value queries (get_last_alert_check)
+
+### Added
 - **API test coverage** — 54 tests for all FastAPI endpoints, query functions, and response schemas
   - Feed router: navigation bounds, JSON parsing, engagement defaults, error cases
   - Price router: yfinance/DB fallback, cache TTL, post_timestamp indexing, validation

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/02_notifications-test-coverage.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/02_notifications-test-coverage.md
@@ -1,5 +1,10 @@
 # Phase 02 — Notifications DB Test Coverage + Query Dedup
 
+**Status:** ✅ COMPLETE
+**Started:** 2026-03-28
+**Completed:** 2026-03-28
+**PR:** #114
+
 | Field | Value |
 |---|---|
 | **PR Title** | `feat: notifications DB test coverage + query dedup` |
@@ -969,7 +974,7 @@ class TestGetLastAlertCheck:
         assert result is None
 ```
 
-**Total test count**: 64 tests (9 existing + 55 new).
+**Total test count**: 62 tests (8 existing + 54 new).
 
 ### Step 2: Run the tests and verify they all pass
 
@@ -978,7 +983,7 @@ Run:
 ./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v
 ```
 
-All 64 tests must pass before proceeding to the refactor step.
+All 62 tests must pass before proceeding to the refactor step.
 
 ### Step 3: Extract query helper functions in `notifications/db.py`
 
@@ -994,6 +999,7 @@ def _execute_read(
     params: Optional[Dict[str, Any]] = None,
     processor=_rows_to_dicts,
     default: Any = None,
+    context: str = "",
 ) -> Any:
     """
     Execute a read query with standard error handling.
@@ -1004,6 +1010,7 @@ def _execute_read(
         processor: Function to process the result (default: _rows_to_dicts).
                    Use _row_to_dict for single-row queries.
         default: Value to return on error or empty result.
+        context: Descriptive label for error logging (e.g. "get_subscription").
 
     Returns:
         Processed query result, or default on error.
@@ -1013,13 +1020,14 @@ def _execute_read(
             result = session.execute(text(query_str), params or {})
             return processor(result)
     except Exception as e:
-        logger.error(f"Read query error: {e}")
+        logger.error(f"Error in {context}: {e}" if context else f"Read query error: {e}")
         return default
 
 
 def _execute_write(
     query_str: str,
     params: Optional[Dict[str, Any]] = None,
+    context: str = "",
 ) -> bool:
     """
     Execute a write query with standard error handling.
@@ -1027,6 +1035,7 @@ def _execute_write(
     Args:
         query_str: SQL query string.
         params: Optional query parameters.
+        context: Descriptive label for error logging (e.g. "record_alert_sent").
 
     Returns:
         True if successful, False on error.
@@ -1036,7 +1045,7 @@ def _execute_write(
             session.execute(text(query_str), params or {})
         return True
     except Exception as e:
-        logger.error(f"Write query error: {e}")
+        logger.error(f"Error in {context}: {e}" if context else f"Write query error: {e}")
         return False
 ```
 
@@ -1105,6 +1114,7 @@ def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
         params={"chat_id": str(chat_id)},
         processor=_row_to_dict,
         default=None,
+        context=f"get_subscription(chat_id={chat_id})",
     )
 ```
 
@@ -1161,6 +1171,7 @@ def get_active_subscriptions() -> List[Dict[str, Any]]:
         ORDER BY subscribed_at ASC
         """,
         default=[],
+        context="get_active_subscriptions",
     )
 ```
 
@@ -1266,6 +1277,7 @@ After:
                 "title": title,
                 "alert_preferences": json.dumps(default_prefs),
             },
+            context=f"create_subscription(chat_id={chat_id})",
         )
         if success:
             logger.info(f"Created Telegram subscription for chat_id {chat_id}")
@@ -1320,6 +1332,7 @@ def record_alert_sent(chat_id: str) -> bool:
         WHERE chat_id = :chat_id
         """,
         params={"chat_id": str(chat_id)},
+        context=f"record_alert_sent(chat_id={chat_id})",
     )
 ```
 
@@ -1362,6 +1375,7 @@ def record_error(chat_id: str, error_message: str) -> bool:
         WHERE chat_id = :chat_id
         """,
         params={"chat_id": str(chat_id), "error_message": error_message},
+        context=f"record_error(chat_id={chat_id})",
     )
 ```
 
@@ -1409,6 +1423,7 @@ def get_subscription_stats() -> Dict[str, Any]:
         """,
         processor=_row_to_dict,
         default=None,
+        context="get_subscription_stats",
     )
     return result or {}
 ```
@@ -1509,9 +1524,8 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
         """,
         params={"since": since},
         default=[],
+        context="get_new_predictions_since",
     )
-    if results is None:
-        return []
     for row_dict in results:
         if isinstance(row_dict.get("timestamp"), datetime):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
@@ -1587,6 +1601,7 @@ def get_prediction_stats() -> Dict[str, Any]:
         """,
         processor=_row_to_dict,
         default=None,
+        context="get_prediction_stats",
     )
     if not row:
         return {}
@@ -1688,9 +1703,8 @@ def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
         """,
         params={"limit": limit},
         default=[],
+        context="get_latest_predictions",
     )
-    if results is None:
-        return []
     for row_dict in results:
         if isinstance(row_dict.get("created_at"), datetime):
             row_dict["created_at"] = row_dict["created_at"].isoformat()
@@ -1754,6 +1768,7 @@ def get_last_alert_check() -> Optional[datetime]:
         """,
         processor=_extract_scalar,
         default=None,
+        context="get_last_alert_check",
     )
 ```
 
@@ -1766,7 +1781,7 @@ Run:
 ./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v
 ```
 
-All 64 tests must still pass. If any fail, the refactor introduced a regression -- fix before proceeding.
+All 62 tests must still pass. If any fail, the refactor introduced a regression -- fix before proceeding.
 
 ### Step 5: Run the full test suite
 
@@ -1839,6 +1854,7 @@ def _execute_read(
     params: Optional[Dict[str, Any]] = None,
     processor=_rows_to_dicts,
     default: Any = None,
+    context: str = "",
 ) -> Any:
     """
     Execute a read query with standard error handling.
@@ -1849,6 +1865,7 @@ def _execute_read(
         processor: Function to process the result (default: _rows_to_dicts).
                    Use _row_to_dict for single-row queries.
         default: Value to return on error or empty result.
+        context: Descriptive label for error logging (e.g. "get_subscription").
 
     Returns:
         Processed query result, or default on error.
@@ -1858,13 +1875,14 @@ def _execute_read(
             result = session.execute(text(query_str), params or {})
             return processor(result)
     except Exception as e:
-        logger.error(f"Read query error: {e}")
+        logger.error(f"Error in {context}: {e}" if context else f"Read query error: {e}")
         return default
 
 
 def _execute_write(
     query_str: str,
     params: Optional[Dict[str, Any]] = None,
+    context: str = "",
 ) -> bool:
     """
     Execute a write query with standard error handling.
@@ -1872,6 +1890,7 @@ def _execute_write(
     Args:
         query_str: SQL query string.
         params: Optional query parameters.
+        context: Descriptive label for error logging (e.g. "record_alert_sent").
 
     Returns:
         True if successful, False on error.
@@ -1881,7 +1900,7 @@ def _execute_write(
             session.execute(text(query_str), params or {})
         return True
     except Exception as e:
-        logger.error(f"Write query error: {e}")
+        logger.error(f"Error in {context}: {e}" if context else f"Write query error: {e}")
         return False
 
 
@@ -1934,6 +1953,7 @@ def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
         params={"chat_id": str(chat_id)},
         processor=_row_to_dict,
         default=None,
+        context=f"get_subscription(chat_id={chat_id})",
     )
 
 
@@ -1956,6 +1976,7 @@ def get_active_subscriptions() -> List[Dict[str, Any]]:
         ORDER BY subscribed_at ASC
         """,
         default=[],
+        context="get_active_subscriptions",
     )
 
 
@@ -2022,6 +2043,7 @@ def create_subscription(
                 "title": title,
                 "alert_preferences": json.dumps(default_prefs),
             },
+            context=f"create_subscription(chat_id={chat_id})",
         )
         if success:
             logger.info(f"Created Telegram subscription for chat_id {chat_id}")
@@ -2092,6 +2114,7 @@ def record_alert_sent(chat_id: str) -> bool:
         WHERE chat_id = :chat_id
         """,
         params={"chat_id": str(chat_id)},
+        context=f"record_alert_sent(chat_id={chat_id})",
     )
 
 
@@ -2106,6 +2129,7 @@ def record_error(chat_id: str, error_message: str) -> bool:
         WHERE chat_id = :chat_id
         """,
         params={"chat_id": str(chat_id), "error_message": error_message},
+        context=f"record_error(chat_id={chat_id})",
     )
 
 
@@ -2124,6 +2148,7 @@ def get_subscription_stats() -> Dict[str, Any]:
         """,
         processor=_row_to_dict,
         default=None,
+        context="get_subscription_stats",
     )
     return result or {}
 
@@ -2169,9 +2194,8 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
         """,
         params={"since": since},
         default=[],
+        context="get_new_predictions_since",
     )
-    if results is None:
-        return []
     for row_dict in results:
         if isinstance(row_dict.get("timestamp"), datetime):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
@@ -2200,6 +2224,7 @@ def get_prediction_stats() -> Dict[str, Any]:
         """,
         processor=_row_to_dict,
         default=None,
+        context="get_prediction_stats",
     )
     if not row:
         return {}
@@ -2251,9 +2276,8 @@ def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
         """,
         params={"limit": limit},
         default=[],
+        context="get_latest_predictions",
     )
-    if results is None:
-        return []
     for row_dict in results:
         if isinstance(row_dict.get("created_at"), datetime):
             row_dict["created_at"] = row_dict["created_at"].isoformat()
@@ -2279,6 +2303,7 @@ def get_last_alert_check() -> Optional[datetime]:
         """,
         processor=_extract_scalar,
         default=None,
+        context="get_last_alert_check",
     )
 ```
 
@@ -2286,7 +2311,7 @@ def get_last_alert_check() -> Optional[datetime]:
 
 ## Test Plan
 
-### New tests added (55 tests across 13 test classes)
+### New tests added (54 tests across 14 test classes)
 
 | Class | Tests | What it verifies |
 |---|---|---|
@@ -2305,12 +2330,12 @@ def get_last_alert_check() -> Optional[datetime]:
 | `TestGetLatestPredictions` | 5 | Results with outcomes, datetime serialization, limit param, default limit, DB error |
 | `TestGetLastAlertCheck` | 4 | datetime returned, NULL → None, no rows → None, DB error |
 
-### Existing tests preserved (9 tests across 2 test classes)
+### Existing tests preserved (8 tests across 2 test classes)
 
 | Class | Tests |
 |---|---|
 | `TestUpdatableColumnsWhitelist` | 3 |
-| `TestUpdateSubscriptionInjectionPrevention` | 6 |
+| `TestUpdateSubscriptionInjectionPrevention` | 5 |
 
 ### Coverage expectations
 
@@ -2374,7 +2399,7 @@ Every function that touches the database is tested with a mock that raises `Exce
 
 ## Verification Checklist
 
-- [ ] All 64 tests pass: `./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v`
+- [ ] All 62 tests pass: `./venv/bin/python -m pytest shit_tests/notifications/test_db.py -v`
 - [ ] Full test suite passes: `./venv/bin/python -m pytest -v`
 - [ ] Linting passes: `./venv/bin/python -m ruff check notifications/db.py shit_tests/notifications/test_db.py`
 - [ ] Formatting passes: `./venv/bin/python -m ruff format --check notifications/db.py shit_tests/notifications/test_db.py`

--- a/notifications/db.py
+++ b/notifications/db.py
@@ -33,24 +33,93 @@ def _rows_to_dicts(result) -> List[Dict[str, Any]]:
     return [dict(zip(columns, row)) for row in rows]
 
 
+def _extract_scalar(result) -> Any:
+    """Extract a single scalar value from a query result."""
+    row = result.fetchone()
+    if row and row[0]:
+        return row[0]
+    return None
+
+
+def _execute_read(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+    processor=_rows_to_dicts,
+    default: Any = None,
+    context: str = "",
+) -> Any:
+    """
+    Execute a read query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+        processor: Function to process the result (default: _rows_to_dicts).
+                   Use _row_to_dict for single-row queries.
+        default: Value to return on error or empty result.
+        context: Descriptive label for error logging (e.g. "get_subscription").
+
+    Returns:
+        Processed query result, or default on error.
+    """
+    try:
+        with get_session() as session:
+            result = session.execute(text(query_str), params or {})
+            return processor(result)
+    except Exception as e:
+        logger.error(
+            f"Error in {context}: {e}" if context else f"Read query error: {e}"
+        )
+        return default
+
+
+def _execute_write(
+    query_str: str,
+    params: Optional[Dict[str, Any]] = None,
+    context: str = "",
+) -> bool:
+    """
+    Execute a write query with standard error handling.
+
+    Args:
+        query_str: SQL query string.
+        params: Optional query parameters.
+        context: Descriptive label for error logging (e.g. "record_alert_sent").
+
+    Returns:
+        True if successful, False on error.
+    """
+    try:
+        with get_session() as session:
+            session.execute(text(query_str), params or {})
+        return True
+    except Exception as e:
+        logger.error(
+            f"Error in {context}: {e}" if context else f"Write query error: {e}"
+        )
+        return False
+
+
 # Whitelist of columns that can be updated via update_subscription().
 # Prevents SQL injection through dynamic kwargs keys.
-_UPDATABLE_COLUMNS = frozenset({
-    "chat_type",
-    "username",
-    "first_name",
-    "last_name",
-    "title",
-    "is_active",
-    "subscribed_at",
-    "unsubscribed_at",
-    "alert_preferences",
-    "last_alert_at",
-    "alerts_sent_count",
-    "consecutive_errors",
-    "last_error",
-    "last_interaction_at",
-})
+_UPDATABLE_COLUMNS = frozenset(
+    {
+        "chat_type",
+        "username",
+        "first_name",
+        "last_name",
+        "title",
+        "is_active",
+        "subscribed_at",
+        "unsubscribed_at",
+        "alert_preferences",
+        "last_alert_at",
+        "alerts_sent_count",
+        "consecutive_errors",
+        "last_error",
+        "last_interaction_at",
+    }
+)
 
 
 # ============================================================
@@ -68,23 +137,22 @@ def get_subscription(chat_id: str) -> Optional[Dict[str, Any]]:
     Returns:
         Subscription dict or None if not found.
     """
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    id, chat_id, chat_type, username, first_name, last_name,
-                    title, is_active, subscribed_at, unsubscribed_at,
-                    alert_preferences, last_alert_at, alerts_sent_count,
-                    last_interaction_at, consecutive_errors, last_error,
-                    created_at, updated_at
-                FROM telegram_subscriptions
-                WHERE chat_id = :chat_id
-            """)
-            result = session.execute(query, {"chat_id": str(chat_id)})
-            return _row_to_dict(result)
-    except Exception as e:
-        logger.error(f"Error getting subscription for chat_id {chat_id}: {e}")
-        return None
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, unsubscribed_at,
+            alert_preferences, last_alert_at, alerts_sent_count,
+            last_interaction_at, consecutive_errors, last_error,
+            created_at, updated_at
+        FROM telegram_subscriptions
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+        processor=_row_to_dict,
+        default=None,
+        context=f"get_subscription(chat_id={chat_id})",
+    )
 
 
 def get_active_subscriptions() -> List[Dict[str, Any]]:
@@ -94,23 +162,20 @@ def get_active_subscriptions() -> List[Dict[str, Any]]:
     Returns:
         List of subscription dicts.
     """
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    id, chat_id, chat_type, username, first_name, last_name,
-                    title, is_active, subscribed_at, alert_preferences,
-                    last_alert_at, alerts_sent_count, consecutive_errors
-                FROM telegram_subscriptions
-                WHERE is_active = true
-                    AND consecutive_errors < 5
-                ORDER BY subscribed_at ASC
-            """)
-            result = session.execute(query)
-            return _rows_to_dicts(result)
-    except Exception as e:
-        logger.error(f"Error getting active subscriptions: {e}")
-        return []
+    return _execute_read(
+        """
+        SELECT
+            id, chat_id, chat_type, username, first_name, last_name,
+            title, is_active, subscribed_at, alert_preferences,
+            last_alert_at, alerts_sent_count, consecutive_errors
+        FROM telegram_subscriptions
+        WHERE is_active = true
+            AND consecutive_errors < 5
+        ORDER BY subscribed_at ASC
+        """,
+        default=[],
+        context="get_active_subscriptions",
+    )
 
 
 def create_subscription(
@@ -153,34 +218,34 @@ def create_subscription(
             "quiet_hours_end": "08:00",
         }
 
-        with get_session() as session:
-            query = text("""
-                INSERT INTO telegram_subscriptions (
-                    chat_id, chat_type, username, first_name, last_name, title,
-                    is_active, subscribed_at, alert_preferences,
-                    alerts_sent_count, consecutive_errors,
-                    created_at, updated_at
-                ) VALUES (
-                    :chat_id, :chat_type, :username, :first_name, :last_name, :title,
-                    true, NOW(), :alert_preferences,
-                    0, 0,
-                    NOW(), NOW()
-                )
-            """)
-            session.execute(
-                query,
-                {
-                    "chat_id": str(chat_id),
-                    "chat_type": chat_type,
-                    "username": username,
-                    "first_name": first_name,
-                    "last_name": last_name,
-                    "title": title,
-                    "alert_preferences": json.dumps(default_prefs),
-                },
+        success = _execute_write(
+            """
+            INSERT INTO telegram_subscriptions (
+                chat_id, chat_type, username, first_name, last_name, title,
+                is_active, subscribed_at, alert_preferences,
+                alerts_sent_count, consecutive_errors,
+                created_at, updated_at
+            ) VALUES (
+                :chat_id, :chat_type, :username, :first_name, :last_name, :title,
+                true, NOW(), :alert_preferences,
+                0, 0,
+                NOW(), NOW()
             )
-        logger.info(f"Created Telegram subscription for chat_id {chat_id}")
-        return True
+            """,
+            params={
+                "chat_id": str(chat_id),
+                "chat_type": chat_type,
+                "username": username,
+                "first_name": first_name,
+                "last_name": last_name,
+                "title": title,
+                "alert_preferences": json.dumps(default_prefs),
+            },
+            context=f"create_subscription(chat_id={chat_id})",
+        )
+        if success:
+            logger.info(f"Created Telegram subscription for chat_id {chat_id}")
+        return success
     except Exception as e:
         logger.error(f"Error creating subscription for chat_id {chat_id}: {e}")
         return False
@@ -237,62 +302,53 @@ def deactivate_subscription(chat_id: str) -> bool:
 
 def record_alert_sent(chat_id: str) -> bool:
     """Record that an alert was sent to this subscription."""
-    try:
-        with get_session() as session:
-            query = text("""
-                UPDATE telegram_subscriptions
-                SET last_alert_at = NOW(),
-                    alerts_sent_count = alerts_sent_count + 1,
-                    consecutive_errors = 0,
-                    updated_at = NOW()
-                WHERE chat_id = :chat_id
-            """)
-            session.execute(query, {"chat_id": str(chat_id)})
-        return True
-    except Exception as e:
-        logger.error(f"Error recording alert sent for chat_id {chat_id}: {e}")
-        return False
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET last_alert_at = NOW(),
+            alerts_sent_count = alerts_sent_count + 1,
+            consecutive_errors = 0,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+        context=f"record_alert_sent(chat_id={chat_id})",
+    )
 
 
 def record_error(chat_id: str, error_message: str) -> bool:
     """Record an error for this subscription."""
-    try:
-        with get_session() as session:
-            query = text("""
-                UPDATE telegram_subscriptions
-                SET consecutive_errors = consecutive_errors + 1,
-                    last_error = :error_message,
-                    updated_at = NOW()
-                WHERE chat_id = :chat_id
-            """)
-            session.execute(
-                query, {"chat_id": str(chat_id), "error_message": error_message}
-            )
-        return True
-    except Exception as e:
-        logger.error(f"Error recording error for chat_id {chat_id}: {e}")
-        return False
+    return _execute_write(
+        """
+        UPDATE telegram_subscriptions
+        SET consecutive_errors = consecutive_errors + 1,
+            last_error = :error_message,
+            updated_at = NOW()
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id), "error_message": error_message},
+        context=f"record_error(chat_id={chat_id})",
+    )
 
 
 def get_subscription_stats() -> Dict[str, Any]:
     """Get statistics about Telegram subscriptions."""
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    COUNT(*) as total,
-                    COUNT(CASE WHEN is_active = true THEN 1 END) as active,
-                    COUNT(CASE WHEN chat_type = 'private' THEN 1 END) as private_chats,
-                    COUNT(CASE WHEN chat_type IN ('group', 'supergroup') THEN 1 END) as groups,
-                    COUNT(CASE WHEN chat_type = 'channel' THEN 1 END) as channels,
-                    SUM(alerts_sent_count) as total_alerts_sent
-                FROM telegram_subscriptions
-            """)
-            result = session.execute(query)
-            return _row_to_dict(result) or {}
-    except Exception as e:
-        logger.error(f"Error getting subscription stats: {e}")
-        return {}
+    result = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total,
+            COUNT(CASE WHEN is_active = true THEN 1 END) as active,
+            COUNT(CASE WHEN chat_type = 'private' THEN 1 END) as private_chats,
+            COUNT(CASE WHEN chat_type IN ('group', 'supergroup') THEN 1 END) as groups,
+            COUNT(CASE WHEN chat_type = 'channel' THEN 1 END) as channels,
+            SUM(alerts_sent_count) as total_alerts_sent
+        FROM telegram_subscriptions
+        """,
+        processor=_row_to_dict,
+        default=None,
+        context="get_subscription_stats",
+    )
+    return result or {}
 
 
 # ============================================================
@@ -310,44 +366,42 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
     Returns:
         List of prediction dicts with associated shitpost data.
     """
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    tss.timestamp,
-                    tss.text,
-                    tss.shitpost_id,
-                    p.id as prediction_id,
-                    p.assets,
-                    p.market_impact,
-                    p.confidence,
-                    p.thesis,
-                    p.analysis_status,
-                    p.created_at as prediction_created_at
-                FROM predictions p
-                INNER JOIN truth_social_shitposts tss
-                    ON tss.shitpost_id = p.shitpost_id
-                WHERE p.analysis_status = 'completed'
-                    AND p.created_at > :since
-                    AND p.confidence IS NOT NULL
-                    AND p.assets IS NOT NULL
-                    AND p.assets::jsonb <> '[]'::jsonb
-                ORDER BY p.created_at DESC
-                LIMIT 50
-            """)
-            result = session.execute(query, {"since": since})
-            results = _rows_to_dicts(result)
-            for row_dict in results:
-                if isinstance(row_dict.get("timestamp"), datetime):
-                    row_dict["timestamp"] = row_dict["timestamp"].isoformat()
-                if isinstance(row_dict.get("prediction_created_at"), datetime):
-                    row_dict["prediction_created_at"] = row_dict[
-                        "prediction_created_at"
-                    ].isoformat()
-            return results
-    except Exception as e:
-        logger.error(f"Error loading new predictions: {e}")
-        return []
+    results = _execute_read(
+        """
+        SELECT
+            tss.timestamp,
+            tss.text,
+            tss.shitpost_id,
+            p.id as prediction_id,
+            p.assets,
+            p.market_impact,
+            p.confidence,
+            p.thesis,
+            p.analysis_status,
+            p.created_at as prediction_created_at
+        FROM predictions p
+        INNER JOIN truth_social_shitposts tss
+            ON tss.shitpost_id = p.shitpost_id
+        WHERE p.analysis_status = 'completed'
+            AND p.created_at > :since
+            AND p.confidence IS NOT NULL
+            AND p.assets IS NOT NULL
+            AND p.assets::jsonb <> '[]'::jsonb
+        ORDER BY p.created_at DESC
+        LIMIT 50
+        """,
+        params={"since": since},
+        default=[],
+        context="get_new_predictions_since",
+    )
+    for row_dict in results:
+        if isinstance(row_dict.get("timestamp"), datetime):
+            row_dict["timestamp"] = row_dict["timestamp"].isoformat()
+        if isinstance(row_dict.get("prediction_created_at"), datetime):
+            row_dict["prediction_created_at"] = row_dict[
+                "prediction_created_at"
+            ].isoformat()
+    return results
 
 
 def get_prediction_stats() -> Dict[str, Any]:
@@ -357,36 +411,35 @@ def get_prediction_stats() -> Dict[str, Any]:
     Returns:
         Dict with accuracy, win_rate, total_pnl, total_predictions.
     """
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    COUNT(*) as total_predictions,
-                    COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_count,
-                    COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_count,
-                    COALESCE(SUM(return_t7), 0) as total_return
-                FROM prediction_outcomes
-            """)
-            result = session.execute(query)
-            row = _row_to_dict(result)
-            if row:
-                total = row.get("total_predictions", 0) or 0
-                correct = row.get("correct_count", 0) or 0
-                evaluated = row.get("evaluated_count", 0) or 0
-                total_return = float(row.get("total_return", 0) or 0)
-
-                win_rate = (correct / evaluated * 100) if evaluated > 0 else 0.0
-                return {
-                    "total_predictions": total,
-                    "evaluated": evaluated,
-                    "correct": correct,
-                    "win_rate": round(win_rate, 1),
-                    "total_return_pct": round(total_return * 100, 2),
-                }
-            return {}
-    except Exception as e:
-        logger.error(f"Error getting prediction stats: {e}")
+    row = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total_predictions,
+            COUNT(CASE WHEN correct_t7 = true THEN 1 END) as correct_count,
+            COUNT(CASE WHEN correct_t7 IS NOT NULL THEN 1 END) as evaluated_count,
+            COALESCE(SUM(return_t7), 0) as total_return
+        FROM prediction_outcomes
+        """,
+        processor=_row_to_dict,
+        default=None,
+        context="get_prediction_stats",
+    )
+    if not row:
         return {}
+
+    total = row.get("total_predictions", 0) or 0
+    correct = row.get("correct_count", 0) or 0
+    evaluated = row.get("evaluated_count", 0) or 0
+    total_return = float(row.get("total_return", 0) or 0)
+
+    win_rate = (correct / evaluated * 100) if evaluated > 0 else 0.0
+    return {
+        "total_predictions": total,
+        "evaluated": evaluated,
+        "correct": correct,
+        "win_rate": round(win_rate, 1),
+        "total_return_pct": round(total_return * 100, 2),
+    }
 
 
 def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
@@ -399,36 +452,34 @@ def get_latest_predictions(limit: int = 5) -> List[Dict[str, Any]]:
     Returns:
         List of prediction dicts with outcome status.
     """
-    try:
-        with get_session() as session:
-            query = text("""
-                SELECT
-                    p.id as prediction_id,
-                    p.assets,
-                    p.confidence,
-                    p.market_impact,
-                    p.thesis,
-                    p.created_at,
-                    po.prediction_sentiment,
-                    po.correct_t7,
-                    po.return_t7,
-                    po.symbol
-                FROM predictions p
-                LEFT JOIN prediction_outcomes po ON po.prediction_id = p.id
-                WHERE p.analysis_status = 'completed'
-                    AND p.confidence IS NOT NULL
-                ORDER BY p.created_at DESC
-                LIMIT :limit
-            """)
-            result = session.execute(query, {"limit": limit})
-            results = _rows_to_dicts(result)
-            for row_dict in results:
-                if isinstance(row_dict.get("created_at"), datetime):
-                    row_dict["created_at"] = row_dict["created_at"].isoformat()
-            return results
-    except Exception as e:
-        logger.error(f"Error getting latest predictions: {e}")
-        return []
+    results = _execute_read(
+        """
+        SELECT
+            p.id as prediction_id,
+            p.assets,
+            p.confidence,
+            p.market_impact,
+            p.thesis,
+            p.created_at,
+            po.prediction_sentiment,
+            po.correct_t7,
+            po.return_t7,
+            po.symbol
+        FROM predictions p
+        LEFT JOIN prediction_outcomes po ON po.prediction_id = p.id
+        WHERE p.analysis_status = 'completed'
+            AND p.confidence IS NOT NULL
+        ORDER BY p.created_at DESC
+        LIMIT :limit
+        """,
+        params={"limit": limit},
+        default=[],
+        context="get_latest_predictions",
+    )
+    for row_dict in results:
+        if isinstance(row_dict.get("created_at"), datetime):
+            row_dict["created_at"] = row_dict["created_at"].isoformat()
+    return results
 
 
 # ============================================================
@@ -440,22 +491,15 @@ def get_last_alert_check() -> Optional[datetime]:
     """
     Get the timestamp of the last alert check from the database.
 
-    Uses a simple key-value approach in a notification_state table,
-    falling back to None if the table doesn't exist yet.
+    Uses the most recent last_alert_at across all active subscriptions as a proxy.
     """
-    try:
-        with get_session() as session:
-            # Use the most recent alert sent across all subscriptions as a proxy
-            query = text("""
-                SELECT MAX(last_alert_at) as last_check
-                FROM telegram_subscriptions
-                WHERE is_active = true
-            """)
-            result = session.execute(query)
-            row = result.fetchone()
-            if row and row[0]:
-                return row[0]
-            return None
-    except Exception as e:
-        logger.error(f"Error getting last alert check: {e}")
-        return None
+    return _execute_read(
+        """
+        SELECT MAX(last_alert_at) as last_check
+        FROM telegram_subscriptions
+        WHERE is_active = true
+        """,
+        processor=_extract_scalar,
+        default=None,
+        context="get_last_alert_check",
+    )

--- a/shit_tests/notifications/test_db.py
+++ b/shit_tests/notifications/test_db.py
@@ -1,6 +1,346 @@
-"""Tests for notifications/db.py — focusing on SQL injection prevention."""
+"""Tests for notifications/db.py — full coverage of all 13 functions."""
 
-from notifications.db import update_subscription, _UPDATABLE_COLUMNS
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from notifications.db import (
+    _row_to_dict,
+    _rows_to_dicts,
+    _UPDATABLE_COLUMNS,
+    get_subscription,
+    get_active_subscriptions,
+    create_subscription,
+    update_subscription,
+    deactivate_subscription,
+    record_alert_sent,
+    record_error,
+    get_subscription_stats,
+    get_new_predictions_since,
+    get_prediction_stats,
+    get_latest_predictions,
+    get_last_alert_check,
+)
+
+
+# ============================================================
+# _row_to_dict / _rows_to_dicts helpers
+# ============================================================
+
+
+class TestRowToDict:
+    """Tests for the _row_to_dict helper function."""
+
+    def test_returns_dict_for_single_row(self):
+        """A result with one row returns a dict mapping column names to values."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_123", "private", True)]
+        mock_result.keys.return_value = ["chat_id", "chat_type", "is_active"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_123", "chat_type": "private", "is_active": True}
+
+    def test_returns_first_row_when_multiple_rows(self):
+        """When multiple rows exist, only the first row is returned."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("chat_1", "private", True),
+            ("chat_2", "group", False),
+        ]
+        mock_result.keys.return_value = ["chat_id", "chat_type", "is_active"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_1", "chat_type": "private", "is_active": True}
+
+    def test_returns_none_for_empty_result(self):
+        """An empty result set returns None."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+
+        result = _row_to_dict(mock_result)
+
+        assert result is None
+
+    def test_handles_none_values_in_row(self):
+        """None values in the row are preserved in the dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_123", None, None)]
+        mock_result.keys.return_value = ["chat_id", "username", "last_error"]
+
+        result = _row_to_dict(mock_result)
+
+        assert result == {"chat_id": "chat_123", "username": None, "last_error": None}
+
+
+class TestRowsToDicts:
+    """Tests for the _rows_to_dicts helper function."""
+
+    def test_returns_list_of_dicts(self):
+        """Multiple rows are converted to a list of dicts."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("chat_1", True),
+            ("chat_2", False),
+        ]
+        mock_result.keys.return_value = ["chat_id", "is_active"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == [
+            {"chat_id": "chat_1", "is_active": True},
+            {"chat_id": "chat_2", "is_active": False},
+        ]
+
+    def test_returns_empty_list_for_no_rows(self):
+        """An empty result set returns an empty list."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = ["chat_id", "is_active"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == []
+
+    def test_single_row_returns_single_element_list(self):
+        """A single row returns a list with one dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("chat_1", 5)]
+        mock_result.keys.return_value = ["chat_id", "alerts_sent_count"]
+
+        result = _rows_to_dicts(mock_result)
+
+        assert result == [{"chat_id": "chat_1", "alerts_sent_count": 5}]
+
+
+# ============================================================
+# get_subscription
+# ============================================================
+
+
+class TestGetSubscription:
+    """Tests for get_subscription()."""
+
+    def test_returns_subscription_dict_when_found(self, mock_sync_session):
+        """Returns a dict when a matching subscription exists."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "12345", "private", "testuser", "Test", "User",
+             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+        ]
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription("12345")
+
+        assert result is not None
+        assert result["chat_id"] == "12345"
+        assert result["username"] == "testuser"
+        assert result["is_active"] is True
+
+    def test_returns_none_when_not_found(self, mock_sync_session):
+        """Returns None when no subscription matches the chat_id."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription("nonexistent")
+
+        assert result is None
+
+    def test_returns_none_on_database_error(self, mock_sync_session):
+        """Returns None when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_subscription("12345")
+
+        assert result is None
+
+    def test_passes_chat_id_as_string(self, mock_sync_session):
+        """chat_id is always converted to string before passing to the query."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        get_subscription(12345)  # Pass as int
+
+        # Verify the params dict has chat_id as a string
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]  # second positional arg is params dict
+        assert params["chat_id"] == "12345"
+
+
+# ============================================================
+# get_active_subscriptions
+# ============================================================
+
+
+class TestGetActiveSubscriptions:
+    """Tests for get_active_subscriptions()."""
+
+    def test_returns_list_of_active_subscriptions(self, mock_sync_session):
+        """Returns a list of dicts for active subscriptions."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "chat_1", "private", "user1", "Alice", None, None, True, None, "{}", None, 3, 0),
+            (2, "chat_2", "group", None, None, None, "My Group", True, None, "{}", None, 7, 1),
+        ]
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "alert_preferences",
+            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_active_subscriptions()
+
+        assert len(result) == 2
+        assert result[0]["chat_id"] == "chat_1"
+        assert result[1]["chat_id"] == "chat_2"
+
+    def test_returns_empty_list_when_no_active_subs(self, mock_sync_session):
+        """Returns empty list when there are no active subscriptions."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "alert_preferences",
+            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_active_subscriptions()
+
+        assert result == []
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection timeout")
+
+        result = get_active_subscriptions()
+
+        assert result == []
+
+
+# ============================================================
+# create_subscription
+# ============================================================
+
+
+class TestCreateSubscription:
+    """Tests for create_subscription()."""
+
+    def test_creates_new_subscription(self, mock_sync_session):
+        """Creates a new subscription when none exists for the chat_id."""
+        # First call: get_subscription returns None (no existing sub)
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = []
+
+        # Second call: INSERT succeeds
+        mock_result_insert = MagicMock()
+
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_insert]
+
+        result = create_subscription("99999", "private", username="newuser", first_name="New")
+
+        assert result is True
+        # Verify INSERT was called (second execute call)
+        assert mock_sync_session.execute.call_count == 2
+        insert_params = mock_sync_session.execute.call_args_list[1][0][1]
+        assert insert_params["chat_id"] == "99999"
+        assert insert_params["chat_type"] == "private"
+        assert insert_params["username"] == "newuser"
+        assert insert_params["first_name"] == "New"
+        # Verify default preferences are JSON-encoded
+        prefs = json.loads(insert_params["alert_preferences"])
+        assert prefs["min_confidence"] == 0.7
+        assert prefs["assets_of_interest"] == []
+
+    def test_reactivates_inactive_subscription(self, mock_sync_session):
+        """Reactivates an existing inactive subscription instead of creating a new one."""
+        # get_subscription returns an inactive sub
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = [
+            (1, "12345", "private", "user", "Test", None,
+             None, False, None, None, "{}", None, 0, None, 0, None, None, None)
+        ]
+        mock_result_select.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+
+        # update_subscription (called internally for reactivation)
+        mock_result_update = MagicMock()
+
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_update]
+
+        result = create_subscription("12345", "private")
+
+        assert result is True
+
+    def test_returns_true_for_already_active_subscription(self, mock_sync_session):
+        """Returns True immediately if subscription already exists and is active."""
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = [
+            (1, "12345", "private", "user", "Test", None,
+             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+        ]
+        mock_result_select.keys.return_value = [
+            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
+            "title", "is_active", "subscribed_at", "unsubscribed_at",
+            "alert_preferences", "last_alert_at", "alerts_sent_count",
+            "last_interaction_at", "consecutive_errors", "last_error",
+            "created_at", "updated_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result_select
+
+        result = create_subscription("12345", "private")
+
+        assert result is True
+        # Only the SELECT was executed (no INSERT)
+        assert mock_sync_session.execute.call_count == 1
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        # get_subscription raises (first execute call)
+        mock_sync_session.execute.side_effect = Exception("DB error")
+
+        result = create_subscription("12345", "private")
+
+        assert result is False
+
+    def test_optional_params_default_to_none(self, mock_sync_session):
+        """Optional parameters (username, first_name, last_name, title) default to None."""
+        mock_result_select = MagicMock()
+        mock_result_select.fetchall.return_value = []
+        mock_result_insert = MagicMock()
+        mock_sync_session.execute.side_effect = [mock_result_select, mock_result_insert]
+
+        result = create_subscription("99999", "channel")
+
+        assert result is True
+        insert_params = mock_sync_session.execute.call_args_list[1][0][1]
+        assert insert_params["username"] is None
+        assert insert_params["first_name"] is None
+        assert insert_params["last_name"] is None
+        assert insert_params["title"] is None
+
+
+# ============================================================
+# update_subscription (existing tests preserved + new tests)
+# ============================================================
 
 
 class TestUpdatableColumnsWhitelist:
@@ -56,3 +396,510 @@ class TestUpdateSubscriptionInjectionPrevention:
     def test_empty_kwargs_returns_true(self, mock_sync_session):
         result = update_subscription("12345")
         assert result is True
+
+
+class TestUpdateSubscription:
+    """Additional update_subscription tests beyond injection prevention."""
+
+    def test_serializes_alert_preferences_dict_to_json(self, mock_sync_session):
+        """When alert_preferences is a dict, it is JSON-serialized before query."""
+        prefs = {"min_confidence": 0.9, "assets_of_interest": ["AAPL"]}
+
+        result = update_subscription("12345", alert_preferences=prefs)
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        # The value should be a JSON string, not a dict
+        assert isinstance(params["alert_preferences"], str)
+        assert json.loads(params["alert_preferences"]) == prefs
+
+    def test_alert_preferences_string_passed_as_is(self, mock_sync_session):
+        """When alert_preferences is already a string, it is not double-serialized."""
+        prefs_str = '{"min_confidence": 0.8}'
+
+        result = update_subscription("12345", alert_preferences=prefs_str)
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["alert_preferences"] == prefs_str
+
+    def test_multiple_columns_updated(self, mock_sync_session):
+        """Multiple valid columns can be updated in a single call."""
+        result = update_subscription(
+            "12345", username="newname", first_name="NewFirst", is_active=True
+        )
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["username"] == "newname"
+        assert params["first_name"] == "NewFirst"
+        assert params["is_active"] is True
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception during UPDATE."""
+        mock_sync_session.execute.side_effect = Exception("Connection lost")
+
+        result = update_subscription("12345", username="new")
+
+        assert result is False
+
+    def test_invalid_column_raises_and_returns_false(self, mock_sync_session):
+        """An invalid column name causes ValueError which is caught, returning False."""
+        result = update_subscription("12345", drop_table="malicious")
+
+        assert result is False
+
+
+# ============================================================
+# deactivate_subscription
+# ============================================================
+
+
+class TestDeactivateSubscription:
+    """Tests for deactivate_subscription()."""
+
+    def test_calls_update_with_is_active_false(self, mock_sync_session):
+        """Deactivation sets is_active=False and unsubscribed_at to a datetime."""
+        result = deactivate_subscription("12345")
+
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["is_active"] is False
+        assert params["chat_id"] == "12345"
+        # unsubscribed_at should be a datetime (from datetime.utcnow())
+        assert "unsubscribed_at" in params
+
+    def test_returns_false_on_error(self, mock_sync_session):
+        """Returns False when the underlying update fails."""
+        mock_sync_session.execute.side_effect = Exception("DB down")
+
+        result = deactivate_subscription("12345")
+
+        assert result is False
+
+
+# ============================================================
+# record_alert_sent
+# ============================================================
+
+
+class TestRecordAlertSent:
+    """Tests for record_alert_sent()."""
+
+    def test_returns_true_on_success(self, mock_sync_session):
+        """Returns True when the update succeeds."""
+        result = record_alert_sent("12345")
+
+        assert result is True
+        mock_sync_session.execute.assert_called_once()
+
+    def test_passes_chat_id_as_string(self, mock_sync_session):
+        """chat_id is passed as a string to the query params."""
+        record_alert_sent(12345)  # Pass int
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Timeout")
+
+        result = record_alert_sent("12345")
+
+        assert result is False
+
+
+# ============================================================
+# record_error
+# ============================================================
+
+
+class TestRecordError:
+    """Tests for record_error()."""
+
+    def test_returns_true_on_success(self, mock_sync_session):
+        """Returns True when the error is recorded successfully."""
+        result = record_error("12345", "Connection timeout")
+
+        assert result is True
+        mock_sync_session.execute.assert_called_once()
+
+    def test_passes_error_message_to_query(self, mock_sync_session):
+        """The error_message is passed to the query params."""
+        record_error("12345", "Rate limited")
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["error_message"] == "Rate limited"
+        assert params["chat_id"] == "12345"
+
+    def test_returns_false_on_database_error(self, mock_sync_session):
+        """Returns False when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("DB error")
+
+        result = record_error("12345", "Some error")
+
+        assert result is False
+
+
+# ============================================================
+# get_subscription_stats
+# ============================================================
+
+
+class TestGetSubscriptionStats:
+    """Tests for get_subscription_stats()."""
+
+    def test_returns_stats_dict(self, mock_sync_session):
+        """Returns aggregated stats as a dict."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(10, 8, 6, 2, 2, 150)]
+        mock_result.keys.return_value = [
+            "total", "active", "private_chats", "groups", "channels", "total_alerts_sent"
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription_stats()
+
+        assert result["total"] == 10
+        assert result["active"] == 8
+        assert result["private_chats"] == 6
+        assert result["groups"] == 2
+        assert result["channels"] == 2
+        assert result["total_alerts_sent"] == 150
+
+    def test_returns_empty_dict_when_no_subscriptions(self, mock_sync_session):
+        """Returns empty dict when _row_to_dict returns None (no rows)."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_subscription_stats()
+
+        # _row_to_dict returns None, function returns {} via `or {}`
+        assert result == {}
+
+    def test_returns_empty_dict_on_database_error(self, mock_sync_session):
+        """Returns empty dict when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_subscription_stats()
+
+        assert result == {}
+
+
+# ============================================================
+# get_new_predictions_since
+# ============================================================
+
+
+class TestGetNewPredictionsSince:
+    """Tests for get_new_predictions_since()."""
+
+    def test_returns_predictions_list(self, mock_sync_session):
+        """Returns a list of prediction dicts with joined shitpost data."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (
+                datetime(2026, 3, 15, 10, 0, 0),  # timestamp
+                "Big news about tariffs!",         # text
+                "post_123",                        # shitpost_id
+                42,                                # prediction_id
+                '["SPY", "DIA"]',                  # assets
+                '{"SPY": "bearish"}',              # market_impact
+                0.85,                              # confidence
+                "Tariffs likely to impact...",      # thesis
+                "completed",                       # analysis_status
+                datetime(2026, 3, 15, 10, 5, 0),  # prediction_created_at
+            ),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert len(result) == 1
+        assert result[0]["shitpost_id"] == "post_123"
+        assert result[0]["confidence"] == 0.85
+
+    def test_serializes_datetime_fields_to_iso(self, mock_sync_session):
+        """datetime fields (timestamp, prediction_created_at) are converted to ISO strings."""
+        since = datetime(2026, 1, 1)
+        ts = datetime(2026, 3, 15, 10, 0, 0)
+        created = datetime(2026, 3, 15, 10, 5, 0)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (ts, "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", created),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result[0]["timestamp"] == "2026-03-15T10:00:00"
+        assert result[0]["prediction_created_at"] == "2026-03-15T10:05:00"
+
+    def test_non_datetime_timestamp_not_converted(self, mock_sync_session):
+        """If timestamp is already a string, it is left as-is."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("2026-03-15T10:00:00", "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", "2026-03-15T10:05:00"),
+        ]
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result[0]["timestamp"] == "2026-03-15T10:00:00"
+
+    def test_returns_empty_list_when_no_predictions(self, mock_sync_session):
+        """Returns empty list when no predictions match the criteria."""
+        since = datetime(2026, 1, 1)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
+            "market_impact", "confidence", "thesis", "analysis_status",
+            "prediction_created_at",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_new_predictions_since(since)
+
+        assert result == []
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Query timeout")
+
+        result = get_new_predictions_since(datetime(2026, 1, 1))
+
+        assert result == []
+
+
+# ============================================================
+# get_prediction_stats
+# ============================================================
+
+
+class TestGetPredictionStats:
+    """Tests for get_prediction_stats()."""
+
+    def test_returns_computed_stats(self, mock_sync_session):
+        """Returns a dict with computed win_rate and total_return_pct."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(100, 60, 80, 0.15)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["total_predictions"] == 100
+        assert result["evaluated"] == 80
+        assert result["correct"] == 60
+        assert result["win_rate"] == 75.0  # 60/80 * 100
+        assert result["total_return_pct"] == 15.0  # 0.15 * 100
+
+    def test_zero_evaluated_avoids_division_by_zero(self, mock_sync_session):
+        """When evaluated_count is 0, win_rate is 0.0 (no ZeroDivisionError)."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(5, 0, 0, 0)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["win_rate"] == 0.0
+        assert result["total_predictions"] == 5
+
+    def test_handles_none_values_from_db(self, mock_sync_session):
+        """None values from SUM/COUNT are treated as 0."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(None, None, None, None)]
+        mock_result.keys.return_value = [
+            "total_predictions", "correct_count", "evaluated_count", "total_return",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result["total_predictions"] == 0
+        assert result["win_rate"] == 0.0
+        assert result["total_return_pct"] == 0.0
+
+    def test_returns_empty_dict_when_no_rows(self, mock_sync_session):
+        """Returns empty dict when _row_to_dict returns None."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_prediction_stats()
+
+        assert result == {}
+
+    def test_returns_empty_dict_on_database_error(self, mock_sync_session):
+        """Returns empty dict when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_prediction_stats()
+
+        assert result == {}
+
+
+# ============================================================
+# get_latest_predictions
+# ============================================================
+
+
+class TestGetLatestPredictions:
+    """Tests for get_latest_predictions()."""
+
+    def test_returns_list_of_predictions_with_outcomes(self, mock_sync_session):
+        """Returns prediction dicts with LEFT JOINed outcome data."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, '["AAPL"]', 0.9, '{"AAPL": "bullish"}', "Strong buy",
+             datetime(2026, 3, 15), "bullish", True, 0.05, "AAPL"),
+        ]
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_latest_predictions(limit=5)
+
+        assert len(result) == 1
+        assert result[0]["prediction_id"] == 1
+        assert result[0]["confidence"] == 0.9
+        # created_at should be serialized to ISO string
+        assert result[0]["created_at"] == "2026-03-15T00:00:00"
+
+    def test_serializes_created_at_to_iso(self, mock_sync_session):
+        """datetime created_at is converted to ISO string."""
+        dt = datetime(2026, 3, 20, 14, 30, 0)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (1, "[]", 0.8, "{}", "thesis", dt, None, None, None, None),
+        ]
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_latest_predictions(limit=1)
+
+        assert result[0]["created_at"] == "2026-03-20T14:30:00"
+
+    def test_passes_limit_to_query(self, mock_sync_session):
+        """The limit parameter is passed through to the SQL query."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        get_latest_predictions(limit=10)
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["limit"] == 10
+
+    def test_default_limit_is_five(self, mock_sync_session):
+        """Default limit is 5 when not specified."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = [
+            "prediction_id", "assets", "confidence", "market_impact", "thesis",
+            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+        ]
+        mock_sync_session.execute.return_value = mock_result
+
+        get_latest_predictions()
+
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["limit"] == 5
+
+    def test_returns_empty_list_on_database_error(self, mock_sync_session):
+        """Returns empty list when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Timeout")
+
+        result = get_latest_predictions()
+
+        assert result == []
+
+
+# ============================================================
+# get_last_alert_check
+# ============================================================
+
+
+class TestGetLastAlertCheck:
+    """Tests for get_last_alert_check()."""
+
+    def test_returns_datetime_when_found(self, mock_sync_session):
+        """Returns a datetime when active subscriptions have a last_alert_at."""
+        expected_dt = datetime(2026, 3, 25, 15, 30, 0)
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (expected_dt,)
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result == expected_dt
+
+    def test_returns_none_when_no_alerts_sent(self, mock_sync_session):
+        """Returns None when MAX(last_alert_at) is NULL (no alerts ever sent)."""
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (None,)
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result is None
+
+    def test_returns_none_when_no_rows(self, mock_sync_session):
+        """Returns None when fetchone returns None (no rows at all)."""
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = None
+        mock_sync_session.execute.return_value = mock_result
+
+        result = get_last_alert_check()
+
+        assert result is None
+
+    def test_returns_none_on_database_error(self, mock_sync_session):
+        """Returns None when the database raises an exception."""
+        mock_sync_session.execute.side_effect = Exception("Connection refused")
+
+        result = get_last_alert_check()
+
+        assert result is None

--- a/shit_tests/notifications/test_db.py
+++ b/shit_tests/notifications/test_db.py
@@ -4,8 +4,6 @@ import json
 from datetime import datetime
 from unittest.mock import MagicMock
 
-import pytest
-
 from notifications.db import (
     _row_to_dict,
     _rows_to_dicts,
@@ -41,7 +39,11 @@ class TestRowToDict:
 
         result = _row_to_dict(mock_result)
 
-        assert result == {"chat_id": "chat_123", "chat_type": "private", "is_active": True}
+        assert result == {
+            "chat_id": "chat_123",
+            "chat_type": "private",
+            "is_active": True,
+        }
 
     def test_returns_first_row_when_multiple_rows(self):
         """When multiple rows exist, only the first row is returned."""
@@ -54,7 +56,11 @@ class TestRowToDict:
 
         result = _row_to_dict(mock_result)
 
-        assert result == {"chat_id": "chat_1", "chat_type": "private", "is_active": True}
+        assert result == {
+            "chat_id": "chat_1",
+            "chat_type": "private",
+            "is_active": True,
+        }
 
     def test_returns_none_for_empty_result(self):
         """An empty result set returns None."""
@@ -128,15 +134,46 @@ class TestGetSubscription:
         """Returns a dict when a matching subscription exists."""
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [
-            (1, "12345", "private", "testuser", "Test", "User",
-             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+            (
+                1,
+                "12345",
+                "private",
+                "testuser",
+                "Test",
+                "User",
+                None,
+                True,
+                None,
+                None,
+                "{}",
+                None,
+                5,
+                None,
+                0,
+                None,
+                None,
+                None,
+            )
         ]
         mock_result.keys.return_value = [
-            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
-            "title", "is_active", "subscribed_at", "unsubscribed_at",
-            "alert_preferences", "last_alert_at", "alerts_sent_count",
-            "last_interaction_at", "consecutive_errors", "last_error",
-            "created_at", "updated_at",
+            "id",
+            "chat_id",
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "unsubscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "last_interaction_at",
+            "consecutive_errors",
+            "last_error",
+            "created_at",
+            "updated_at",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -191,13 +228,51 @@ class TestGetActiveSubscriptions:
         """Returns a list of dicts for active subscriptions."""
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [
-            (1, "chat_1", "private", "user1", "Alice", None, None, True, None, "{}", None, 3, 0),
-            (2, "chat_2", "group", None, None, None, "My Group", True, None, "{}", None, 7, 1),
+            (
+                1,
+                "chat_1",
+                "private",
+                "user1",
+                "Alice",
+                None,
+                None,
+                True,
+                None,
+                "{}",
+                None,
+                3,
+                0,
+            ),
+            (
+                2,
+                "chat_2",
+                "group",
+                None,
+                None,
+                None,
+                "My Group",
+                True,
+                None,
+                "{}",
+                None,
+                7,
+                1,
+            ),
         ]
         mock_result.keys.return_value = [
-            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
-            "title", "is_active", "subscribed_at", "alert_preferences",
-            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+            "id",
+            "chat_id",
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "consecutive_errors",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -212,9 +287,19 @@ class TestGetActiveSubscriptions:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = []
         mock_result.keys.return_value = [
-            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
-            "title", "is_active", "subscribed_at", "alert_preferences",
-            "last_alert_at", "alerts_sent_count", "consecutive_errors",
+            "id",
+            "chat_id",
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "consecutive_errors",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -250,7 +335,9 @@ class TestCreateSubscription:
 
         mock_sync_session.execute.side_effect = [mock_result_select, mock_result_insert]
 
-        result = create_subscription("99999", "private", username="newuser", first_name="New")
+        result = create_subscription(
+            "99999", "private", username="newuser", first_name="New"
+        )
 
         assert result is True
         # Verify INSERT was called (second execute call)
@@ -270,15 +357,46 @@ class TestCreateSubscription:
         # get_subscription returns an inactive sub
         mock_result_select = MagicMock()
         mock_result_select.fetchall.return_value = [
-            (1, "12345", "private", "user", "Test", None,
-             None, False, None, None, "{}", None, 0, None, 0, None, None, None)
+            (
+                1,
+                "12345",
+                "private",
+                "user",
+                "Test",
+                None,
+                None,
+                False,
+                None,
+                None,
+                "{}",
+                None,
+                0,
+                None,
+                0,
+                None,
+                None,
+                None,
+            )
         ]
         mock_result_select.keys.return_value = [
-            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
-            "title", "is_active", "subscribed_at", "unsubscribed_at",
-            "alert_preferences", "last_alert_at", "alerts_sent_count",
-            "last_interaction_at", "consecutive_errors", "last_error",
-            "created_at", "updated_at",
+            "id",
+            "chat_id",
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "unsubscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "last_interaction_at",
+            "consecutive_errors",
+            "last_error",
+            "created_at",
+            "updated_at",
         ]
 
         # update_subscription (called internally for reactivation)
@@ -294,15 +412,46 @@ class TestCreateSubscription:
         """Returns True immediately if subscription already exists and is active."""
         mock_result_select = MagicMock()
         mock_result_select.fetchall.return_value = [
-            (1, "12345", "private", "user", "Test", None,
-             None, True, None, None, "{}", None, 5, None, 0, None, None, None)
+            (
+                1,
+                "12345",
+                "private",
+                "user",
+                "Test",
+                None,
+                None,
+                True,
+                None,
+                None,
+                "{}",
+                None,
+                5,
+                None,
+                0,
+                None,
+                None,
+                None,
+            )
         ]
         mock_result_select.keys.return_value = [
-            "id", "chat_id", "chat_type", "username", "first_name", "last_name",
-            "title", "is_active", "subscribed_at", "unsubscribed_at",
-            "alert_preferences", "last_alert_at", "alerts_sent_count",
-            "last_interaction_at", "consecutive_errors", "last_error",
-            "created_at", "updated_at",
+            "id",
+            "chat_id",
+            "chat_type",
+            "username",
+            "first_name",
+            "last_name",
+            "title",
+            "is_active",
+            "subscribed_at",
+            "unsubscribed_at",
+            "alert_preferences",
+            "last_alert_at",
+            "alerts_sent_count",
+            "last_interaction_at",
+            "consecutive_errors",
+            "last_error",
+            "created_at",
+            "updated_at",
         ]
         mock_sync_session.execute.return_value = mock_result_select
 
@@ -561,7 +710,12 @@ class TestGetSubscriptionStats:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [(10, 8, 6, 2, 2, 150)]
         mock_result.keys.return_value = [
-            "total", "active", "private_chats", "groups", "channels", "total_alerts_sent"
+            "total",
+            "active",
+            "private_chats",
+            "groups",
+            "channels",
+            "total_alerts_sent",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -609,20 +763,27 @@ class TestGetNewPredictionsSince:
         mock_result.fetchall.return_value = [
             (
                 datetime(2026, 3, 15, 10, 0, 0),  # timestamp
-                "Big news about tariffs!",         # text
-                "post_123",                        # shitpost_id
-                42,                                # prediction_id
-                '["SPY", "DIA"]',                  # assets
-                '{"SPY": "bearish"}',              # market_impact
-                0.85,                              # confidence
-                "Tariffs likely to impact...",      # thesis
-                "completed",                       # analysis_status
+                "Big news about tariffs!",  # text
+                "post_123",  # shitpost_id
+                42,  # prediction_id
+                '["SPY", "DIA"]',  # assets
+                '{"SPY": "bearish"}',  # market_impact
+                0.85,  # confidence
+                "Tariffs likely to impact...",  # thesis
+                "completed",  # analysis_status
                 datetime(2026, 3, 15, 10, 5, 0),  # prediction_created_at
             ),
         ]
         mock_result.keys.return_value = [
-            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
-            "market_impact", "confidence", "thesis", "analysis_status",
+            "timestamp",
+            "text",
+            "shitpost_id",
+            "prediction_id",
+            "assets",
+            "market_impact",
+            "confidence",
+            "thesis",
+            "analysis_status",
             "prediction_created_at",
         ]
         mock_sync_session.execute.return_value = mock_result
@@ -643,8 +804,15 @@ class TestGetNewPredictionsSince:
             (ts, "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", created),
         ]
         mock_result.keys.return_value = [
-            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
-            "market_impact", "confidence", "thesis", "analysis_status",
+            "timestamp",
+            "text",
+            "shitpost_id",
+            "prediction_id",
+            "assets",
+            "market_impact",
+            "confidence",
+            "thesis",
+            "analysis_status",
             "prediction_created_at",
         ]
         mock_sync_session.execute.return_value = mock_result
@@ -659,11 +827,29 @@ class TestGetNewPredictionsSince:
         since = datetime(2026, 1, 1)
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [
-            ("2026-03-15T10:00:00", "text", "post_1", 1, "[]", "{}", 0.9, "thesis", "completed", "2026-03-15T10:05:00"),
+            (
+                "2026-03-15T10:00:00",
+                "text",
+                "post_1",
+                1,
+                "[]",
+                "{}",
+                0.9,
+                "thesis",
+                "completed",
+                "2026-03-15T10:05:00",
+            ),
         ]
         mock_result.keys.return_value = [
-            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
-            "market_impact", "confidence", "thesis", "analysis_status",
+            "timestamp",
+            "text",
+            "shitpost_id",
+            "prediction_id",
+            "assets",
+            "market_impact",
+            "confidence",
+            "thesis",
+            "analysis_status",
             "prediction_created_at",
         ]
         mock_sync_session.execute.return_value = mock_result
@@ -678,8 +864,15 @@ class TestGetNewPredictionsSince:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = []
         mock_result.keys.return_value = [
-            "timestamp", "text", "shitpost_id", "prediction_id", "assets",
-            "market_impact", "confidence", "thesis", "analysis_status",
+            "timestamp",
+            "text",
+            "shitpost_id",
+            "prediction_id",
+            "assets",
+            "market_impact",
+            "confidence",
+            "thesis",
+            "analysis_status",
             "prediction_created_at",
         ]
         mock_sync_session.execute.return_value = mock_result
@@ -710,7 +903,10 @@ class TestGetPredictionStats:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [(100, 60, 80, 0.15)]
         mock_result.keys.return_value = [
-            "total_predictions", "correct_count", "evaluated_count", "total_return",
+            "total_predictions",
+            "correct_count",
+            "evaluated_count",
+            "total_return",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -727,7 +923,10 @@ class TestGetPredictionStats:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [(5, 0, 0, 0)]
         mock_result.keys.return_value = [
-            "total_predictions", "correct_count", "evaluated_count", "total_return",
+            "total_predictions",
+            "correct_count",
+            "evaluated_count",
+            "total_return",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -741,7 +940,10 @@ class TestGetPredictionStats:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [(None, None, None, None)]
         mock_result.keys.return_value = [
-            "total_predictions", "correct_count", "evaluated_count", "total_return",
+            "total_predictions",
+            "correct_count",
+            "evaluated_count",
+            "total_return",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -782,12 +984,30 @@ class TestGetLatestPredictions:
         """Returns prediction dicts with LEFT JOINed outcome data."""
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [
-            (1, '["AAPL"]', 0.9, '{"AAPL": "bullish"}', "Strong buy",
-             datetime(2026, 3, 15), "bullish", True, 0.05, "AAPL"),
+            (
+                1,
+                '["AAPL"]',
+                0.9,
+                '{"AAPL": "bullish"}',
+                "Strong buy",
+                datetime(2026, 3, 15),
+                "bullish",
+                True,
+                0.05,
+                "AAPL",
+            ),
         ]
         mock_result.keys.return_value = [
-            "prediction_id", "assets", "confidence", "market_impact", "thesis",
-            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+            "prediction_id",
+            "assets",
+            "confidence",
+            "market_impact",
+            "thesis",
+            "created_at",
+            "prediction_sentiment",
+            "correct_t7",
+            "return_t7",
+            "symbol",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -807,8 +1027,16 @@ class TestGetLatestPredictions:
             (1, "[]", 0.8, "{}", "thesis", dt, None, None, None, None),
         ]
         mock_result.keys.return_value = [
-            "prediction_id", "assets", "confidence", "market_impact", "thesis",
-            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+            "prediction_id",
+            "assets",
+            "confidence",
+            "market_impact",
+            "thesis",
+            "created_at",
+            "prediction_sentiment",
+            "correct_t7",
+            "return_t7",
+            "symbol",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -821,8 +1049,16 @@ class TestGetLatestPredictions:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = []
         mock_result.keys.return_value = [
-            "prediction_id", "assets", "confidence", "market_impact", "thesis",
-            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+            "prediction_id",
+            "assets",
+            "confidence",
+            "market_impact",
+            "thesis",
+            "created_at",
+            "prediction_sentiment",
+            "correct_t7",
+            "return_t7",
+            "symbol",
         ]
         mock_sync_session.execute.return_value = mock_result
 
@@ -837,8 +1073,16 @@ class TestGetLatestPredictions:
         mock_result = MagicMock()
         mock_result.fetchall.return_value = []
         mock_result.keys.return_value = [
-            "prediction_id", "assets", "confidence", "market_impact", "thesis",
-            "created_at", "prediction_sentiment", "correct_t7", "return_t7", "symbol",
+            "prediction_id",
+            "assets",
+            "confidence",
+            "market_impact",
+            "thesis",
+            "created_at",
+            "prediction_sentiment",
+            "correct_t7",
+            "return_t7",
+            "symbol",
         ]
         mock_sync_session.execute.return_value = mock_result
 


### PR DESCRIPTION
## Summary
- **62 tests** covering all 13 functions in `notifications/db.py` (was 8 tests, now 62)
- **Query dedup**: extracted `_execute_read`/`_execute_write` helpers eliminating 11 duplicated try/session/except blocks
- **`context` parameter** on helpers preserves function-specific error logging (no traceability loss)
- `_extract_scalar` helper for single-value queries (`get_last_alert_check`)
- `update_subscription` left unchanged — custom validation logic doesn't fit the generic helper pattern

## Test plan
- [x] All 62 notification tests pass before refactoring (safety net)
- [x] All 62 notification tests pass after refactoring (no regressions)
- [x] Full test suite: 2619 passed (5 pre-existing config failures)
- [x] Lint clean: `ruff check` passes
- [x] Format clean: `ruff format --check` passes
- [x] All public function signatures unchanged
- [x] All return types unchanged

Phase 02 of tech-debt-2026-03-26 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)