### PR TITLE
Refactor: feed API service extraction + test fixture factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Feed API service extraction** — Extracted `_build_feed_response()` monolith into `FeedService` class (`api/services/feed_service.py`) with static builder methods; router shrinks from 226 to 30 lines (#120)
+- **Test fixture factory** — Replaced 4 duplicate post-row and 2 outcome-row construction patterns with `make_post_row()`, `make_outcome_row()`, `make_outcome_rows()` factory functions; future column additions require updating 1 place instead of 8 (#122)
+
 ### Added
 - **Post card enrichment** — Author profile (verified badge, follower count), market timing badges (PRE-MKT/OPEN/AFTER-HRS/WEEKEND with relative timing), link preview cards, reply/quote context, media thumbnails
 - **Fundamentals strip** — Company name, exchange, sector, market cap, P/E, forward P/E, beta, dividend yield below ticker pills (JOIN on `ticker_registry`)

--- a/api/routers/feed.py
+++ b/api/routers/feed.py
@@ -1,225 +1,27 @@
 """Feed API router — single-post-at-a-time endpoint."""
 
-from datetime import datetime
-
 from fastapi import APIRouter, HTTPException, Query
 
-from api.queries.feed_queries import (
-    get_analyzed_post_at_offset,
-    get_outcomes_for_prediction,
-    get_snapshots_for_prediction,
-)
-from api.schemas.feed import (
-    Correct,
-    Engagement,
-    FeedResponse,
-    Fundamentals,
-    LinkPreview,
-    Navigation,
-    Outcome,
-    Pnl,
-    Post,
-    Prediction,
-    PriceSnapshotSchema,
-    ReplyContext,
-    Returns,
-    Scores,
-)
-from shit.market_data.market_timing import (
-    compute_market_timing,
-    compute_marker_dates,
-)
+from api.schemas.feed import FeedResponse
+from api.services.feed_service import FeedService
 
 router = APIRouter()
-
-
-def _build_link_preview(card_data: dict | None) -> LinkPreview | None:
-    """Extract link preview from Truth Social card JSON."""
-    if not card_data or not isinstance(card_data, dict):
-        return None
-    title = card_data.get("title")
-    if not title:
-        return None
-    return LinkPreview(
-        title=title,
-        description=card_data.get("description"),
-        image=card_data.get("image"),
-        url=card_data.get("url"),
-        provider_name=card_data.get("provider_name"),
-    )
-
-
-def _build_reply_context(in_reply_to: dict | None) -> ReplyContext | None:
-    """Extract reply context from the in_reply_to JSON."""
-    if not in_reply_to or not isinstance(in_reply_to, dict):
-        return None
-    account = in_reply_to.get("account", {})
-    username = account.get("username") or account.get("acct")
-    # Use plain text content, falling back to stripping HTML
-    text = in_reply_to.get("text") or in_reply_to.get("content", "")
-    if not username and not text:
-        return None
-    return ReplyContext(username=username, text=text[:200] if text else None)
-
-
-def _build_feed_response(offset: int) -> FeedResponse:
-    """Build a complete feed response for a given offset."""
-    result = get_analyzed_post_at_offset(offset)
-    if result is None:
-        raise HTTPException(status_code=404, detail="No post found at this offset")
-
-    row, total = result
-    outcomes_raw = get_outcomes_for_prediction(row["prediction_id"])
-
-    # Compute market timing from post timestamp
-    ts = row["timestamp"]
-    if isinstance(ts, str):
-        ts = datetime.fromisoformat(ts)
-    market_timing, minutes_to_market = compute_market_timing(ts)
-
-    # Build post
-    post = Post(
-        shitpost_id=row["shitpost_id"],
-        text=row["text"] or "",
-        content_html=row.get("content_html"),
-        timestamp=ts.isoformat() if hasattr(ts, "isoformat") else str(ts),
-        username=row["username"] or "",
-        url=row.get("url"),
-        engagement=Engagement(
-            replies=row.get("replies_count") or 0,
-            reblogs=row.get("reblogs_count") or 0,
-            favourites=row.get("favourites_count") or 0,
-            upvotes=row.get("upvotes_count") or 0,
-            downvotes=row.get("downvotes_count") or 0,
-        ),
-        verified=bool(row.get("account_verified")),
-        followers_count=row.get("account_followers_count"),
-        card=_build_link_preview(row.get("card")),
-        media_attachments=row.get("media_attachments") or [],
-        reply_context=_build_reply_context(row.get("in_reply_to")),
-        is_repost=row.get("reblog") is not None,
-        market_timing=market_timing,
-        minutes_to_market=minutes_to_market,
-    )
-
-    # Build prediction
-    assets = row.get("assets") or []
-    market_impact = row.get("market_impact") or {}
-
-    prediction = Prediction(
-        prediction_id=row["prediction_id"],
-        confidence=row.get("confidence"),
-        thesis=row.get("thesis"),
-        assets=assets if isinstance(assets, list) else [],
-        market_impact=market_impact if isinstance(market_impact, dict) else {},
-        scores=Scores(
-            engagement=row.get("engagement_score"),
-            viral=row.get("viral_score"),
-            sentiment=row.get("sentiment_score"),
-            urgency=row.get("urgency_score"),
-        ),
-    )
-
-    # Fetch price snapshots for this prediction
-    snapshots_by_symbol = get_snapshots_for_prediction(
-        row["prediction_id"]
-    )
-
-    # Build outcomes
-    outcomes = []
-    for o in outcomes_raw:
-        # Build fundamentals from ticker_registry JOIN
-        has_fundamentals = o.get("company_name") is not None
-        fundamentals = Fundamentals(
-            company_name=o.get("company_name"),
-            asset_type=o.get("asset_type"),
-            exchange=o.get("exchange"),
-            sector=o.get("sector"),
-            industry=o.get("industry"),
-            market_cap=o.get("market_cap"),
-            pe_ratio=o.get("pe_ratio"),
-            forward_pe=o.get("forward_pe"),
-            beta=o.get("beta"),
-            dividend_yield=o.get("dividend_yield"),
-        ) if has_fundamentals else None
-
-        # Build price snapshot from captured data
-        snap_data = snapshots_by_symbol.get(o["symbol"])
-        price_snapshot = PriceSnapshotSchema(
-            **snap_data
-        ) if snap_data else None
-
-        # Compute T+N marker dates for chart annotations
-        pred_date = o.get("prediction_date")
-        marker_dates = compute_marker_dates(pred_date, o)
-        if hasattr(pred_date, "isoformat"):
-            pred_date_str = pred_date.isoformat()
-        elif pred_date:
-            pred_date_str = str(pred_date)
-        else:
-            pred_date_str = None
-
-        outcomes.append(
-            Outcome(
-                symbol=o["symbol"],
-                sentiment=o.get("prediction_sentiment"),
-                confidence=o.get("prediction_confidence"),
-                price_at_prediction=o.get("price_at_prediction"),
-                price_at_post=o.get("price_at_post"),
-                returns=Returns(
-                    same_day=o.get("return_same_day"),
-                    hour_1=o.get("return_1h"),
-                    t1=o.get("return_t1"),
-                    t3=o.get("return_t3"),
-                    t7=o.get("return_t7"),
-                    t30=o.get("return_t30"),
-                ),
-                correct=Correct(
-                    same_day=o.get("correct_same_day"),
-                    hour_1=o.get("correct_1h"),
-                    t1=o.get("correct_t1"),
-                    t3=o.get("correct_t3"),
-                    t7=o.get("correct_t7"),
-                    t30=o.get("correct_t30"),
-                ),
-                pnl=Pnl(
-                    same_day=o.get("pnl_same_day"),
-                    hour_1=o.get("pnl_1h"),
-                    t1=o.get("pnl_t1"),
-                    t3=o.get("pnl_t3"),
-                    t7=o.get("pnl_t7"),
-                    t30=o.get("pnl_t30"),
-                ),
-                is_complete=o.get("is_complete", False) or False,
-                fundamentals=fundamentals,
-                price_snapshot=price_snapshot,
-                prediction_date=pred_date_str,
-                marker_dates=marker_dates,
-            )
-        )
-
-    navigation = Navigation(
-        has_newer=offset > 0,
-        has_older=offset < total - 1,
-        current_offset=offset,
-        total_posts=total,
-    )
-
-    return FeedResponse(
-        post=post,
-        prediction=prediction,
-        outcomes=outcomes,
-        navigation=navigation,
-    )
+_service = FeedService()
 
 
 @router.get("/latest", response_model=FeedResponse)
 def get_latest_post():
     """Get the most recent analyzed shitpost."""
-    return _build_feed_response(0)
+    result = _service.get_feed_response(0)
+    if result is None:
+        raise HTTPException(status_code=404, detail="No post found at this offset")
+    return result
 
 
 @router.get("/at", response_model=FeedResponse)
 def get_post_at_offset(offset: int = Query(default=0, ge=0)):
     """Get the Nth most recent analyzed shitpost."""
-    return _build_feed_response(offset)
+    result = _service.get_feed_response(offset)
+    if result is None:
+        raise HTTPException(status_code=404, detail="No post found at this offset")
+    return result

--- a/api/services/feed_service.py
+++ b/api/services/feed_service.py
@@ -1,0 +1,234 @@
+"""Feed service — transforms raw query data into API response models."""
+
+from datetime import datetime
+from typing import Any
+
+from api.queries.feed_queries import (
+    get_analyzed_post_at_offset,
+    get_outcomes_for_prediction,
+    get_snapshots_for_prediction,
+)
+from api.schemas.feed import (
+    Correct,
+    Engagement,
+    FeedResponse,
+    Fundamentals,
+    LinkPreview,
+    Navigation,
+    Outcome,
+    Pnl,
+    Post,
+    Prediction,
+    PriceSnapshotSchema,
+    ReplyContext,
+    Returns,
+    Scores,
+)
+from shit.market_data.market_timing import (
+    compute_market_timing,
+    compute_marker_dates,
+)
+
+
+class FeedService:
+    """Assembles feed responses from query data and enrichment services."""
+
+    def get_feed_response(self, offset: int) -> FeedResponse | None:
+        """Build a complete feed response for a given offset.
+
+        Returns None if no post exists at the given offset.
+        """
+        result = get_analyzed_post_at_offset(offset)
+        if result is None:
+            return None
+
+        row, total = result
+        outcomes_raw = get_outcomes_for_prediction(row["prediction_id"])
+
+        # Compute market timing from post timestamp
+        ts = row["timestamp"]
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        market_timing, minutes_to_market = compute_market_timing(ts)
+
+        post = self.build_post(row, market_timing, minutes_to_market)
+        prediction = self.build_prediction(row)
+
+        # Fetch price snapshots for this prediction
+        snapshots_by_symbol = get_snapshots_for_prediction(row["prediction_id"])
+
+        # Build outcomes
+        outcomes = []
+        for o in outcomes_raw:
+            snap_data = snapshots_by_symbol.get(o["symbol"])
+            outcomes.append(self.build_outcome(o, snap_data))
+
+        navigation = self.build_navigation(offset, total)
+
+        return FeedResponse(
+            post=post,
+            prediction=prediction,
+            outcomes=outcomes,
+            navigation=navigation,
+        )
+
+    @staticmethod
+    def build_post(
+        row: dict[str, Any], market_timing: str, minutes_to_market: str
+    ) -> Post:
+        """Build a Post schema from a raw query row."""
+        ts = row["timestamp"]
+        return Post(
+            shitpost_id=row["shitpost_id"],
+            text=row["text"] or "",
+            content_html=row.get("content_html"),
+            timestamp=ts.isoformat() if hasattr(ts, "isoformat") else str(ts),
+            username=row["username"] or "",
+            url=row.get("url"),
+            engagement=Engagement(
+                replies=row.get("replies_count") or 0,
+                reblogs=row.get("reblogs_count") or 0,
+                favourites=row.get("favourites_count") or 0,
+                upvotes=row.get("upvotes_count") or 0,
+                downvotes=row.get("downvotes_count") or 0,
+            ),
+            verified=bool(row.get("account_verified")),
+            followers_count=row.get("account_followers_count"),
+            card=FeedService.build_link_preview(row.get("card")),
+            media_attachments=row.get("media_attachments") or [],
+            reply_context=FeedService.build_reply_context(row.get("in_reply_to")),
+            is_repost=row.get("reblog") is not None,
+            market_timing=market_timing,
+            minutes_to_market=minutes_to_market,
+        )
+
+    @staticmethod
+    def build_prediction(row: dict[str, Any]) -> Prediction:
+        """Build a Prediction schema from a raw query row."""
+        assets = row.get("assets") or []
+        market_impact = row.get("market_impact") or {}
+
+        return Prediction(
+            prediction_id=row["prediction_id"],
+            confidence=row.get("confidence"),
+            thesis=row.get("thesis"),
+            assets=assets if isinstance(assets, list) else [],
+            market_impact=market_impact if isinstance(market_impact, dict) else {},
+            scores=Scores(
+                engagement=row.get("engagement_score"),
+                viral=row.get("viral_score"),
+                sentiment=row.get("sentiment_score"),
+                urgency=row.get("urgency_score"),
+            ),
+        )
+
+    @staticmethod
+    def build_outcome(o: dict[str, Any], snap_data: dict[str, Any] | None) -> Outcome:
+        """Build a single Outcome schema from a raw outcome dict + snapshot."""
+        # Build fundamentals from ticker_registry JOIN
+        has_fundamentals = o.get("company_name") is not None
+        fundamentals = (
+            Fundamentals(
+                company_name=o.get("company_name"),
+                asset_type=o.get("asset_type"),
+                exchange=o.get("exchange"),
+                sector=o.get("sector"),
+                industry=o.get("industry"),
+                market_cap=o.get("market_cap"),
+                pe_ratio=o.get("pe_ratio"),
+                forward_pe=o.get("forward_pe"),
+                beta=o.get("beta"),
+                dividend_yield=o.get("dividend_yield"),
+            )
+            if has_fundamentals
+            else None
+        )
+
+        # Build price snapshot from captured data
+        price_snapshot = PriceSnapshotSchema(**snap_data) if snap_data else None
+
+        # Compute T+N marker dates for chart annotations
+        pred_date = o.get("prediction_date")
+        marker_dates = compute_marker_dates(pred_date, o)
+        if hasattr(pred_date, "isoformat"):
+            pred_date_str = pred_date.isoformat()
+        elif pred_date:
+            pred_date_str = str(pred_date)
+        else:
+            pred_date_str = None
+
+        return Outcome(
+            symbol=o["symbol"],
+            sentiment=o.get("prediction_sentiment"),
+            confidence=o.get("prediction_confidence"),
+            price_at_prediction=o.get("price_at_prediction"),
+            price_at_post=o.get("price_at_post"),
+            returns=Returns(
+                same_day=o.get("return_same_day"),
+                hour_1=o.get("return_1h"),
+                t1=o.get("return_t1"),
+                t3=o.get("return_t3"),
+                t7=o.get("return_t7"),
+                t30=o.get("return_t30"),
+            ),
+            correct=Correct(
+                same_day=o.get("correct_same_day"),
+                hour_1=o.get("correct_1h"),
+                t1=o.get("correct_t1"),
+                t3=o.get("correct_t3"),
+                t7=o.get("correct_t7"),
+                t30=o.get("correct_t30"),
+            ),
+            pnl=Pnl(
+                same_day=o.get("pnl_same_day"),
+                hour_1=o.get("pnl_1h"),
+                t1=o.get("pnl_t1"),
+                t3=o.get("pnl_t3"),
+                t7=o.get("pnl_t7"),
+                t30=o.get("pnl_t30"),
+            ),
+            is_complete=o.get("is_complete", False) or False,
+            fundamentals=fundamentals,
+            price_snapshot=price_snapshot,
+            prediction_date=pred_date_str,
+            marker_dates=marker_dates,
+        )
+
+    @staticmethod
+    def build_navigation(offset: int, total: int) -> Navigation:
+        """Build navigation metadata."""
+        return Navigation(
+            has_newer=offset > 0,
+            has_older=offset < total - 1,
+            current_offset=offset,
+            total_posts=total,
+        )
+
+    @staticmethod
+    def build_link_preview(card_data: dict | None) -> LinkPreview | None:
+        """Extract link preview from Truth Social card JSON."""
+        if not card_data or not isinstance(card_data, dict):
+            return None
+        title = card_data.get("title")
+        if not title:
+            return None
+        return LinkPreview(
+            title=title,
+            description=card_data.get("description"),
+            image=card_data.get("image"),
+            url=card_data.get("url"),
+            provider_name=card_data.get("provider_name"),
+        )
+
+    @staticmethod
+    def build_reply_context(in_reply_to: dict | None) -> ReplyContext | None:
+        """Extract reply context from the in_reply_to JSON."""
+        if not in_reply_to or not isinstance(in_reply_to, dict):
+            return None
+        account = in_reply_to.get("account", {})
+        username = account.get("username") or account.get("acct")
+        # Use plain text content, falling back to stripping HTML
+        text = in_reply_to.get("text") or in_reply_to.get("content", "")
+        if not username and not text:
+            return None
+        return ReplyContext(username=username, text=text[:200] if text else None)

--- a/shit_tests/api/conftest.py
+++ b/shit_tests/api/conftest.py
@@ -1,11 +1,11 @@
 """
 Conftest for API tests.
-Provides TestClient, mock execute_query, and sample data fixtures.
+Provides TestClient, mock execute_query, and row factory functions.
 """
 
 import os
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +17,143 @@ if project_root not in sys.path:
 
 # Set DATABASE_URL env var so sync_session module can import
 os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+
+
+# ---------------------------------------------------------------------------
+# Row factory functions
+# ---------------------------------------------------------------------------
+
+
+def make_post_row(**overrides) -> tuple[list[tuple], list[str]]:
+    """Build a post row as returned by get_analyzed_post_at_offset's SQL.
+
+    Column order matches the SQL query in api/queries/feed_queries.py.
+    Returns (rows, columns) matching execute_query() return format.
+
+    Usage:
+        rows, cols = make_post_row()                          # all defaults
+        rows, cols = make_post_row(text=None)                 # override one field
+        rows, cols = make_post_row(assets='["SPY"]')          # JSON string variant
+    """
+    defaults = {
+        "shitpost_id": "post_abc123",
+        "text": "Big tariff announcement coming!",
+        "content_html": "<p>Big tariff announcement coming!</p>",
+        "timestamp": datetime(2026, 3, 25, 14, 30, 0),
+        "username": "realDonaldTrump",
+        "url": "https://truthsocial.com/@realDonaldTrump/post_abc123",
+        "replies_count": 42,
+        "reblogs_count": 150,
+        "favourites_count": 500,
+        "upvotes_count": 300,
+        "downvotes_count": 10,
+        "account_verified": True,
+        "account_followers_count": 8200000,
+        "card": None,
+        "media_attachments": [],
+        "in_reply_to_id": None,
+        "in_reply_to": None,
+        "reblog": None,
+        "prediction_id": 101,
+        "assets": ["AAPL", "TSLA"],
+        "market_impact": {"AAPL": "bearish", "TSLA": "bullish"},
+        "confidence": 0.85,
+        "thesis": "Tariffs on China will hurt Apple supply chain but benefit Tesla domestic production.",
+        "analysis_status": "completed",
+        "engagement_score": 0.7,
+        "viral_score": 0.8,
+        "sentiment_score": -0.3,
+        "urgency_score": 0.9,
+        "total_count": 42,
+    }
+    defaults.update(overrides)
+    columns = list(defaults.keys())
+    row = tuple(defaults.values())
+    return ([row], columns)
+
+
+def make_outcome_row(**overrides) -> tuple[list[tuple], list[str]]:
+    """Build an outcome row as returned by get_outcomes_for_prediction's SQL.
+
+    Column order matches the SQL query in api/queries/feed_queries.py.
+    Returns (rows, columns) matching execute_query() return format.
+
+    Usage:
+        rows, cols = make_outcome_row()                              # AAPL defaults
+        rows, cols = make_outcome_row(symbol="TSLA", prediction_sentiment="bullish")
+    """
+    defaults = {
+        "symbol": "AAPL",
+        "prediction_sentiment": "bearish",
+        "prediction_confidence": 0.85,
+        "prediction_date": date(2026, 3, 25),
+        "price_at_prediction": 178.50,
+        "price_at_post": 178.20,
+        "price_at_next_close": 177.80,
+        "price_1h_after": 178.00,
+        "price_t1": 176.50,
+        "price_t3": 175.00,
+        "price_t7": 174.00,
+        "price_t30": 180.00,
+        "return_t1": -1.12,
+        "return_t3": -1.96,
+        "return_t7": -2.52,
+        "return_t30": 0.84,
+        "return_same_day": -0.39,
+        "return_1h": -0.11,
+        "correct_t1": True,
+        "correct_t3": True,
+        "correct_t7": True,
+        "correct_t30": False,
+        "correct_same_day": True,
+        "correct_1h": True,
+        "pnl_t1": 11.20,
+        "pnl_t3": 19.60,
+        "pnl_t7": 25.20,
+        "pnl_t30": -8.40,
+        "pnl_same_day": 3.90,
+        "pnl_1h": 1.10,
+        "is_complete": True,
+        "company_name": "Apple Inc.",
+        "asset_type": "stock",
+        "exchange": "NASDAQ",
+        "sector": "Technology",
+        "industry": "Consumer Electronics",
+        "market_cap": 2800000000000,
+        "pe_ratio": 28.5,
+        "forward_pe": 26.1,
+        "beta": 1.2,
+        "dividend_yield": 0.005,
+    }
+    defaults.update(overrides)
+    columns = list(defaults.keys())
+    row = tuple(defaults.values())
+    return ([row], columns)
+
+
+def make_outcome_rows(*rows_overrides: dict) -> tuple[list[tuple], list[str]]:
+    """Build multiple outcome rows sharing the same column list.
+
+    Usage:
+        rows, cols = make_outcome_rows(
+            {"symbol": "AAPL"},
+            {"symbol": "TSLA", "prediction_sentiment": "bullish"},
+        )
+    """
+    if not rows_overrides:
+        return make_outcome_row()
+
+    first_rows, columns = make_outcome_row(**rows_overrides[0])
+    all_rows = list(first_rows)
+    for ov in rows_overrides[1:]:
+        more_rows, _ = make_outcome_row(**ov)
+        all_rows.extend(more_rows)
+    return (all_rows, columns)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -56,286 +193,6 @@ def client(mock_execute_query):
 
 
 @pytest.fixture
-def sample_post_row() -> tuple[list[tuple], list[str]]:
-    """A single analyzed post row as returned by execute_query.
-
-    Returns (rows, columns) matching get_analyzed_post_at_offset's SQL.
-    Includes total_count from COUNT(*) OVER().
-    """
-    columns = [
-        "shitpost_id",
-        "text",
-        "content_html",
-        "timestamp",
-        "username",
-        "url",
-        "replies_count",
-        "reblogs_count",
-        "favourites_count",
-        "upvotes_count",
-        "downvotes_count",
-        "account_verified",
-        "account_followers_count",
-        "card",
-        "media_attachments",
-        "in_reply_to_id",
-        "in_reply_to",
-        "reblog",
-        "prediction_id",
-        "assets",
-        "market_impact",
-        "confidence",
-        "thesis",
-        "analysis_status",
-        "engagement_score",
-        "viral_score",
-        "sentiment_score",
-        "urgency_score",
-        "total_count",
-    ]
-    row = (
-        "post_abc123",
-        "Big tariff announcement coming!",
-        "<p>Big tariff announcement coming!</p>",
-        datetime(2026, 3, 25, 14, 30, 0),
-        "realDonaldTrump",
-        "https://truthsocial.com/@realDonaldTrump/post_abc123",
-        42,
-        150,
-        500,
-        300,
-        10,
-        True,
-        8200000,
-        None,
-        [],
-        None,
-        None,
-        None,
-        101,
-        ["AAPL", "TSLA"],
-        {"AAPL": "bearish", "TSLA": "bullish"},
-        0.85,
-        "Tariffs on China will hurt Apple supply chain but benefit Tesla domestic production.",
-        "completed",
-        0.7,
-        0.8,
-        -0.3,
-        0.9,
-        42,
-    )
-    return ([row], columns)
-
-
-@pytest.fixture
-def sample_post_row_json_strings() -> tuple[list[tuple], list[str]]:
-    """A post row where assets and market_impact are JSON strings (not parsed).
-
-    This simulates what some database drivers return.
-    """
-    columns = [
-        "shitpost_id",
-        "text",
-        "content_html",
-        "timestamp",
-        "username",
-        "url",
-        "replies_count",
-        "reblogs_count",
-        "favourites_count",
-        "upvotes_count",
-        "downvotes_count",
-        "account_verified",
-        "account_followers_count",
-        "card",
-        "media_attachments",
-        "in_reply_to_id",
-        "in_reply_to",
-        "reblog",
-        "prediction_id",
-        "assets",
-        "market_impact",
-        "confidence",
-        "thesis",
-        "analysis_status",
-        "engagement_score",
-        "viral_score",
-        "sentiment_score",
-        "urgency_score",
-        "total_count",
-    ]
-    row = (
-        "post_json456",
-        "Trade deal signed!",
-        "<p>Trade deal signed!</p>",
-        datetime(2026, 3, 24, 10, 0, 0),
-        "realDonaldTrump",
-        None,
-        10,
-        50,
-        200,
-        100,
-        5,
-        False,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        202,
-        '["SPY", "DIA"]',
-        '{"SPY": "bullish", "DIA": "bullish"}',
-        0.72,
-        "Trade deal boosts market indices.",
-        "completed",
-        0.5,
-        0.6,
-        0.4,
-        0.3,
-        42,
-    )
-    return ([row], columns)
-
-
-@pytest.fixture
-def sample_outcomes_rows() -> tuple[list[tuple], list[str]]:
-    """Outcome rows as returned by get_outcomes_for_prediction's SQL."""
-    from datetime import date
-
-    columns = [
-        "symbol",
-        "prediction_sentiment",
-        "prediction_confidence",
-        "prediction_date",
-        "price_at_prediction",
-        "price_at_post",
-        "price_at_next_close",
-        "price_1h_after",
-        "price_t1",
-        "price_t3",
-        "price_t7",
-        "price_t30",
-        "return_t1",
-        "return_t3",
-        "return_t7",
-        "return_t30",
-        "return_same_day",
-        "return_1h",
-        "correct_t1",
-        "correct_t3",
-        "correct_t7",
-        "correct_t30",
-        "correct_same_day",
-        "correct_1h",
-        "pnl_t1",
-        "pnl_t3",
-        "pnl_t7",
-        "pnl_t30",
-        "pnl_same_day",
-        "pnl_1h",
-        "is_complete",
-        "company_name",
-        "asset_type",
-        "exchange",
-        "sector",
-        "industry",
-        "market_cap",
-        "pe_ratio",
-        "forward_pe",
-        "beta",
-        "dividend_yield",
-    ]
-    row_aapl = (
-        "AAPL",
-        "bearish",
-        0.85,
-        date(2026, 3, 25),
-        178.50,
-        178.20,
-        177.80,
-        178.00,
-        176.50,
-        175.00,
-        174.00,
-        180.00,
-        -1.12,
-        -1.96,
-        -2.52,
-        0.84,
-        -0.39,
-        -0.11,
-        True,
-        True,
-        True,
-        False,
-        True,
-        True,
-        11.20,
-        19.60,
-        25.20,
-        -8.40,
-        3.90,
-        1.10,
-        True,
-        "Apple Inc.",
-        "stock",
-        "NASDAQ",
-        "Technology",
-        "Consumer Electronics",
-        2800000000000,
-        28.5,
-        26.1,
-        1.2,
-        0.005,
-    )
-    row_tsla = (
-        "TSLA",
-        "bullish",
-        0.85,
-        date(2026, 3, 25),
-        245.00,
-        244.80,
-        246.50,
-        245.50,
-        248.00,
-        252.00,
-        260.00,
-        240.00,
-        1.22,
-        2.86,
-        6.12,
-        -2.04,
-        0.69,
-        0.20,
-        True,
-        True,
-        True,
-        False,
-        True,
-        True,
-        12.20,
-        28.60,
-        61.20,
-        -20.40,
-        6.90,
-        2.00,
-        True,
-        "Tesla Inc.",
-        "stock",
-        "NASDAQ",
-        "Automotive",
-        "Auto Manufacturers",
-        812000000000,
-        68.4,
-        42.1,
-        2.05,
-        None,
-    )
-    return ([row_aapl, row_tsla], columns)
-
-
-@pytest.fixture
 def sample_snapshot_rows() -> tuple[list[tuple], list[str]]:
     """Empty snapshot rows (no snapshots captured yet)."""
     return ([], [])
@@ -344,8 +201,6 @@ def sample_snapshot_rows() -> tuple[list[tuple], list[str]]:
 @pytest.fixture
 def sample_candle_rows() -> tuple[list[tuple], list[str]]:
     """Price candle rows as returned from the database fallback query."""
-    from datetime import date
-
     columns = ["date", "open", "high", "low", "close", "volume"]
     rows = [
         (date(2026, 3, 20), 175.0, 178.0, 174.5, 177.0, 50000000),

--- a/shit_tests/api/test_feed_queries.py
+++ b/shit_tests/api/test_feed_queries.py
@@ -4,8 +4,9 @@ Unit tests for the query layer, mocking execute_query at the
 api.dependencies level.
 """
 
-from datetime import datetime
 from unittest.mock import patch
+
+from conftest import make_outcome_row, make_post_row
 
 
 # ---------------------------------------------------------------------------
@@ -13,43 +14,32 @@ from unittest.mock import patch
 # ---------------------------------------------------------------------------
 
 
-def _make_query_row(overrides=None):
-    """Build a sample post query row with columns + total_count."""
-    columns = [
-        "shitpost_id", "text", "content_html", "timestamp",
-        "username", "url",
-        "replies_count", "reblogs_count", "favourites_count",
-        "upvotes_count", "downvotes_count",
-        "account_verified", "account_followers_count",
-        "card", "media_attachments",
-        "in_reply_to_id", "in_reply_to", "reblog",
-        "prediction_id", "assets", "market_impact",
-        "confidence", "thesis", "analysis_status",
-        "engagement_score", "viral_score",
-        "sentiment_score", "urgency_score",
-        "total_count",
-    ]
-    defaults = (
-        "post_1", "Hello", None,
-        datetime(2026, 3, 25, 12, 0, 0),
-        "user", None,
-        1, 2, 3, 4, 5,
-        False, None, None, None, None, None, None,
-        100, ["AAPL"], {"AAPL": "bullish"},
-        0.9, "Thesis", "completed",
-        0.5, 0.6, 0.7, 0.8,
-        10,
-    )
-    if overrides:
-        vals = dict(zip(columns, defaults))
-        vals.update(overrides)
-        return ([tuple(vals.values())], list(vals.keys()))
-    return ([defaults], columns)
-
-
 def test_get_analyzed_post_at_offset_returns_dict():
     """get_analyzed_post_at_offset returns (dict, total) tuple."""
-    rows, columns = _make_query_row()
+    rows, columns = make_post_row(
+        shitpost_id="post_1",
+        text="Hello",
+        content_html=None,
+        username="user",
+        url=None,
+        replies_count=1,
+        reblogs_count=2,
+        favourites_count=3,
+        upvotes_count=4,
+        downvotes_count=5,
+        account_verified=False,
+        account_followers_count=None,
+        prediction_id=100,
+        assets=["AAPL"],
+        market_impact={"AAPL": "bullish"},
+        confidence=0.9,
+        thesis="Thesis",
+        engagement_score=0.5,
+        viral_score=0.6,
+        sentiment_score=0.7,
+        urgency_score=0.8,
+        total_count=10,
+    )
 
     with patch("api.queries.feed_queries.execute_query", return_value=(rows, columns)):
         from api.queries.feed_queries import get_analyzed_post_at_offset
@@ -86,11 +76,11 @@ def test_get_analyzed_post_at_offset_returns_none_when_empty():
 
 def test_get_analyzed_post_at_offset_parses_json_string_assets():
     """When assets is a JSON string, it gets parsed to a list."""
-    rows, columns = _make_query_row({
-        "shitpost_id": "post_json",
-        "assets": '["TSLA", "NVDA"]',
-        "market_impact": '{"TSLA": "bullish"}',
-    })
+    rows, columns = make_post_row(
+        shitpost_id="post_json",
+        assets='["TSLA", "NVDA"]',
+        market_impact='{"TSLA": "bullish"}',
+    )
 
     with patch("api.queries.feed_queries.execute_query", return_value=(rows, columns)):
         from api.queries.feed_queries import get_analyzed_post_at_offset
@@ -111,11 +101,11 @@ def test_get_analyzed_post_at_offset_parses_json_string_assets():
 
 def test_get_analyzed_post_at_offset_leaves_native_types():
     """When assets is already a list and market_impact a dict, they are not re-parsed."""
-    rows, columns = _make_query_row({
-        "shitpost_id": "post_native",
-        "assets": ["AAPL"],
-        "market_impact": {"AAPL": "bearish"},
-    })
+    rows, columns = make_post_row(
+        shitpost_id="post_native",
+        assets=["AAPL"],
+        market_impact={"AAPL": "bearish"},
+    )
 
     with patch("api.queries.feed_queries.execute_query", return_value=(rows, columns)):
         from api.queries.feed_queries import get_analyzed_post_at_offset
@@ -134,39 +124,9 @@ def test_get_analyzed_post_at_offset_leaves_native_types():
 
 def test_get_outcomes_for_prediction_returns_list():
     """get_outcomes_for_prediction returns a list of outcome dicts."""
-    from datetime import date
+    rows, columns = make_outcome_row()
 
-    columns = [
-        "symbol", "prediction_sentiment", "prediction_confidence",
-        "prediction_date",
-        "price_at_prediction", "price_at_post",
-        "price_at_next_close", "price_1h_after",
-        "price_t1", "price_t3", "price_t7", "price_t30",
-        "return_t1", "return_t3", "return_t7", "return_t30",
-        "return_same_day", "return_1h",
-        "correct_t1", "correct_t3", "correct_t7", "correct_t30",
-        "correct_same_day", "correct_1h",
-        "pnl_t1", "pnl_t3", "pnl_t7", "pnl_t30",
-        "pnl_same_day", "pnl_1h",
-        "is_complete",
-        "company_name", "asset_type", "exchange", "sector", "industry",
-        "market_cap", "pe_ratio", "forward_pe", "beta", "dividend_yield",
-    ]
-    row = (
-        "AAPL", "bearish", 0.85,
-        date(2026, 3, 25),
-        178.5, 178.2, 177.8, 178.0,
-        176.5, 175.0, 174.0, 180.0,
-        -1.12, -1.96, -2.52, 0.84, -0.39, -0.11,
-        True, True, True, False, True, True,
-        11.2, 19.6, 25.2, -8.4, 3.9, 1.1,
-        True,
-        "Apple Inc.", "stock", "NASDAQ", "Technology",
-        "Consumer Electronics", 2800000000000,
-        28.5, 26.1, 1.2, 0.005,
-    )
-
-    with patch("api.queries.feed_queries.execute_query", return_value=([row], columns)):
+    with patch("api.queries.feed_queries.execute_query", return_value=(rows, columns)):
         from api.queries.feed_queries import get_outcomes_for_prediction
 
         result = get_outcomes_for_prediction(101)
@@ -190,5 +150,3 @@ def test_get_outcomes_for_prediction_empty():
         result = get_outcomes_for_prediction(9999)
 
     assert result == []
-
-

--- a/shit_tests/api/test_feed_router.py
+++ b/shit_tests/api/test_feed_router.py
@@ -9,7 +9,7 @@ Covers:
 - GET /api/health
 """
 
-from datetime import datetime
+from conftest import make_outcome_rows, make_post_row
 
 
 # ---------------------------------------------------------------------------
@@ -17,15 +17,55 @@ from datetime import datetime
 # ---------------------------------------------------------------------------
 
 
-def test_get_latest_post_happy_path(
-    client,
-    mock_execute_query,
-    sample_post_row,
-    sample_outcomes_rows,
-):
+def test_get_latest_post_happy_path(client, mock_execute_query):
     """GET /api/feed/latest returns a complete FeedResponse with post, prediction, outcomes."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {
+            "symbol": "AAPL",
+            "prediction_sentiment": "bearish",
+        },
+        {
+            "symbol": "TSLA",
+            "prediction_sentiment": "bullish",
+            "price_at_prediction": 245.00,
+            "price_at_post": 244.80,
+            "price_at_next_close": 246.50,
+            "price_1h_after": 245.50,
+            "price_t1": 248.00,
+            "price_t3": 252.00,
+            "price_t7": 260.00,
+            "price_t30": 240.00,
+            "return_t1": 1.22,
+            "return_t3": 2.86,
+            "return_t7": 6.12,
+            "return_t30": -2.04,
+            "return_same_day": 0.69,
+            "return_1h": 0.20,
+            "correct_t1": True,
+            "correct_t3": True,
+            "correct_t7": True,
+            "correct_t30": False,
+            "correct_same_day": True,
+            "correct_1h": True,
+            "pnl_t1": 12.20,
+            "pnl_t3": 28.60,
+            "pnl_t7": 61.20,
+            "pnl_t30": -20.40,
+            "pnl_same_day": 6.90,
+            "pnl_1h": 2.00,
+            "company_name": "Tesla Inc.",
+            "asset_type": "stock",
+            "exchange": "NASDAQ",
+            "sector": "Automotive",
+            "industry": "Auto Manufacturers",
+            "market_cap": 812000000000,
+            "pe_ratio": 68.4,
+            "forward_pe": 42.1,
+            "beta": 2.05,
+            "dividend_yield": None,
+        },
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -81,15 +121,12 @@ def test_get_latest_post_empty_database(client, mock_execute_query):
 # ---------------------------------------------------------------------------
 
 
-def test_get_post_at_offset_zero(
-    client,
-    mock_execute_query,
-    sample_post_row,
-    sample_outcomes_rows,
-):
+def test_get_post_at_offset_zero(client, mock_execute_query):
     """GET /api/feed/at?offset=0 behaves identically to /api/feed/latest."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -108,15 +145,12 @@ def test_get_post_at_offset_zero(
 # ---------------------------------------------------------------------------
 
 
-def test_get_post_at_offset_five(
-    client,
-    mock_execute_query,
-    sample_post_row,
-    sample_outcomes_rows,
-):
+def test_get_post_at_offset_five(client, mock_execute_query):
     """GET /api/feed/at?offset=5 returns the 5th most recent analyzed post."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -163,12 +197,12 @@ def test_get_post_at_negative_offset(client, mock_execute_query):
 # ---------------------------------------------------------------------------
 
 
-def test_navigation_has_newer_false_at_offset_zero(
-    client, mock_execute_query, sample_post_row, sample_outcomes_rows
-):
+def test_navigation_has_newer_false_at_offset_zero(client, mock_execute_query):
     """At offset=0, has_newer must be False (already at the newest post)."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -187,12 +221,12 @@ def test_navigation_has_newer_false_at_offset_zero(
 # ---------------------------------------------------------------------------
 
 
-def test_navigation_has_older_false_at_last_post(
-    client, mock_execute_query, sample_post_row, sample_outcomes_rows
-):
+def test_navigation_has_older_false_at_last_post(client, mock_execute_query):
     """At offset = total - 1, has_older must be False (already at the oldest post)."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -200,7 +234,7 @@ def test_navigation_has_older_false_at_last_post(
         ([], []),  # snapshots
     ]
 
-    # total_count is 42 in sample_post_row, so offset=41 is the last post
+    # total_count is 42 in make_post_row defaults, so offset=41 is the last post
     response = client.get("/api/feed/at?offset=41")
     assert response.status_code == 200
 
@@ -215,12 +249,12 @@ def test_navigation_has_older_false_at_last_post(
 # ---------------------------------------------------------------------------
 
 
-def test_navigation_mid_range_has_both_directions(
-    client, mock_execute_query, sample_post_row, sample_outcomes_rows
-):
+def test_navigation_mid_range_has_both_directions(client, mock_execute_query):
     """At a mid-range offset, both has_newer and has_older must be True."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -241,11 +275,12 @@ def test_navigation_mid_range_has_both_directions(
 # ---------------------------------------------------------------------------
 
 
-def test_assets_json_string_parsed_to_list(
-    client, mock_execute_query, sample_post_row_json_strings
-):
+def test_assets_json_string_parsed_to_list(client, mock_execute_query):
     """When assets comes back as a JSON string from the DB, it gets parsed to a list."""
-    post_rows, post_cols = sample_post_row_json_strings
+    post_rows, post_cols = make_post_row(
+        assets='["SPY", "DIA"]',
+        market_impact='{"SPY": "bullish", "DIA": "bullish"}',
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -266,11 +301,12 @@ def test_assets_json_string_parsed_to_list(
 # ---------------------------------------------------------------------------
 
 
-def test_market_impact_json_string_parsed_to_dict(
-    client, mock_execute_query, sample_post_row_json_strings
-):
+def test_market_impact_json_string_parsed_to_dict(client, mock_execute_query):
     """When market_impact comes back as a JSON string, it gets parsed to a dict."""
-    post_rows, post_cols = sample_post_row_json_strings
+    post_rows, post_cols = make_post_row(
+        assets='["SPY", "DIA"]',
+        market_impact='{"SPY": "bullish", "DIA": "bullish"}',
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -291,42 +327,12 @@ def test_market_impact_json_string_parsed_to_dict(
 # ---------------------------------------------------------------------------
 
 
-def _make_minimal_post_row(overrides: dict) -> tuple[list[tuple], list[str]]:
-    """Build a post row with defaults, applying overrides."""
-    defaults = {
-        "shitpost_id": "post_test",
-        "text": "Test",
-        "content_html": None,
-        "timestamp": datetime(2026, 3, 25, 12, 0, 0),
-        "username": "realDonaldTrump",
-        "url": None,
-        "replies_count": 0, "reblogs_count": 0, "favourites_count": 0,
-        "upvotes_count": 0, "downvotes_count": 0,
-        "account_verified": False, "account_followers_count": None,
-        "card": None, "media_attachments": None,
-        "in_reply_to_id": None, "in_reply_to": None, "reblog": None,
-        "prediction_id": 999,
-        "assets": ["SPY"], "market_impact": {"SPY": "bullish"},
-        "confidence": 0.5, "thesis": "Thesis",
-        "analysis_status": "completed",
-        "engagement_score": None, "viral_score": None,
-        "sentiment_score": None, "urgency_score": None,
-        "total_count": 1,
-    }
-    defaults.update(overrides)
-    columns = list(defaults.keys())
-    row = tuple(defaults.values())
-    return ([row], columns)
-
-
-def test_post_with_none_text_defaults_to_empty_string(
-    client, mock_execute_query
-):
+def test_post_with_none_text_defaults_to_empty_string(client, mock_execute_query):
     """When text is None in the DB row, the response should use an empty string."""
-    post_rows, post_cols = _make_minimal_post_row({
-        "shitpost_id": "post_null_text",
-        "text": None,
-    })
+    post_rows, post_cols = make_post_row(
+        shitpost_id="post_null_text",
+        text=None,
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -344,17 +350,17 @@ def test_post_with_none_text_defaults_to_empty_string(
 # ---------------------------------------------------------------------------
 
 
-def test_post_with_none_engagement_defaults_to_zero(
-    client, mock_execute_query
-):
+def test_post_with_none_engagement_defaults_to_zero(client, mock_execute_query):
     """When engagement counts are None, the response should default them to 0."""
-    post_rows, post_cols = _make_minimal_post_row({
-        "shitpost_id": "post_none_eng",
-        "text": "Test post",
-        "replies_count": None, "reblogs_count": None,
-        "favourites_count": None, "upvotes_count": None,
-        "downvotes_count": None,
-    })
+    post_rows, post_cols = make_post_row(
+        shitpost_id="post_none_eng",
+        text="Test post",
+        replies_count=None,
+        reblogs_count=None,
+        favourites_count=None,
+        upvotes_count=None,
+        downvotes_count=None,
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -378,11 +384,9 @@ def test_post_with_none_engagement_defaults_to_zero(
 # ---------------------------------------------------------------------------
 
 
-def test_feed_response_with_no_outcomes(
-    client, mock_execute_query, sample_post_row
-):
+def test_feed_response_with_no_outcomes(client, mock_execute_query):
     """When there are no outcomes for a prediction, outcomes list is empty."""
-    post_rows, post_cols = sample_post_row
+    post_rows, post_cols = make_post_row()
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -402,14 +406,20 @@ def test_feed_response_with_no_outcomes(
 
 def test_scores_with_none_values(client, mock_execute_query):
     """When score fields are None, they serialize as null in the JSON response."""
-    post_rows, post_cols = _make_minimal_post_row({
-        "shitpost_id": "post_no_scores",
-        "replies_count": 5, "reblogs_count": 10,
-        "favourites_count": 20, "upvotes_count": 15,
-        "downvotes_count": 1,
-        "prediction_id": 505,
-        "confidence": 0.7,
-    })
+    post_rows, post_cols = make_post_row(
+        shitpost_id="post_no_scores",
+        replies_count=5,
+        reblogs_count=10,
+        favourites_count=20,
+        upvotes_count=15,
+        downvotes_count=1,
+        prediction_id=505,
+        confidence=0.7,
+        engagement_score=None,
+        viral_score=None,
+        sentiment_score=None,
+        urgency_score=None,
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -432,15 +442,12 @@ def test_scores_with_none_values(client, mock_execute_query):
 # ---------------------------------------------------------------------------
 
 
-def test_at_endpoint_default_offset_is_zero(
-    client,
-    mock_execute_query,
-    sample_post_row,
-    sample_outcomes_rows,
-):
+def test_at_endpoint_default_offset_is_zero(client, mock_execute_query):
     """GET /api/feed/at without offset param defaults to offset=0."""
-    post_rows, post_cols = sample_post_row
-    outcome_rows, outcome_cols = sample_outcomes_rows
+    post_rows, post_cols = make_post_row()
+    outcome_rows, outcome_cols = make_outcome_rows(
+        {"symbol": "AAPL"}, {"symbol": "TSLA"}
+    )
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),
@@ -458,11 +465,9 @@ def test_at_endpoint_default_offset_is_zero(
 # ---------------------------------------------------------------------------
 
 
-def test_timestamp_serialized_as_iso_string(
-    client, mock_execute_query, sample_post_row
-):
+def test_timestamp_serialized_as_iso_string(client, mock_execute_query):
     """The post timestamp should be an ISO-format string in the response."""
-    post_rows, post_cols = sample_post_row
+    post_rows, post_cols = make_post_row()
 
     mock_execute_query.side_effect = [
         (post_rows, post_cols),

--- a/shit_tests/api/test_feed_service.py
+++ b/shit_tests/api/test_feed_service.py
@@ -1,0 +1,377 @@
+"""Tests for the feed service layer (api/services/feed_service.py).
+
+Unit tests for static builder methods (pure functions, no DB mocking needed)
+and orchestration tests for get_feed_response.
+"""
+
+from datetime import date, datetime
+from unittest.mock import patch
+
+from api.services.feed_service import FeedService
+
+
+# ---------------------------------------------------------------------------
+# build_link_preview
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLinkPreview:
+    def test_none_returns_none(self):
+        assert FeedService.build_link_preview(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert FeedService.build_link_preview({}) is None
+
+    def test_non_dict_returns_none(self):
+        assert FeedService.build_link_preview("not a dict") is None
+
+    def test_missing_title_returns_none(self):
+        assert FeedService.build_link_preview({"description": "desc"}) is None
+
+    def test_empty_title_returns_none(self):
+        assert FeedService.build_link_preview({"title": ""}) is None
+
+    def test_complete_card(self):
+        card = {
+            "title": "Article Title",
+            "description": "Summary",
+            "image": "https://example.com/img.jpg",
+            "url": "https://example.com/article",
+            "provider_name": "Example News",
+        }
+        result = FeedService.build_link_preview(card)
+        assert result is not None
+        assert result.title == "Article Title"
+        assert result.description == "Summary"
+        assert result.url == "https://example.com/article"
+        assert result.provider_name == "Example News"
+
+    def test_title_only(self):
+        result = FeedService.build_link_preview({"title": "Just a title"})
+        assert result is not None
+        assert result.title == "Just a title"
+        assert result.description is None
+
+
+# ---------------------------------------------------------------------------
+# build_reply_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReplyContext:
+    def test_none_returns_none(self):
+        assert FeedService.build_reply_context(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert FeedService.build_reply_context({}) is None
+
+    def test_non_dict_returns_none(self):
+        assert FeedService.build_reply_context("not a dict") is None
+
+    def test_no_username_no_text_returns_none(self):
+        assert FeedService.build_reply_context({"account": {}}) is None
+
+    def test_with_username(self):
+        reply = {"account": {"username": "someone"}, "text": "original post"}
+        result = FeedService.build_reply_context(reply)
+        assert result is not None
+        assert result.username == "someone"
+        assert result.text == "original post"
+
+    def test_acct_fallback(self):
+        reply = {"account": {"acct": "user@server"}, "text": "post"}
+        result = FeedService.build_reply_context(reply)
+        assert result.username == "user@server"
+
+    def test_text_truncated_to_200(self):
+        reply = {"account": {"username": "user"}, "text": "x" * 300}
+        result = FeedService.build_reply_context(reply)
+        assert len(result.text) == 200
+
+    def test_html_content_fallback(self):
+        reply = {"account": {"username": "user"}, "content": "<p>HTML</p>"}
+        result = FeedService.build_reply_context(reply)
+        assert result.text == "<p>HTML</p>"
+
+
+# ---------------------------------------------------------------------------
+# build_navigation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNavigation:
+    def test_at_newest(self):
+        nav = FeedService.build_navigation(0, 42)
+        assert nav.has_newer is False
+        assert nav.has_older is True
+        assert nav.current_offset == 0
+        assert nav.total_posts == 42
+
+    def test_at_oldest(self):
+        nav = FeedService.build_navigation(41, 42)
+        assert nav.has_newer is True
+        assert nav.has_older is False
+
+    def test_mid_range(self):
+        nav = FeedService.build_navigation(5, 42)
+        assert nav.has_newer is True
+        assert nav.has_older is True
+
+    def test_single_post(self):
+        nav = FeedService.build_navigation(0, 1)
+        assert nav.has_newer is False
+        assert nav.has_older is False
+
+
+# ---------------------------------------------------------------------------
+# build_post
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPost:
+    def test_basic_post(self):
+        row = {
+            "shitpost_id": "post_1",
+            "text": "Hello",
+            "content_html": "<p>Hello</p>",
+            "timestamp": datetime(2026, 3, 25, 14, 30, 0),
+            "username": "user",
+            "url": "https://example.com",
+            "replies_count": 10,
+            "reblogs_count": 20,
+            "favourites_count": 30,
+            "upvotes_count": 40,
+            "downvotes_count": 5,
+            "account_verified": True,
+            "account_followers_count": 1000,
+            "card": None,
+            "media_attachments": [],
+            "in_reply_to": None,
+            "reblog": None,
+        }
+        post = FeedService.build_post(row, "market_open", "0m")
+        assert post.shitpost_id == "post_1"
+        assert post.text == "Hello"
+        assert post.engagement.replies == 10
+        assert post.verified is True
+        assert post.market_timing == "market_open"
+        assert post.is_repost is False
+
+    def test_none_text_defaults_to_empty(self):
+        row = {
+            "shitpost_id": "p",
+            "text": None,
+            "timestamp": datetime(2026, 1, 1),
+            "username": "u",
+            "replies_count": 0,
+            "reblogs_count": 0,
+            "favourites_count": 0,
+            "upvotes_count": 0,
+            "downvotes_count": 0,
+        }
+        post = FeedService.build_post(row, "", "")
+        assert post.text == ""
+
+    def test_reblog_sets_is_repost(self):
+        row = {
+            "shitpost_id": "p",
+            "text": "rt",
+            "timestamp": datetime(2026, 1, 1),
+            "username": "u",
+            "reblog": {"id": "orig"},
+            "replies_count": 0,
+            "reblogs_count": 0,
+            "favourites_count": 0,
+            "upvotes_count": 0,
+            "downvotes_count": 0,
+        }
+        post = FeedService.build_post(row, "", "")
+        assert post.is_repost is True
+
+
+# ---------------------------------------------------------------------------
+# build_prediction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrediction:
+    def test_basic_prediction(self):
+        row = {
+            "prediction_id": 101,
+            "confidence": 0.85,
+            "thesis": "Bull case",
+            "assets": ["AAPL"],
+            "market_impact": {"AAPL": "bullish"},
+            "engagement_score": 0.7,
+            "viral_score": 0.8,
+            "sentiment_score": 0.5,
+            "urgency_score": 0.9,
+        }
+        pred = FeedService.build_prediction(row)
+        assert pred.prediction_id == 101
+        assert pred.assets == ["AAPL"]
+        assert pred.scores.urgency == 0.9
+
+    def test_none_assets_defaults_to_empty_list(self):
+        row = {
+            "prediction_id": 1,
+            "assets": None,
+            "market_impact": None,
+        }
+        pred = FeedService.build_prediction(row)
+        assert pred.assets == []
+        assert pred.market_impact == {}
+
+
+# ---------------------------------------------------------------------------
+# build_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOutcome:
+    def test_basic_outcome(self):
+        o = {
+            "symbol": "AAPL",
+            "prediction_sentiment": "bearish",
+            "prediction_confidence": 0.85,
+            "prediction_date": date(2026, 3, 25),
+            "price_at_prediction": 178.50,
+            "price_at_post": 178.20,
+            "return_same_day": -0.39,
+            "return_1h": -0.11,
+            "return_t1": -1.12,
+            "return_t3": -1.96,
+            "return_t7": -2.52,
+            "return_t30": 0.84,
+            "correct_same_day": True,
+            "correct_1h": True,
+            "correct_t1": True,
+            "correct_t3": True,
+            "correct_t7": True,
+            "correct_t30": False,
+            "pnl_same_day": 3.90,
+            "pnl_1h": 1.10,
+            "pnl_t1": 11.20,
+            "pnl_t3": 19.60,
+            "pnl_t7": 25.20,
+            "pnl_t30": -8.40,
+            "is_complete": True,
+            "company_name": "Apple Inc.",
+            "asset_type": "stock",
+            "exchange": "NASDAQ",
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+            "market_cap": 2800000000000,
+            "pe_ratio": 28.5,
+            "forward_pe": 26.1,
+            "beta": 1.2,
+            "dividend_yield": 0.005,
+        }
+        outcome = FeedService.build_outcome(o, None)
+        assert outcome.symbol == "AAPL"
+        assert outcome.returns.t1 == -1.12
+        assert outcome.correct.t1 is True
+        assert outcome.pnl.t1 == 11.20
+        assert outcome.fundamentals is not None
+        assert outcome.fundamentals.company_name == "Apple Inc."
+        assert outcome.price_snapshot is None
+        assert outcome.prediction_date == "2026-03-25"
+
+    def test_without_fundamentals(self):
+        o = {
+            "symbol": "XYZ",
+            "company_name": None,
+            "prediction_date": None,
+            "is_complete": False,
+        }
+        outcome = FeedService.build_outcome(o, None)
+        assert outcome.fundamentals is None
+        assert outcome.prediction_date is None
+
+    def test_with_price_snapshot(self):
+        o = {
+            "symbol": "AAPL",
+            "company_name": None,
+            "prediction_date": None,
+            "is_complete": True,
+        }
+        snap = {
+            "price": 178.50,
+            "captured_at": "2026-03-25T14:30:00",
+            "market_status": "open",
+            "previous_close": 177.00,
+            "day_high": 179.00,
+            "day_low": 176.50,
+        }
+        outcome = FeedService.build_outcome(o, snap)
+        assert outcome.price_snapshot is not None
+        assert outcome.price_snapshot.price == 178.50
+        assert outcome.price_snapshot.market_status == "open"
+
+
+# ---------------------------------------------------------------------------
+# get_feed_response — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestGetFeedResponse:
+    def test_returns_none_when_no_post(self):
+        with patch(
+            "api.services.feed_service.get_analyzed_post_at_offset", return_value=None
+        ):
+            service = FeedService()
+            result = service.get_feed_response(0)
+        assert result is None
+
+    def test_happy_path(self):
+        row = {
+            "shitpost_id": "post_1",
+            "text": "Test",
+            "content_html": None,
+            "timestamp": datetime(2026, 3, 25, 14, 30, 0),
+            "username": "user",
+            "url": None,
+            "replies_count": 0,
+            "reblogs_count": 0,
+            "favourites_count": 0,
+            "upvotes_count": 0,
+            "downvotes_count": 0,
+            "account_verified": False,
+            "account_followers_count": None,
+            "card": None,
+            "media_attachments": None,
+            "in_reply_to": None,
+            "reblog": None,
+            "prediction_id": 1,
+            "assets": ["SPY"],
+            "market_impact": {"SPY": "bullish"},
+            "confidence": 0.5,
+            "thesis": "Thesis",
+            "analysis_status": "completed",
+            "engagement_score": None,
+            "viral_score": None,
+            "sentiment_score": None,
+            "urgency_score": None,
+        }
+
+        with (
+            patch(
+                "api.services.feed_service.get_analyzed_post_at_offset",
+                return_value=(row, 10),
+            ),
+            patch(
+                "api.services.feed_service.get_outcomes_for_prediction", return_value=[]
+            ),
+            patch(
+                "api.services.feed_service.get_snapshots_for_prediction",
+                return_value={},
+            ),
+        ):
+            service = FeedService()
+            result = service.get_feed_response(0)
+
+        assert result is not None
+        assert result.post.shitpost_id == "post_1"
+        assert result.prediction.assets == ["SPY"]
+        assert result.outcomes == []
+        assert result.navigation.total_posts == 10


### PR DESCRIPTION
## Summary
- **#122** — Migrate feed API test fixtures to factory pattern: `make_post_row()`, `make_outcome_row()`, `make_outcome_rows()` replace 6 duplicate construction patterns. Future column additions update 1 place instead of 8.
- **#120** — Extract `FeedService` class from `_build_feed_response()` monolith. Router shrinks from 226 to 30 lines. 29 new unit tests for static builder methods.
- **#121** — Data validation complete: `price_snapshots` table is empty (0 rows). Consolidation blocked until snapshot service populates production data.

## Test plan
- [x] All 81 API tests pass (52 original + 29 new service tests)
- [x] `ruff check` and `ruff format` clean
- [x] Existing mock targets unchanged (mocks at `execute_query` level)
- [ ] Verify feed endpoint works on Railway after deploy

Closes #120, closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)