### PR TITLE
chore: resolve TODOs, add legacy documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **TODO resolution** — Replaced 5 vague TODO comments with concrete decision records
+  - `shitvault/s3_processor.py`: Dual-write stays until signals migration (linked to plan)
+  - `shitposts/twitter_harvester.py`: Twitter skeleton marked as not currently planned
+  - `shit/utils/error_handling.py`: Sentry/metrics deferred until error volume warrants it
+  - `shitty_ui/data/__init__.py`: Added deprecation notice for legacy Dash re-export layer
 - **Outcome Calculator** — Decomposed 245-line `_calculate_single_outcome` into 3 focused helpers: `_resolve_base_price`, `_fill_timeframe_prices`, `_fill_intraday_prices`
 - **Market Data CLI** — Split 754-line CLI into domain submodules: `cli_fetch.py` (5 commands), `cli_outcomes.py` (6 commands), `cli_registry.py` (2 commands); entry point preserved at `cli.py`
 

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
@@ -1,7 +1,9 @@
 # Phase 05: Resolve TODOs, Add Legacy Documentation
 
-**Status**: `🔧 IN PROGRESS`
+**Status**: `✅ COMPLETE`
 **Started**: 2026-03-28
+**Completed**: 2026-03-28
+**PR**: #117
 
 **PR Title**: `chore: resolve TODOs, add legacy documentation`
 **Risk**: Low (comment-only changes, no behavior changes)

--- a/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
+++ b/documentation/planning/tech_debt/tech-debt-2026-03-26/05_todo-resolution.md
@@ -1,5 +1,8 @@
 # Phase 05: Resolve TODOs, Add Legacy Documentation
 
+**Status**: `🔧 IN PROGRESS`
+**Started**: 2026-03-28
+
 **PR Title**: `chore: resolve TODOs, add legacy documentation`
 **Risk**: Low (comment-only changes, no behavior changes)
 **Estimated Effort**: Low (~30 minutes)
@@ -76,8 +79,8 @@ Resolving these TODOs replaces vague future intent with concrete decision record
     async def _test_connection(self) -> None:
         """Test Twitter API v2 connection.
 
-        NOTE: Skeleton -- implement when Twitter/X API access is obtained.
-        Not currently planned.
+        Skeleton — no implementation planned. Revisit if Twitter/X API
+        access is obtained.
         """
 ```
 
@@ -99,8 +102,8 @@ Resolving these TODOs replaces vague future intent with concrete decision record
     ) -> tuple[List[Dict], Optional[str]]:
         """Fetch a batch of tweets.
 
-        NOTE: Skeleton -- implement when Twitter/X API access is obtained.
-        Not currently planned.
+        Skeleton — no implementation planned. Revisit if Twitter/X API
+        access is obtained.
         """
 ```
 

--- a/shit/utils/error_handling.py
+++ b/shit/utils/error_handling.py
@@ -23,8 +23,9 @@ async def handle_exceptions(error: Exception, context: str = "Unknown") -> None:
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Full traceback: {traceback.format_exc()}")
     
-    # TODO: Add error reporting to external services (Sentry, etc.)
-    # TODO: Add metrics collection for error rates
+    # Deferred: Error reporting (Sentry) and metrics collection.
+    # Currently tracked via Railway service logs and the orchestrator
+    # log files. Re-evaluate when error volume warrants external tooling.
 
 
 def async_retry(

--- a/shitposts/twitter_harvester.py
+++ b/shitposts/twitter_harvester.py
@@ -63,7 +63,8 @@ class TwitterHarvester(SignalHarvester):
     async def _test_connection(self) -> None:
         """Test Twitter API v2 connection.
 
-        TODO: Implement with real Twitter API call.
+        Skeleton — no implementation planned. Revisit if Twitter/X API
+        access is obtained.
         """
         if not self.bearer_token:
             raise ValueError(
@@ -89,7 +90,8 @@ class TwitterHarvester(SignalHarvester):
     ) -> tuple[List[Dict], Optional[str]]:
         """Fetch a batch of tweets.
 
-        TODO: Implement with Twitter API v2 search or user timeline.
+        Skeleton — no implementation planned. Revisit if Twitter/X API
+        access is obtained.
         """
         raise NotImplementedError(
             "TwitterHarvester is a skeleton. "

--- a/shitty_ui/data/__init__.py
+++ b/shitty_ui/data/__init__.py
@@ -13,6 +13,11 @@ Internal structure:
     data/timeframe.py         -- Timeframe column mapping helper
 """
 
+# DEPRECATED: This module re-exports query functions for the legacy Dash
+# dashboard (shitty_ui/). The Dash dashboard is being retired in favor of
+# the React frontend (api/ + frontend/). Do not add new functions here.
+# New query work should go in api/queries/.
+
 # --- Timeframe helpers ---
 from data.timeframe import (  # noqa: F401
     get_tf_columns,

--- a/shitvault/s3_processor.py
+++ b/shitvault/s3_processor.py
@@ -213,8 +213,10 @@ class S3Processor:
                 signal_data = self._transformer(s3_data)
                 result = await self.signal_ops.store_signal(signal_data)
 
-                # Also store in legacy table for backward compatibility
-                # TODO: Remove after full migration is complete
+                # Dual-write to legacy truth_social_shitposts table.
+                # This stays until api/queries/feed_queries.py and shitty_ui/data/
+                # migrate their reads to the signals table. Tracked in:
+                # documentation/planning/SIGNALS_MIGRATION.md
                 legacy_data = DatabaseUtils.transform_s3_data_to_shitpost(s3_data)
                 await self.shitpost_ops.store_shitpost(legacy_data)
 


### PR DESCRIPTION
## Summary
- Replaced 5 vague TODO comments across 4 files with concrete decision records
- `shitvault/s3_processor.py`: Dual-write linked to `SIGNALS_MIGRATION.md`
- `shitposts/twitter_harvester.py`: Skeleton marked as not currently planned
- `shit/utils/error_handling.py`: Sentry/metrics deferred until volume warrants
- `shitty_ui/data/__init__.py`: Deprecation notice for legacy Dash re-export layer
- CHANGELOG.md updated

## Test plan
- [x] `pytest -v` — 2619 passed (5 pre-existing config failures)
- [x] `ruff check` — no new lint errors
- [x] `grep "TODO"` across target files — zero matches
- [x] Comment-only changes, no behavioral impact

Phase 05 of `documentation/planning/tech_debt/tech-debt-2026-03-26/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)