### PR TITLE
Fix: price snapshot observability + backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Price snapshot observability** — Added warning log when market-data-worker captures 0 snapshots despite having assets, preventing silent pipeline failures (#121)
+- **Price snapshot backfill** — Backfilled 706 price snapshots for 361 existing predictions that were processed before snapshot capture was deployed
+
 ### Changed
 - **Feed API service extraction** — Extracted `_build_feed_response()` monolith into `FeedService` class (`api/services/feed_service.py`) with static builder methods; router shrinks from 226 to 30 lines (#120)
 - **Test fixture factory** — Replaced 4 duplicate post-row and 2 outcome-row construction patterns with `make_post_row()`, `make_outcome_row()`, `make_outcome_rows()` factory functions; future column additions require updating 1 place instead of 8 (#122)

--- a/shit/market_data/event_consumer.py
+++ b/shit/market_data/event_consumer.py
@@ -60,9 +60,7 @@ class MarketDataWorker(EventWorker):
         post_published_at = None
         if payload.get("post_published_at"):
             try:
-                post_published_at = datetime.fromisoformat(
-                    payload["post_published_at"]
-                )
+                post_published_at = datetime.fromisoformat(payload["post_published_at"])
             except (ValueError, TypeError):
                 pass
 
@@ -79,8 +77,13 @@ class MarketDataWorker(EventWorker):
                 session.commit()
         except Exception as e:
             logger.warning(
-                f"Snapshot capture failed for prediction "
-                f"{prediction_id}: {e}"
+                f"Snapshot capture failed for prediction {prediction_id}: {e}"
+            )
+
+        if snapshots_captured == 0 and assets:
+            logger.warning(
+                f"No snapshots captured for prediction {prediction_id} "
+                f"despite having {len(assets)} assets: {assets}"
             )
 
         # Backfill price history + calculate outcomes

--- a/shit_tests/events/consumers/test_market_data.py
+++ b/shit_tests/events/consumers/test_market_data.py
@@ -101,20 +101,26 @@ class TestMarketDataWorker:
 
         mock_snapshot_svc = MagicMock()
         mock_snapshot_svc.capture_for_prediction.return_value = [
-            MagicMock(), MagicMock(), MagicMock()
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         ]
 
         mock_session = MagicMock()
 
-        with patch(
-            "shit.market_data.auto_backfill_service.AutoBackfillService",
-            return_value=mock_backfill,
-        ), patch(
-            "shit.market_data.snapshot_service.PriceSnapshotService",
-            return_value=mock_snapshot_svc,
-        ), patch(
-            "shit.db.sync_session.SessionLocal",
-            return_value=mock_session,
+        with (
+            patch(
+                "shit.market_data.auto_backfill_service.AutoBackfillService",
+                return_value=mock_backfill,
+            ),
+            patch(
+                "shit.market_data.snapshot_service.PriceSnapshotService",
+                return_value=mock_snapshot_svc,
+            ),
+            patch(
+                "shit.db.sync_session.SessionLocal",
+                return_value=mock_session,
+            ),
         ):
             worker = MarketDataWorker.__new__(MarketDataWorker)
             result = worker.process_event(
@@ -137,3 +143,56 @@ class TestMarketDataWorker:
                 "assets_backfilled": 3,
                 "outcomes_calculated": 2,
             }
+
+    def test_logs_warning_when_zero_snapshots_captured(self):
+        """Verify a warning is logged when snapshot capture returns 0 despite having assets.
+
+        What it verifies: When PriceSnapshotService.capture_for_prediction raises
+        an exception, snapshots_captured stays 0 and a warning is logged.
+        Mocking:
+          - PriceSnapshotService.capture_for_prediction raises RuntimeError
+          - AutoBackfillService.process_single_prediction returns (0, 0)
+          - SessionLocal context manager
+        Assertions:
+          - Warning log contains "No snapshots captured"
+          - Result has snapshots_captured=0
+        """
+        mock_backfill = MagicMock()
+        mock_backfill.process_single_prediction.return_value = (0, 0)
+
+        mock_snapshot_svc = MagicMock()
+        mock_snapshot_svc.capture_for_prediction.side_effect = RuntimeError(
+            "yfinance down"
+        )
+
+        mock_session = MagicMock()
+
+        with (
+            patch(
+                "shit.market_data.auto_backfill_service.AutoBackfillService",
+                return_value=mock_backfill,
+            ),
+            patch(
+                "shit.market_data.snapshot_service.PriceSnapshotService",
+                return_value=mock_snapshot_svc,
+            ),
+            patch(
+                "shit.db.sync_session.SessionLocal",
+                return_value=mock_session,
+            ),
+            patch("shit.market_data.event_consumer.logger") as mock_logger,
+        ):
+            worker = MarketDataWorker.__new__(MarketDataWorker)
+            result = worker.process_event(
+                "prediction_created",
+                {
+                    "prediction_id": 99,
+                    "assets": ["AAPL", "TSLA"],
+                    "analysis_status": "completed",
+                },
+            )
+
+            assert result["snapshots_captured"] == 0
+            # Should have warning about capture failure + warning about 0 snapshots
+            warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any("No snapshots captured" in w for w in warning_calls)


### PR DESCRIPTION
## Summary
- **Root cause investigation**: `price_snapshots` table was empty because the snapshot capture code (PR #119) was merged but hadn't processed any new predictions with assets since deployment
- **Observability fix**: Added warning log when market-data-worker captures 0 snapshots despite having assets — prevents this silent failure from going undetected
- **Backfill**: Ran one-time backfill capturing 706 price snapshots for 361 existing predictions

## Investigation findings
- The `price_snapshots` table existed with correct schema — the write path was the issue
- Railway DID redeploy the market-data-worker (confirmed via `railway deployment list`)
- But only 1 event with assets was processed post-deployment (prediction_id=42, a legacy bypassed prediction)
- All 27 real prediction events (5136-5175) were processed March 30, before PR #119 existed
- Snapshot capture works correctly when tested locally against production DB

## Test plan
- [x] All 6 market data worker tests pass (5 existing + 1 new warning test)
- [x] Backfill verified: 706 rows in `price_snapshots` table
- [x] `ruff check` and `ruff format` clean
- [ ] Monitor next `prediction_created` event for `snapshots_captured > 0` in result

🤖 Generated with [Claude Code](https://claude.com/claude-code)