### PR TITLE
chore: dependency cleanup — remove 4 unused packages, bump safe minors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Unused dependencies** — Removed 4 packages with zero imports: `asyncio-mqtt`, `apscheduler`, `asyncio-throttle`, `structlog`
+- **Stale comments** — Removed "Phase 2" planning comments from `requirements.txt`
+
+### Changed
+- **Dependency version bumps** — Safe minor/patch bumps: `sqlalchemy` 2.0.47→2.0.48, `psycopg` 3.2→3.3, `click` 8.2→8.3, `rich` 14.1→14.3
+- **Dependency annotations** — Added comments for non-obvious deps: `twilio` (lazy import), `psycopg2-binary` (sync driver, remove when Dash retired), `asyncpg` (URL cleanup only)
+
 ### Added
 - **Notifications DB test coverage** — 62 tests for all 13 functions in `notifications/db.py`
   - Subscription CRUD: get, create, update, deactivate, reactivation flows

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
@@ -1,7 +1,9 @@
 # Phase 03: Remove Unused Dependencies, Bump Safe Minors
 
-**Status:** 🔧 IN PROGRESS
+**Status:** ✅ COMPLETE
 **Started:** 2026-03-28
+**Completed:** 2026-03-28
+**PR:** #115
 
 ## Header
 

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/03_dependency-cleanup.md
@@ -1,5 +1,8 @@
 # Phase 03: Remove Unused Dependencies, Bump Safe Minors
 
+**Status:** 🔧 IN PROGRESS
+**Started:** 2026-03-28
+
 ## Header
 
 | Field | Value |
@@ -121,7 +124,7 @@ The following changes are applied simultaneously in a single edit:
 9. **Bump `sqlalchemy[asyncio]`**: `>=2.0.47` to `>=2.0.48` (patch bump, no breaking changes).
 10. **Bump `psycopg[binary]`**: `>=3.2.0` to `>=3.3.0` (minor bump within same major, async driver improvements).
 11. **Bump `click`**: `>=8.1.0` to `>=8.3.0` (minor bump, bug fixes only).
-12. **Bump `rich`**: `>=13.0.0` to `>=14.3.0` (minor bump to match installed `14.1.0`; floor should be at or near installed version).
+12. **Bump `rich`**: `>=13.0.0` to `>=14.3.0` (minor bump; installed is 14.1.0, bumping floor to latest 14.x to stay current).
 
 ### Step 3: Write the new file
 
@@ -281,7 +284,7 @@ Add under `## [Unreleased]`:
 
 The bumped version floors (`>=2.0.48`, `>=3.3.0`, `>=8.3.0`, `>=14.3.0`) are all below or equal to the currently installed versions in production (sqlalchemy 2.0.47->2.0.48, psycopg 3.2.10->3.3.0 minimum, click 8.2.1->8.3.0 minimum, rich 14.1.0->14.3.0 minimum). On Railway's next deploy, `pip install` will pull the latest compatible versions, which are the same or newer than what is already running.
 
-**Risk**: psycopg `>=3.3.0` raises the floor above the currently installed `3.2.10`. This means pip will upgrade to `3.3.x` on next install. The psycopg 3.3.x series is backwards compatible with 3.2.x (same major version, non-breaking minor). The SQLAlchemy integration (`postgresql+psycopg://`) is stable across both.
+**Risk**: All four bumps raise floors above currently-installed versions (sqlalchemy 2.0.47→2.0.48, psycopg 3.2.10→3.3.x, click 8.2.1→8.3.x, rich 14.1.0→14.3.x). To mitigate, install the updated requirements locally and run the full test suite before committing. psycopg 3.3.x is backwards compatible with 3.2.x (same major version, non-breaking minor). The SQLAlchemy integration (`postgresql+psycopg://`) is stable across both.
 
 **Risk**: rich `>=14.3.0` raises the floor above the currently installed `14.1.0`. Rich 14.x is backwards compatible within the major version. Our usage is limited to CLI output formatting.
 
@@ -338,3 +341,5 @@ Even though `asyncpg` is not directly imported, it may be pulled in as a transit
 7. **Do NOT add new dependencies**. This PR is strictly about cleanup and minor bumps. Any new packages belong in their own PRs.
 
 8. **Do NOT forget to update CHANGELOG.md**. Every PR in this project requires a changelog entry per CLAUDE.md conventions.
+
+9. **Do NOT add `ruff` to requirements.txt**. The overview plan mentioned bumping ruff, but ruff is a dev-only tool not tracked in requirements.txt. It is excluded from this phase intentionally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Core dependencies
 pydantic>=2.0.0
-sqlalchemy[asyncio]>=2.0.47
+sqlalchemy[asyncio]>=2.0.48
 aiosqlite>=0.19.0
-asyncio-mqtt>=0.16.0
 
 # HTTP and web scraping
 aiohttp>=3.8.0
@@ -18,9 +17,9 @@ openai>=2.0.0,<3.0.0
 anthropic>=0.83.0
 
 # Database
-psycopg[binary]>=3.2.0  # For PostgreSQL async support
-psycopg2-binary>=2.9.0  # For PostgreSQL sync support (dashboard)
-asyncpg>=0.29.0  # For PostgreSQL async support (dashboard)
+psycopg[binary]>=3.3.0  # Async PostgreSQL driver (used by shit/db/database_client.py)
+psycopg2-binary>=2.9.0  # Sync PostgreSQL driver for shit/db/sync_session.py — remove when Dash UI retired
+asyncpg>=0.29.0  # Legacy: only referenced in URL cleanup (sync_session.py:22), not directly imported
 
 # Testing
 pytest>=8.4.0
@@ -31,17 +30,11 @@ vcrpy>=7.0.0
 # Development and utilities
 python-dotenv>=1.0.0
 pydantic-settings>=2.0.0
-click>=8.1.0
-rich>=13.0.0
+click>=8.3.0
+rich>=14.3.0
 
-# SMS/Alerting (Phase 2)
-twilio>=8.0.0
-
-# Job scheduling (Phase 2)
-apscheduler>=3.10.0
-
-# Logging and monitoring
-structlog>=23.0.0
+# Notifications
+twilio>=8.0.0  # Lazy import in notifications/dispatcher.py:331 for SMS delivery
 
 # Data processing
 pandas>=2.0.0
@@ -55,9 +48,6 @@ exchange_calendars>=4.5.0
 dash>=4.0.0,<5.0.0
 plotly>=5.15.0
 dash-bootstrap-components>=2.0.0,<3.0.0
-
-# Async utilities
-asyncio-throttle>=1.0.0
 
 # FastAPI web server (new React frontend API)
 fastapi>=0.115.0


### PR DESCRIPTION
## Summary
- **Remove 4 unused dependencies** with zero imports: `asyncio-mqtt`, `apscheduler`, `asyncio-throttle`, `structlog`
- **Bump 4 safe minors**: `sqlalchemy` 2.0.47→2.0.48, `psycopg` 3.2→3.3, `click` 8.2→8.3, `rich` 14.1→14.3
- **Annotate non-obvious deps**: `twilio` (lazy import), `psycopg2-binary` (sync driver, remove when Dash retired), `asyncpg` (URL cleanup only)
- Remove stale "Phase 2" planning comments from requirements.txt

## Test plan
- [x] All upgraded deps installed locally and verified
- [x] Full test suite: 2619 passed (5 pre-existing config failures unchanged)
- [x] `pip install -r requirements.txt` resolves cleanly

Phase 03 of tech-debt-2026-03-26 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)