### PR TITLE
feat: add Price at Post and Price Now KPIs

### DIFF
--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -6,7 +6,7 @@ import {
   CrosshairMode,
   type IChartApi,
 } from "lightweight-charts";
-import { usePriceData } from "../api/hooks";
+import type { PriceResponse } from "../types/api";
 import { colors } from "../styles/theme";
 
 const containerStyle: CSSProperties = {
@@ -30,14 +30,13 @@ const loadingStyle: CSSProperties = {
 
 interface Props {
   symbol: string;
-  days: number;
-  postTimestamp: string;
+  data: PriceResponse | undefined;
+  isLoading: boolean;
 }
 
-export function PriceChart({ symbol, days, postTimestamp }: Props) {
+export function PriceChart({ symbol, data, isLoading }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
-  const { data, isLoading } = usePriceData(symbol, days, postTimestamp);
 
   useEffect(() => {
     if (!containerRef.current || !data || data.candles.length === 0) return;

--- a/frontend/src/components/PriceKPIs.tsx
+++ b/frontend/src/components/PriceKPIs.tsx
@@ -1,0 +1,92 @@
+import { CSSProperties } from "react";
+import { formatPrice, formatDollar, formatPercent } from "../utils/format";
+
+const cardStyle: CSSProperties = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "12px",
+  padding: "16px 20px",
+  marginTop: "12px",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.06)",
+};
+
+const rowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+};
+
+const labelStyle: CSSProperties = {
+  fontFamily: "var(--font-display)",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "var(--text-faint)",
+  marginBottom: "4px",
+};
+
+const priceStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "1.3rem",
+  fontWeight: 700,
+  color: "var(--text-primary)",
+};
+
+const changeRowStyle: CSSProperties = {
+  textAlign: "center",
+  marginTop: "10px",
+  paddingTop: "10px",
+  borderTop: "1px solid var(--border-light)",
+};
+
+interface Props {
+  priceAtPost: number | null;
+  currentPrice: number | null;
+}
+
+export function PriceKPIs({ priceAtPost, currentPrice }: Props) {
+  if (priceAtPost == null && currentPrice == null) return null;
+
+  const hasChange = priceAtPost != null && currentPrice != null && priceAtPost !== 0;
+  const dollarChange = hasChange ? currentPrice - priceAtPost : null;
+  const pctChange = hasChange ? ((currentPrice - priceAtPost) / priceAtPost) * 100 : null;
+
+  const changeColor =
+    dollarChange == null
+      ? "var(--text-muted)"
+      : dollarChange > 0
+        ? "var(--color-money)"
+        : dollarChange < 0
+          ? "var(--color-red)"
+          : "var(--text-muted)";
+
+  return (
+    <div style={cardStyle}>
+      <div style={rowStyle}>
+        <div>
+          <div style={labelStyle}>Price at Post</div>
+          <div style={priceStyle}>{formatPrice(priceAtPost)}</div>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <div style={labelStyle}>Price Now</div>
+          <div style={priceStyle}>{formatPrice(currentPrice)}</div>
+        </div>
+      </div>
+      {hasChange && (
+        <div style={changeRowStyle}>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+              color: changeColor,
+            }}
+          >
+            {formatDollar(dollarChange)} ({formatPercent(pctChange)})
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, CSSProperties } from "react";
 import { useSearchParams } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { useFeedPost, usePrefetchAdjacentPosts } from "../api/hooks";
+import { useFeedPost, usePrefetchAdjacentPosts, usePriceData } from "../api/hooks";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
@@ -9,6 +9,7 @@ import { ShitpostCard } from "../components/ShitpostCard";
 import { PredictionPanel } from "../components/PredictionPanel";
 import { TickerSelector } from "../components/TickerSelector";
 import { MetricBubbles } from "../components/MetricBubbles";
+import { PriceKPIs } from "../components/PriceKPIs";
 import { TimeframeToggle, timeframeToDays, type Timeframe } from "../components/TimeframeToggle";
 import { PriceChart } from "../components/PriceChart";
 import { NavigationArrows } from "../components/NavigationArrows";
@@ -122,6 +123,16 @@ export function FeedPage() {
   const activeTicker = selectedTicker || data.prediction.assets[0] || "";
   const activeOutcome = data.outcomes.find((o) => o.symbol === activeTicker);
 
+  // Price data for chart and KPIs (shared hook)
+  const priceQuery = usePriceData(
+    activeTicker || undefined,
+    timeframeToDays[timeframe],
+    data.post.timestamp,
+  );
+  const currentPrice = priceQuery.data?.candles?.length
+    ? priceQuery.data.candles[priceQuery.data.candles.length - 1].close
+    : null;
+
   return (
     <>
       <Header />
@@ -155,6 +166,11 @@ export function FeedPage() {
                   onSelect={setSelectedTicker}
                 />
 
+                <PriceKPIs
+                  priceAtPost={activeOutcome?.price_at_post ?? null}
+                  currentPrice={currentPrice}
+                />
+
                 <MetricBubbles outcome={activeOutcome} />
 
                 <TimeframeToggle selected={timeframe} onSelect={setTimeframe} />
@@ -162,8 +178,8 @@ export function FeedPage() {
                 {activeTicker && (
                   <PriceChart
                     symbol={activeTicker}
-                    days={timeframeToDays[timeframe]}
-                    postTimestamp={data.post.timestamp}
+                    data={priceQuery.data}
+                    isLoading={priceQuery.isLoading}
                   />
                 )}
               </>


### PR DESCRIPTION
## Summary
- Adds a **PriceKPIs** component showing "Price at Post" and "Price Now" side by side with dollar/percent change
- Lifts `usePriceData` hook from PriceChart to FeedPage so both components share the same data
- Refactors PriceChart to accept price data as props instead of fetching internally
- **Zero backend changes, zero new API calls** — current price derived from already-fetched chart candle data

## Test plan
- [x] `npm run build` passes (TypeScript compiles cleanly)
- [ ] Visual check: KPIs appear between ticker selector and Freedom Metrics
- [ ] Verify color coding: green when price is up, red when down
- [ ] Null handling: dashes shown when price_at_post unavailable
- [ ] Switching tickers updates both KPIs and chart
- [ ] Navigating between posts resets KPIs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)