### PR TITLE
feat: pipeline cohesion + live prices in feed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Live price quotes** — New `/api/prices/{symbol}/live` endpoint using yfinance fast_info (~300ms); `useLiveQuote()` TanStack Query hook polls every 15 seconds; PriceKPIs shows pulsing green dot when live data is active
+- **Inline snapshot capture** — Price snapshots now captured within seconds of LLM analysis (in analyzer's `_trigger_reactive_backfill`), down from 5-15 minutes via the market-data-worker cron hop; worker stays as idempotent safety net
+
 ### Fixed
 - **Price snapshot observability** — Added warning log when market-data-worker captures 0 snapshots despite having assets, preventing silent pipeline failures (#121)
 - **Price snapshot backfill** — Backfilled 706 price snapshots for 361 existing predictions that were processed before snapshot capture was deployed

--- a/api/routers/prices.py
+++ b/api/routers/prices.py
@@ -1,13 +1,36 @@
-"""Price data API router — OHLCV candles for charts."""
+"""Price data API router — OHLCV candles for charts + live quotes."""
 
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 
 from api.queries.price_queries import get_price_data
-from api.schemas.feed import PriceResponse
+from api.schemas.feed import LiveQuoteResponse, PriceResponse
 
 router = APIRouter()
+
+
+@router.get("/{symbol}/live", response_model=LiveQuoteResponse)
+def get_live_quote(symbol: str):
+    """Get the current live price for a symbol.
+
+    Uses yfinance fast_info for a lightweight single HTTP call (~300ms).
+    Returns 404 if the symbol is invalid or yfinance is unavailable.
+    """
+    from shit.market_data.yfinance_provider import fetch_live_quote
+
+    quote = fetch_live_quote(symbol.upper())
+    if quote is None:
+        raise HTTPException(status_code=404, detail=f"No quote available for {symbol}")
+    return LiveQuoteResponse(
+        symbol=quote.symbol,
+        price=quote.price,
+        previous_close=quote.previous_close,
+        day_high=quote.day_high,
+        day_low=quote.day_low,
+        volume=quote.volume,
+        captured_at=quote.captured_at.isoformat(),
+    )
 
 
 @router.get("/{symbol}", response_model=PriceResponse)

--- a/api/schemas/feed.py
+++ b/api/schemas/feed.py
@@ -148,6 +148,16 @@ class Candle(BaseModel):
     volume: int
 
 
+class LiveQuoteResponse(BaseModel):
+    symbol: str
+    price: float
+    previous_close: Optional[float] = None
+    day_high: Optional[float] = None
+    day_low: Optional[float] = None
+    volume: Optional[int] = None
+    captured_at: str
+
+
 class PriceResponse(BaseModel):
     symbol: str
     post_timestamp: Optional[str] = None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 /** API client — fetch wrapper with base URL handling. */
 
-import type { FeedResponse, PriceResponse } from "../types/api";
+import type { FeedResponse, LiveQuote, PriceResponse } from "../types/api";
 
 const BASE_URL = "";
 
@@ -24,4 +24,8 @@ export function fetchPriceData(
   const params = new URLSearchParams({ days: String(days) });
   if (postTimestamp) params.set("post_timestamp", postTimestamp);
   return fetchJson<PriceResponse>(`/api/prices/${symbol}?${params}`);
+}
+
+export function fetchLiveQuote(symbol: string): Promise<LiveQuote> {
+  return fetchJson<LiveQuote>(`/api/prices/${symbol}/live`);
 }

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { fetchFeedPost, fetchPriceData } from "./client";
+import { fetchFeedPost, fetchLiveQuote, fetchPriceData } from "./client";
 
 export function useFeedPost(offset: number) {
   return useQuery({
@@ -23,6 +23,16 @@ export function usePriceData(
     queryFn: () => fetchPriceData(symbol!, days, postTimestamp),
     staleTime: 5 * 60_000,
     enabled: !!symbol,
+  });
+}
+
+export function useLiveQuote(symbol: string | undefined) {
+  return useQuery({
+    queryKey: ["liveQuote", symbol],
+    queryFn: () => fetchLiveQuote(symbol!),
+    enabled: !!symbol,
+    staleTime: 10_000,
+    refetchInterval: 15_000,
   });
 }
 

--- a/frontend/src/components/PriceKPIs.tsx
+++ b/frontend/src/components/PriceKPIs.tsx
@@ -40,12 +40,23 @@ const changeRowStyle: CSSProperties = {
   borderTop: "1px solid var(--border-light)",
 };
 
+const liveDotStyle: CSSProperties = {
+  display: "inline-block",
+  width: "6px",
+  height: "6px",
+  borderRadius: "50%",
+  backgroundColor: "var(--color-money)",
+  marginRight: "5px",
+  animation: "livePulse 2s ease-in-out infinite",
+};
+
 interface Props {
   priceAtPost: number | null;
   currentPrice: number | null;
+  isLive?: boolean;
 }
 
-export function PriceKPIs({ priceAtPost, currentPrice }: Props) {
+export function PriceKPIs({ priceAtPost, currentPrice, isLive }: Props) {
   if (priceAtPost == null && currentPrice == null) return null;
 
   const hasChange = priceAtPost != null && currentPrice != null && priceAtPost !== 0;
@@ -63,13 +74,17 @@ export function PriceKPIs({ priceAtPost, currentPrice }: Props) {
 
   return (
     <div style={cardStyle}>
+      <style>{`@keyframes livePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }`}</style>
       <div style={rowStyle}>
         <div>
           <div style={labelStyle}>Price at Post</div>
           <div style={priceStyle}>{formatPrice(priceAtPost)}</div>
         </div>
         <div style={{ textAlign: "right" }}>
-          <div style={labelStyle}>Price Now</div>
+          <div style={labelStyle}>
+            {isLive && <span style={liveDotStyle} />}
+            Price Now
+          </div>
           <div style={priceStyle}>{formatPrice(currentPrice)}</div>
         </div>
       </div>

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, CSSProperties } from "react";
 import { useSearchParams } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { useFeedPost, usePrefetchAdjacentPosts, usePriceData } from "../api/hooks";
+import { useFeedPost, useLiveQuote, usePrefetchAdjacentPosts, usePriceData } from "../api/hooks";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
@@ -106,9 +106,11 @@ export function FeedPage() {
     timeframeToDays[timeframe],
     data?.post.timestamp,
   );
-  const currentPrice = priceQuery.data?.candles?.length
-    ? priceQuery.data.candles[priceQuery.data.candles.length - 1].close
-    : null;
+  const liveQuote = useLiveQuote(activeTicker || undefined);
+  const currentPrice = liveQuote.data?.price
+    ?? (priceQuery.data?.candles?.length
+      ? priceQuery.data.candles[priceQuery.data.candles.length - 1].close
+      : null);
 
   if (isLoading) {
     return (
@@ -178,6 +180,7 @@ export function FeedPage() {
                     ?? null
                   }
                   currentPrice={currentPrice}
+                  isLive={liveQuote.data != null}
                 />
 
                 <MetricBubbles outcome={activeOutcome} />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -135,6 +135,16 @@ export interface FeedResponse {
   navigation: Navigation;
 }
 
+export interface LiveQuote {
+  symbol: string;
+  price: number;
+  previous_close: number | null;
+  day_high: number | null;
+  day_low: number | null;
+  volume: number | null;
+  captured_at: string;
+}
+
 export interface Candle {
   date: string;
   open: number;

--- a/shit_tests/api/test_prices_router.py
+++ b/shit_tests/api/test_prices_router.py
@@ -293,3 +293,61 @@ def test_post_timestamp_between_dates_picks_earlier(client, mock_execute_query):
 
     assert response.status_code == 200
     assert response.json()["post_date_index"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/prices/{symbol}/live — live quote
+# ---------------------------------------------------------------------------
+
+
+def test_get_live_quote_happy_path(client, mock_execute_query):
+    """GET /api/prices/AAPL/live returns a live quote from yfinance."""
+    from datetime import datetime, timezone
+
+    mock_quote = type(
+        "LiveQuote",
+        (),
+        {
+            "symbol": "AAPL",
+            "price": 182.50,
+            "previous_close": 180.00,
+            "day_high": 183.00,
+            "day_low": 179.50,
+            "volume": 45000000,
+            "captured_at": datetime(2026, 4, 5, 14, 30, 0, tzinfo=timezone.utc),
+        },
+    )()
+
+    with patch(
+        "shit.market_data.yfinance_provider.fetch_live_quote", return_value=mock_quote
+    ):
+        response = client.get("/api/prices/AAPL/live")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "AAPL"
+    assert data["price"] == 182.50
+    assert data["previous_close"] == 180.00
+    assert data["day_high"] == 183.00
+    assert data["volume"] == 45000000
+    assert "captured_at" in data
+
+
+def test_get_live_quote_symbol_uppercased(client, mock_execute_query):
+    """GET /api/prices/aapl/live uppercases the symbol before fetching."""
+    with patch(
+        "shit.market_data.yfinance_provider.fetch_live_quote", return_value=None
+    ) as mock_fq:
+        client.get("/api/prices/aapl/live")
+    mock_fq.assert_called_once_with("AAPL")
+
+
+def test_get_live_quote_not_found(client, mock_execute_query):
+    """GET /api/prices/INVALID/live returns 404 when yfinance fails."""
+    with patch(
+        "shit.market_data.yfinance_provider.fetch_live_quote", return_value=None
+    ):
+        response = client.get("/api/prices/INVALID/live")
+
+    assert response.status_code == 404
+    assert "No quote available" in response.json()["detail"]

--- a/shit_tests/shitpost_ai/test_reactive_backfill.py
+++ b/shit_tests/shitpost_ai/test_reactive_backfill.py
@@ -9,12 +9,70 @@ import os
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 import pytest
-import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer
 
 BACKFILL_PATCH = "shitpost_ai.shitpost_analyzer.auto_backfill_prediction"
+SNAPSHOT_SVC_PATCH = "shit.market_data.snapshot_service.PriceSnapshotService"
+SESSION_PATCH = "shit.db.sync_session.SessionLocal"
+
+
+class TestCaptureSnapshots:
+    """Tests for ShitpostAnalyzer._capture_snapshots static method."""
+
+    def test_captures_snapshots_and_commits(self):
+        mock_session = MagicMock()
+        mock_svc = MagicMock()
+        mock_svc.capture_for_prediction.return_value = [MagicMock(), MagicMock()]
+
+        with (
+            patch(SESSION_PATCH, return_value=mock_session),
+            patch(SNAPSHOT_SVC_PATCH, return_value=mock_svc),
+        ):
+            result = ShitpostAnalyzer._capture_snapshots(42, ["AAPL", "TSLA"])
+
+        assert result == 2
+        mock_svc.capture_for_prediction.assert_called_once_with(
+            session=mock_session.__enter__(),
+            prediction_id=42,
+            assets=["AAPL", "TSLA"],
+            post_published_at=None,
+        )
+        mock_session.__enter__().commit.assert_called_once()
+
+    def test_passes_post_published_at(self):
+        from datetime import datetime
+
+        ts = datetime(2026, 3, 25, 14, 30, 0)
+        mock_session = MagicMock()
+        mock_svc = MagicMock()
+        mock_svc.capture_for_prediction.return_value = []
+
+        with (
+            patch(SESSION_PATCH, return_value=mock_session),
+            patch(SNAPSHOT_SVC_PATCH, return_value=mock_svc),
+        ):
+            ShitpostAnalyzer._capture_snapshots(42, ["AAPL"], post_published_at=ts)
+
+        mock_svc.capture_for_prediction.assert_called_once_with(
+            session=mock_session.__enter__(),
+            prediction_id=42,
+            assets=["AAPL"],
+            post_published_at=ts,
+        )
+
+    def test_propagates_exceptions(self):
+        mock_session = MagicMock()
+        mock_svc = MagicMock()
+        mock_svc.capture_for_prediction.side_effect = RuntimeError("db down")
+
+        with (
+            patch(SESSION_PATCH, return_value=mock_session),
+            patch(SNAPSHOT_SVC_PATCH, return_value=mock_svc),
+        ):
+            with pytest.raises(RuntimeError, match="db down"):
+                ShitpostAnalyzer._capture_snapshots(42, ["AAPL"])
 
 
 class TestTriggerReactiveBackfill:
@@ -30,38 +88,82 @@ class TestTriggerReactiveBackfill:
         return a
 
     @pytest.mark.asyncio
+    async def test_captures_snapshots_before_backfill(self, analyzer):
+        """Snapshot capture runs before backfill (most time-sensitive first)."""
+        call_order = []
+        with (
+            patch.object(
+                ShitpostAnalyzer,
+                "_capture_snapshots",
+                side_effect=lambda *a, **k: call_order.append("snapshot") or 2,
+            ),
+            patch(
+                BACKFILL_PATCH,
+                side_effect=lambda *a, **k: call_order.append("backfill") or True,
+            ),
+        ):
+            await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+        assert call_order == ["snapshot", "backfill"]
+
+    @pytest.mark.asyncio
     async def test_calls_auto_backfill_prediction_with_correct_id(self, analyzer):
-        with patch(BACKFILL_PATCH, return_value=True) as mock_bf:
+        with (
+            patch.object(ShitpostAnalyzer, "_capture_snapshots", return_value=0),
+            patch(BACKFILL_PATCH, return_value=True) as mock_bf,
+        ):
             await analyzer._trigger_reactive_backfill(42, ["AAPL", "TSLA"])
         mock_bf.assert_called_once_with(42)
 
     @pytest.mark.asyncio
+    async def test_snapshot_failure_does_not_block_backfill(self, analyzer):
+        """If snapshot capture fails, backfill should still run."""
+        with (
+            patch.object(
+                ShitpostAnalyzer,
+                "_capture_snapshots",
+                side_effect=RuntimeError("snap fail"),
+            ),
+            patch(BACKFILL_PATCH, return_value=True) as mock_bf,
+        ):
+            await analyzer._trigger_reactive_backfill(42, ["AAPL"])
+        mock_bf.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
     async def test_logs_success_on_backfill(self, analyzer):
-        with patch(BACKFILL_PATCH, return_value=True):
+        with (
+            patch.object(ShitpostAnalyzer, "_capture_snapshots", return_value=0),
+            patch(BACKFILL_PATCH, return_value=True),
+        ):
             with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
                 await analyzer._trigger_reactive_backfill(42, ["AAPL"])
-                # Should log info for successful backfill
                 mock_logger.info.assert_called()
 
     @pytest.mark.asyncio
     async def test_logs_debug_when_no_new_data_needed(self, analyzer):
-        with patch(BACKFILL_PATCH, return_value=False):
+        with (
+            patch.object(ShitpostAnalyzer, "_capture_snapshots", return_value=0),
+            patch(BACKFILL_PATCH, return_value=False),
+        ):
             with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
                 await analyzer._trigger_reactive_backfill(42, ["AAPL"])
                 mock_logger.debug.assert_called()
 
     @pytest.mark.asyncio
     async def test_catches_exception_and_logs_warning(self, analyzer):
-        with patch(BACKFILL_PATCH, side_effect=Exception("boom")):
+        with (
+            patch.object(ShitpostAnalyzer, "_capture_snapshots", return_value=0),
+            patch(BACKFILL_PATCH, side_effect=Exception("boom")),
+        ):
             with patch("shitpost_ai.shitpost_analyzer.logger") as mock_logger:
-                # Should not raise
                 await analyzer._trigger_reactive_backfill(42, ["AAPL"])
                 mock_logger.warning.assert_called()
 
     @pytest.mark.asyncio
     async def test_does_not_propagate_backfill_errors(self, analyzer):
-        with patch(BACKFILL_PATCH, side_effect=RuntimeError("db down")):
-            # This should not raise any exceptions
+        with (
+            patch.object(ShitpostAnalyzer, "_capture_snapshots", return_value=0),
+            patch(BACKFILL_PATCH, side_effect=RuntimeError("db down")),
+        ):
             await analyzer._trigger_reactive_backfill(42, ["AAPL"])
 
 
@@ -105,16 +207,20 @@ class TestAnalyzeShitpostReactiveIntegration:
         analyzer.llm_client.analyze.return_value = analysis
         analyzer.prediction_ops.store_analysis.return_value = "42"
 
-        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+        with patch.object(
+            analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock
+        ) as mock_bf:
             await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
-            mock_bf.assert_called_once_with(42, ["AAPL"])
+            mock_bf.assert_called_once_with(42, ["AAPL"], post_published_at=None)
 
     @pytest.mark.asyncio
     async def test_does_not_trigger_backfill_on_dry_run(self, analyzer):
         analysis = {"assets": ["AAPL"], "confidence": 0.85}
         analyzer.llm_client.analyze.return_value = analysis
 
-        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+        with patch.object(
+            analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock
+        ) as mock_bf:
             await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=True)
             mock_bf.assert_not_called()
 
@@ -124,7 +230,9 @@ class TestAnalyzeShitpostReactiveIntegration:
         analyzer.llm_client.analyze.return_value = analysis
         analyzer.prediction_ops.store_analysis.return_value = "42"
 
-        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+        with patch.object(
+            analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock
+        ) as mock_bf:
             await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
             mock_bf.assert_not_called()
 
@@ -134,7 +242,9 @@ class TestAnalyzeShitpostReactiveIntegration:
         analyzer.llm_client.analyze.return_value = analysis
         analyzer.prediction_ops.store_analysis.return_value = None
 
-        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
+        with patch.object(
+            analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock
+        ) as mock_bf:
             await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
             mock_bf.assert_not_called()
 
@@ -143,7 +253,11 @@ class TestAnalyzeShitpostReactiveIntegration:
         analyzer.bypass_service.should_bypass_post.return_value = (True, "retruth")
         analyzer.prediction_ops.handle_no_text_prediction = AsyncMock()
 
-        with patch.object(analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock) as mock_bf:
-            result = await analyzer._analyze_shitpost(self._make_shitpost(), dry_run=False)
+        with patch.object(
+            analyzer, "_trigger_reactive_backfill", new_callable=AsyncMock
+        ) as mock_bf:
+            result = await analyzer._analyze_shitpost(
+                self._make_shitpost(), dry_run=False
+            )
             mock_bf.assert_not_called()
             assert result["analysis_status"] == "bypassed"

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -22,10 +22,17 @@ logger = get_service_logger("analyzer")
 
 class ShitpostAnalyzer:
     """Analyzes shitposts for financial implications with enhanced context."""
-    
-    def __init__(self, mode="incremental", start_date=None, end_date=None, limit=None, batch_size=5):
+
+    def __init__(
+        self,
+        mode="incremental",
+        start_date=None,
+        end_date=None,
+        limit=None,
+        batch_size=5,
+    ):
         """Initialize the shitpost analyzer.
-        
+
         Args:
             mode: Analysis mode - "incremental", "backfill", "range"
             start_date: Start date for range mode (YYYY-MM-DD)
@@ -40,7 +47,7 @@ class ShitpostAnalyzer:
         self.db_ops = None  # Will be initialized in initialize()
         self.shitpost_ops = None  # Will be initialized in initialize()
         self.prediction_ops = None  # Will be initialized in initialize()
-        
+
         self.llm_client = LLMClient()
         self.bypass_service = BypassService()
         self.launch_date = settings.SYSTEM_LAUNCH_DATE
@@ -51,7 +58,7 @@ class ShitpostAnalyzer:
         self.end_date = end_date
         self.limit = limit
         self.batch_size = batch_size
-        
+
         # Parse dates if provided
         if start_date:
             self.start_datetime = datetime.fromisoformat(start_date)
@@ -61,7 +68,7 @@ class ShitpostAnalyzer:
             # Default end_date to today for range mode
             self.end_datetime = datetime.now()
             self.end_date = self.end_datetime.strftime("%Y-%m-%d")
-        
+
     async def initialize(self):
         """Initialize the shitpost analyzer."""
         logger.info("")
@@ -82,16 +89,18 @@ class ShitpostAnalyzer:
         # Initialize LLM client
         await self.llm_client.initialize()
 
-        logger.info(f"Shitpost Analyzer initialized with launch date: {self.launch_date}")
+        logger.info(
+            f"Shitpost Analyzer initialized with launch date: {self.launch_date}"
+        )
         logger.info("✅ Analyzer initialized successfully")
         logger.info("")
-    
+
     async def analyze_shitposts(self, dry_run: bool = False) -> int:
         """Analyze shitposts based on configured mode.
-        
+
         Args:
             dry_run: If True, don't actually store results to database
-            
+
         Returns:
             Number of posts analyzed
         """
@@ -100,188 +109,233 @@ class ShitpostAnalyzer:
         logger.info("ANALYZING SHITPOSTS")
         logger.info("═══════════════════════════════════════════════════════════")
         logger.info(f"Starting shitpost analysis in {self.mode} mode...")
-        
+
         if self.mode == "backfill":
             result = await self._analyze_backfill(dry_run)
         elif self.mode == "range":
             result = await self._analyze_date_range(dry_run)
         else:  # incremental (default)
             result = await self._analyze_incremental(dry_run)
-        
+
         logger.info("")
         logger.info("═══════════════════════════════════════════════════════════")
         logger.info("ANALYSIS COMPLETED")
         logger.info("═══════════════════════════════════════════════════════════")
         logger.info(f"Total posts analyzed: {result}")
-        
+
         return result
-    
+
     async def _analyze_backfill(self, dry_run: bool = False) -> int:
         """Analyze all unprocessed shitposts from launch date onwards."""
         logger.info("Starting full backfill analysis of unprocessed shitposts...")
         logger.info(f"Launch date filter: {self.launch_date}")
-        
+
         total_analyzed = 0
         batch_number = 0
-        
+
         while True:
             try:
                 batch_number += 1
-                print(f"🔄 Batch {batch_number}: Fetching {self.batch_size} unprocessed shitposts...")
-                
+                print(
+                    f"🔄 Batch {batch_number}: Fetching {self.batch_size} unprocessed shitposts..."
+                )
+
                 # Get batch of unprocessed shitposts
                 shitposts = await self.shitpost_ops.get_unprocessed_shitposts(
-                    launch_date=self.launch_date,
-                    limit=self.batch_size
+                    launch_date=self.launch_date, limit=self.batch_size
                 )
-                
+
                 if not shitposts:
-                    print("✅ No more unprocessed shitposts found for backfill analysis")
+                    print(
+                        "✅ No more unprocessed shitposts found for backfill analysis"
+                    )
                     break
-                
+
                 # Show date range of this batch
-                timestamps = [s.get('timestamp') for s in shitposts if s.get('timestamp')]
+                timestamps = [
+                    s.get("timestamp") for s in shitposts if s.get("timestamp")
+                ]
                 if timestamps:
                     latest_date = max(timestamps)
                     earliest_date = min(timestamps)
-                    print(f"📅 Batch {batch_number} date range: {earliest_date} to {latest_date}")
-                
+                    print(
+                        f"📅 Batch {batch_number} date range: {earliest_date} to {latest_date}"
+                    )
+
                 print(f"📊 Batch {batch_number}: Processing {len(shitposts)} posts...")
-                
+
                 # Analyze batch
-                batch_analyzed = await self._analyze_batch(shitposts, dry_run, batch_number)
+                batch_analyzed = await self._analyze_batch(
+                    shitposts, dry_run, batch_number
+                )
                 total_analyzed += batch_analyzed
-                
-                print(f"✅ Batch {batch_number} completed: {batch_analyzed}/{len(shitposts)} posts analyzed (Total: {total_analyzed})")
-                
+
+                print(
+                    f"✅ Batch {batch_number} completed: {batch_analyzed}/{len(shitposts)} posts analyzed (Total: {total_analyzed})"
+                )
+
                 # Check if we've reached the limit
                 if self.limit and total_analyzed >= self.limit:
                     print(f"🛑 Reached analysis limit of {self.limit} posts")
                     break
-                
+
                 # Small delay to be respectful to LLM API
                 await asyncio.sleep(1)
-                
+
             except Exception as e:
                 logger.error(f"❌ Error in backfill analysis batch {batch_number}: {e}")
                 await handle_exceptions(e)
                 break
-        
-        logger.info(f"🎉 Backfill analysis completed! Total posts analyzed: {total_analyzed}")
+
+        logger.info(
+            f"🎉 Backfill analysis completed! Total posts analyzed: {total_analyzed}"
+        )
         return total_analyzed
-    
+
     async def _analyze_date_range(self, dry_run: bool = False) -> int:
         """Analyze shitposts within a specific date range."""
-        logger.info(f"Starting date range analysis from {self.start_date} to {self.end_date}")
+        logger.info(
+            f"Starting date range analysis from {self.start_date} to {self.end_date}"
+        )
         logger.info(f"Launch date filter: {self.launch_date}")
-        
+
         total_analyzed = 0
         batch_number = 0
-        
+
         while True:
             try:
                 batch_number += 1
-                logger.info(f"🔄 Batch {batch_number}: Fetching {self.batch_size} unprocessed shitposts...")
-                
+                logger.info(
+                    f"🔄 Batch {batch_number}: Fetching {self.batch_size} unprocessed shitposts..."
+                )
+
                 # Get batch of unprocessed shitposts
                 shitposts = await self.shitpost_ops.get_unprocessed_shitposts(
-                    launch_date=self.launch_date,
-                    limit=self.batch_size
+                    launch_date=self.launch_date, limit=self.batch_size
                 )
-                
+
                 if not shitposts:
-                    logger.info("✅ No more unprocessed shitposts found for date range analysis")
+                    logger.info(
+                        "✅ No more unprocessed shitposts found for date range analysis"
+                    )
                     break
-                
+
                 # Show date range of this batch
-                timestamps = [s.get('timestamp') for s in shitposts if s.get('timestamp')]
+                timestamps = [
+                    s.get("timestamp") for s in shitposts if s.get("timestamp")
+                ]
                 if timestamps:
                     latest_date = max(timestamps)
                     earliest_date = min(timestamps)
-                    logger.info(f"📅 Batch {batch_number} date range: {earliest_date} to {latest_date}")
-                
+                    logger.info(
+                        f"📅 Batch {batch_number} date range: {earliest_date} to {latest_date}"
+                    )
+
                 # Filter shitposts by date range
                 filtered_shitposts = []
                 for shitpost in shitposts:
-                    post_timestamp = shitpost.get('timestamp')
+                    post_timestamp = shitpost.get("timestamp")
                     if post_timestamp:
                         if isinstance(post_timestamp, str):
-                            post_datetime = datetime.fromisoformat(post_timestamp.replace('Z', '+00:00'))
+                            post_datetime = datetime.fromisoformat(
+                                post_timestamp.replace("Z", "+00:00")
+                            )
                         else:
                             post_datetime = post_timestamp
-                        
+
                         # Check if post is within date range
                         if self.start_datetime <= post_datetime <= self.end_datetime:
                             filtered_shitposts.append(shitpost)
                         elif post_datetime < self.start_datetime:
                             # If we've reached posts before the start date, we can stop
-                            logger.info(f"🛑 Reached posts before start date {self.start_date}, stopping analysis")
+                            logger.info(
+                                f"🛑 Reached posts before start date {self.start_date}, stopping analysis"
+                            )
                             break
-                
+
                 if not filtered_shitposts:
-                    logger.info(f"⏭️  Batch {batch_number}: No shitposts found in specified date range")
+                    logger.info(
+                        f"⏭️  Batch {batch_number}: No shitposts found in specified date range"
+                    )
                     continue
-                
-                logger.info(f"📊 Batch {batch_number}: Processing {len(filtered_shitposts)} posts in date range...")
-                
+
+                logger.info(
+                    f"📊 Batch {batch_number}: Processing {len(filtered_shitposts)} posts in date range..."
+                )
+
                 # Analyze filtered batch
-                batch_analyzed = await self._analyze_batch(filtered_shitposts, dry_run, batch_number)
+                batch_analyzed = await self._analyze_batch(
+                    filtered_shitposts, dry_run, batch_number
+                )
                 total_analyzed += batch_analyzed
-                
-                logger.info(f"✅ Batch {batch_number} completed: {batch_analyzed}/{len(filtered_shitposts)} posts analyzed (Total: {total_analyzed})")
-                
+
+                logger.info(
+                    f"✅ Batch {batch_number} completed: {batch_analyzed}/{len(filtered_shitposts)} posts analyzed (Total: {total_analyzed})"
+                )
+
                 # Check if we've reached the limit
                 if self.limit and total_analyzed >= self.limit:
                     logger.info(f"🛑 Reached analysis limit of {self.limit} posts")
                     break
-                
+
                 # Small delay to be respectful to LLM API
                 await asyncio.sleep(1)
-                
+
             except Exception as e:
-                logger.error(f"❌ Error in date range analysis batch {batch_number}: {e}")
+                logger.error(
+                    f"❌ Error in date range analysis batch {batch_number}: {e}"
+                )
                 await handle_exceptions(e)
                 break
-        
-        logger.info(f"🎉 Date range analysis completed! Total posts analyzed: {total_analyzed}")
+
+        logger.info(
+            f"🎉 Date range analysis completed! Total posts analyzed: {total_analyzed}"
+        )
         return total_analyzed
-    
+
     async def _analyze_incremental(self, dry_run: bool = False) -> int:
         """Analyze only new unprocessed shitposts (incremental mode)."""
         logger.info("Starting incremental analysis of new unprocessed shitposts...")
-        
+
         try:
             # Get batch of unprocessed shitposts
             shitposts = await self.shitpost_ops.get_unprocessed_shitposts(
-                launch_date=self.launch_date,
-                limit=self.batch_size
+                launch_date=self.launch_date, limit=self.batch_size
             )
-            
-            logger.info(f"Retrieved {len(shitposts) if shitposts else 0} unprocessed shitposts for incremental analysis")
-            
+
+            logger.info(
+                f"Retrieved {len(shitposts) if shitposts else 0} unprocessed shitposts for incremental analysis"
+            )
+
             if not shitposts:
-                logger.info("No new unprocessed shitposts found for incremental analysis")
+                logger.info(
+                    "No new unprocessed shitposts found for incremental analysis"
+                )
                 return 0
-            
+
             # Analyze batch
             total_analyzed = await self._analyze_batch(shitposts, dry_run)
-            
-            logger.info(f"Incremental analysis completed. Total posts analyzed: {total_analyzed}")
+
+            logger.info(
+                f"Incremental analysis completed. Total posts analyzed: {total_analyzed}"
+            )
             return total_analyzed
-            
+
         except Exception as e:
             logger.error(f"Error in incremental analysis: {e}")
             await handle_exceptions(e)
             return 0
-    
-    async def _analyze_batch(self, shitposts: List[Dict], dry_run: bool = False, batch_number: int = 0) -> int:
+
+    async def _analyze_batch(
+        self, shitposts: List[Dict], dry_run: bool = False, batch_number: int = 0
+    ) -> int:
         """Analyze a batch of shitposts.
-        
+
         Args:
             shitposts: List of shitpost dictionaries
             dry_run: If True, don't actually store results to database
             batch_number: Batch number for logging
-            
+
         Returns:
             Number of posts successfully analyzed
         """
@@ -289,104 +343,130 @@ class ShitpostAnalyzer:
         skipped_count = 0
         bypassed_count = 0
         failed_count = 0
-        
+
         for i, shitpost in enumerate(shitposts, 1):
             try:
                 # Check if prediction already exists (deduplication)
-                shitpost_id = shitpost.get('shitpost_id')
+                shitpost_id = shitpost.get("shitpost_id")
                 if not shitpost_id:
-                    logger.warning(f"⚠️  Post {i}/{len(shitposts)}: Missing ID, skipping")
+                    logger.warning(
+                        f"⚠️  Post {i}/{len(shitposts)}: Missing ID, skipping"
+                    )
                     skipped_count += 1
                     continue
-                
+
                 if await self.prediction_ops.check_prediction_exists(shitpost_id):
-                    print(f"⏭️  Post {i}/{len(shitposts)}: {shitpost_id} already analyzed, skipping")
+                    print(
+                        f"⏭️  Post {i}/{len(shitposts)}: {shitpost_id} already analyzed, skipping"
+                    )
                     skipped_count += 1
                     continue
-                
+
                 # Show post info
-                post_date = shitpost.get('timestamp', 'Unknown')
-                post_text = shitpost.get('text', '')[:50] + "..." if len(shitpost.get('text', '')) > 50 else shitpost.get('text', '')
-                print(f"🔍 Post {i}/{len(shitposts)}: {shitpost_id} ({post_date}) - {post_text}")
-                
+                post_date = shitpost.get("timestamp", "Unknown")
+                post_text = (
+                    shitpost.get("text", "")[:50] + "..."
+                    if len(shitpost.get("text", "")) > 50
+                    else shitpost.get("text", "")
+                )
+                print(
+                    f"🔍 Post {i}/{len(shitposts)}: {shitpost_id} ({post_date}) - {post_text}"
+                )
+
                 # Analyze shitpost
                 analysis = await self._analyze_shitpost(shitpost, dry_run)
-                
+
                 if analysis:
-                    if analysis.get('analysis_status') == 'bypassed':
+                    if analysis.get("analysis_status") == "bypassed":
                         bypassed_count += 1
-                        reason = analysis.get('analysis_comment', 'Unknown')
-                        print(f"⏭️  Post {i}/{len(shitposts)}: {shitpost_id} bypassed - {reason}")
+                        reason = analysis.get("analysis_comment", "Unknown")
+                        print(
+                            f"⏭️  Post {i}/{len(shitposts)}: {shitpost_id} bypassed - {reason}"
+                        )
                     else:
                         analyzed_count += 1
-                        assets = analysis.get('assets', [])
-                        confidence = analysis.get('confidence', 0.0)
-                        print(f"✅ Post {i}/{len(shitposts)}: {shitpost_id} analyzed - Assets: {assets}, Confidence: {confidence:.1%}")
+                        assets = analysis.get("assets", [])
+                        confidence = analysis.get("confidence", 0.0)
+                        print(
+                            f"✅ Post {i}/{len(shitposts)}: {shitpost_id} analyzed - Assets: {assets}, Confidence: {confidence:.1%}"
+                        )
                 else:
                     failed_count += 1
-                    print(f"❌ Post {i}/{len(shitposts)}: {shitpost_id} failed to analyze")
-                
+                    print(
+                        f"❌ Post {i}/{len(shitposts)}: {shitpost_id} failed to analyze"
+                    )
+
             except Exception as e:
                 failed_count += 1
-                logger.error(f"❌ Post {i}/{len(shitposts)}: Error analyzing {shitpost.get('shitpost_id', 'unknown')}: {e}")
+                logger.error(
+                    f"❌ Post {i}/{len(shitposts)}: Error analyzing {shitpost.get('shitpost_id', 'unknown')}: {e}"
+                )
                 continue
-        
+
         # Summary for this batch
-        print(f"📊 Batch {batch_number} summary: {analyzed_count} analyzed, {bypassed_count} bypassed, {skipped_count} skipped, {failed_count} failed")
-        
+        print(
+            f"📊 Batch {batch_number} summary: {analyzed_count} analyzed, {bypassed_count} bypassed, {skipped_count} skipped, {failed_count} failed"
+        )
+
         return analyzed_count
-    
-    async def _analyze_shitpost(self, shitpost: Dict, dry_run: bool = False) -> Optional[Dict]:
+
+    async def _analyze_shitpost(
+        self, shitpost: Dict, dry_run: bool = False
+    ) -> Optional[Dict]:
         """Analyze a single shitpost for financial implications.
-        
+
         Args:
             shitpost: Shitpost dictionary
             dry_run: If True, don't actually store results to database
-            
+
         Returns:
             Analysis result dictionary or None if failed
         """
         try:
-            shitpost_id = shitpost.get('shitpost_id')
+            shitpost_id = shitpost.get("shitpost_id")
             if not shitpost_id:
                 logger.warning("Shitpost missing ID, cannot analyze")
                 return None
-            
+
             # Check if post should be bypassed using unified bypass service
-            should_bypass, bypass_reason = self.bypass_service.should_bypass_post(shitpost)
+            should_bypass, bypass_reason = self.bypass_service.should_bypass_post(
+                shitpost
+            )
 
             if should_bypass:
                 logger.info(f"Bypassing shitpost {shitpost_id}: {bypass_reason}")
 
                 if not dry_run:
                     # Create bypassed prediction record
-                    await self.prediction_ops.handle_no_text_prediction(shitpost_id, shitpost, bypass_reason)
+                    await self.prediction_ops.handle_no_text_prediction(
+                        shitpost_id, shitpost, bypass_reason
+                    )
 
                 return {
-                    'shitpost_id': shitpost_id,
-                    'analysis_status': 'bypassed',
-                    'analysis_comment': str(bypass_reason)
+                    "shitpost_id": shitpost_id,
+                    "analysis_status": "bypassed",
+                    "analysis_comment": str(bypass_reason),
                 }
-            
+
             # Prepare enhanced content for LLM analysis
             enhanced_content = self._prepare_enhanced_content(shitpost)
-            
+
             # Analyze with LLM
             analysis = await self.llm_client.analyze(enhanced_content)
-            
+
             if not analysis:
                 logger.warning(f"LLM analysis failed for shitpost {shitpost_id}")
                 return None
-            
+
             # Enhance analysis with shitpost data
-            enhanced_analysis = self._enhance_analysis_with_shitpost_data(analysis, shitpost)
-            
+            enhanced_analysis = self._enhance_analysis_with_shitpost_data(
+                analysis, shitpost
+            )
+
             if not dry_run:
                 # Store analysis in database
                 analysis_id = await self.prediction_ops.store_analysis(
-                    shitpost_id,
-                    enhanced_analysis,
-                    shitpost
+                    shitpost_id, enhanced_analysis, shitpost
                 )
 
                 if analysis_id:
@@ -395,7 +475,9 @@ class ShitpostAnalyzer:
                     # Emit event for downstream consumers
                     assets = enhanced_analysis.get("assets", [])
                     confidence = enhanced_analysis.get("confidence", 0.0)
-                    analysis_status = enhanced_analysis.get("analysis_status", "completed")
+                    analysis_status = enhanced_analysis.get(
+                        "analysis_status", "completed"
+                    )
                     try:
                         from shit.events.producer import emit_event
                         from shit.events.event_types import EventType
@@ -404,7 +486,9 @@ class ShitpostAnalyzer:
                         post_published = (
                             post_ts.isoformat()
                             if hasattr(post_ts, "isoformat")
-                            else str(post_ts) if post_ts else None
+                            else str(post_ts)
+                            if post_ts
+                            else None
                         )
                         emit_event(
                             event_type=EventType.PREDICTION_CREATED,
@@ -422,23 +506,33 @@ class ShitpostAnalyzer:
                     except Exception as e:
                         logger.warning(f"Failed to emit prediction_created event: {e}")
 
-                    # Reactively trigger market data backfill for new tickers
+                    # Reactively capture price snapshots + backfill for new tickers
                     if assets:
                         try:
                             pred_id = int(analysis_id)
                         except (ValueError, TypeError):
                             pred_id = None
                         if pred_id is not None:
-                            await self._trigger_reactive_backfill(pred_id, assets)
+                            post_ts = shitpost.get("timestamp")
+                            post_pub = (
+                                post_ts if hasattr(post_ts, "isoformat") else None
+                            )
+                            await self._trigger_reactive_backfill(
+                                pred_id, assets, post_published_at=post_pub
+                            )
                 else:
-                    logger.warning(f"Failed to store analysis for shitpost {shitpost_id}")
+                    logger.warning(
+                        f"Failed to store analysis for shitpost {shitpost_id}"
+                    )
 
             return enhanced_analysis
-            
+
         except Exception as e:
-            logger.error(f"Error analyzing shitpost {shitpost.get('shitpost_id', 'unknown')}: {e}")
+            logger.error(
+                f"Error analyzing shitpost {shitpost.get('shitpost_id', 'unknown')}: {e}"
+            )
             return None
-    
+
     def _prepare_enhanced_content(self, signal_data: Dict) -> str:
         """Prepare enhanced content for LLM analysis.
 
@@ -451,85 +545,120 @@ class ShitpostAnalyzer:
         Returns:
             Enhanced content string
         """
-        content = signal_data.get('text', '')
-        username = signal_data.get('author_username', signal_data.get('username', ''))
-        timestamp = signal_data.get('published_at', signal_data.get('timestamp', ''))
-        source = signal_data.get('source', signal_data.get('platform', 'unknown'))
+        content = signal_data.get("text", "")
+        username = signal_data.get("author_username", signal_data.get("username", ""))
+        timestamp = signal_data.get("published_at", signal_data.get("timestamp", ""))
+        source = signal_data.get("source", signal_data.get("platform", "unknown"))
 
         # Engagement metrics (generic names with fallback)
-        replies = signal_data.get('replies_count', 0)
-        shares = signal_data.get('shares_count', signal_data.get('reblogs_count', 0))
-        likes = signal_data.get('likes_count', signal_data.get('favourites_count', 0))
+        replies = signal_data.get("replies_count", 0)
+        shares = signal_data.get("shares_count", signal_data.get("reblogs_count", 0))
+        likes = signal_data.get("likes_count", signal_data.get("favourites_count", 0))
 
         # Account information (generic names with fallback)
-        verified = signal_data.get('author_verified', signal_data.get('account_verified', False))
-        followers = signal_data.get('author_followers', signal_data.get('account_followers_count', 0))
+        verified = signal_data.get(
+            "author_verified", signal_data.get("account_verified", False)
+        )
+        followers = signal_data.get(
+            "author_followers", signal_data.get("account_followers_count", 0)
+        )
 
         # Media information
-        has_media = signal_data.get('has_media', False)
-        mentions = signal_data.get('mentions', [])
+        has_media = signal_data.get("has_media", False)
+        mentions = signal_data.get("mentions", [])
         mentions_count = len(mentions) if isinstance(mentions, list) else 0
-        tags = signal_data.get('tags', [])
+        tags = signal_data.get("tags", [])
         tags_count = len(tags) if isinstance(tags, list) else 0
 
         # Build enhanced content
         enhanced_content = f"Content: {content}\n"
         enhanced_content += f"Source: {source}\n"
-        enhanced_content += f"Author: {username} (Verified: {verified}, Followers: {followers:,})\n"
+        enhanced_content += (
+            f"Author: {username} (Verified: {verified}, Followers: {followers:,})\n"
+        )
         enhanced_content += f"Timestamp: {timestamp}\n"
-        enhanced_content += f"Engagement: {replies} replies, {shares} shares, {likes} likes\n"
+        enhanced_content += (
+            f"Engagement: {replies} replies, {shares} shares, {likes} likes\n"
+        )
         enhanced_content += f"Media: {'Yes' if has_media else 'No'}, Mentions: {mentions_count}, Tags: {tags_count}"
 
         return enhanced_content
-    
-    def _enhance_analysis_with_shitpost_data(self, analysis: Dict, shitpost: Dict) -> Dict:
+
+    def _enhance_analysis_with_shitpost_data(
+        self, analysis: Dict, shitpost: Dict
+    ) -> Dict:
         """Enhance LLM analysis with additional shitpost data.
-        
+
         Args:
             analysis: LLM analysis result
             shitpost: Original shitpost data
-            
+
         Returns:
             Enhanced analysis dictionary
         """
         enhanced_analysis = analysis.copy()
-        
-        # Add engagement metrics
-        enhanced_analysis['engagement_metrics'] = {
-            'replies': shitpost.get('replies_count', 0),
-            'reblogs': shitpost.get('reblogs_count', 0),
-            'favourites': shitpost.get('favourites_count', 0),
-            'upvotes': shitpost.get('upvotes_count', 0)
-        }
-        
-        # Add account information
-        enhanced_analysis['account_info'] = {
-            'username': shitpost.get('username', ''),
-            'verified': shitpost.get('account_verified', False),
-            'followers': shitpost.get('account_followers_count', 0)
-        }
-        
-        # Add content metadata
-        enhanced_analysis['content_metadata'] = {
-            'has_media': shitpost.get('has_media', False),
-            'mentions_count': len(shitpost.get('mentions', [])),
-            'tags_count': len(shitpost.get('tags', [])),
-            'content_length': len(shitpost.get('text', ''))
-        }
-        
-        return enhanced_analysis
-    
-    async def _trigger_reactive_backfill(self, prediction_id: int, assets: list) -> None:
-        """Trigger market data backfill for new tickers found in a prediction.
 
-        Runs the synchronous backfill service in a thread executor to avoid
-        blocking the async event loop. Failures are logged but do not
-        propagate -- the prediction was already stored successfully.
+        # Add engagement metrics
+        enhanced_analysis["engagement_metrics"] = {
+            "replies": shitpost.get("replies_count", 0),
+            "reblogs": shitpost.get("reblogs_count", 0),
+            "favourites": shitpost.get("favourites_count", 0),
+            "upvotes": shitpost.get("upvotes_count", 0),
+        }
+
+        # Add account information
+        enhanced_analysis["account_info"] = {
+            "username": shitpost.get("username", ""),
+            "verified": shitpost.get("account_verified", False),
+            "followers": shitpost.get("account_followers_count", 0),
+        }
+
+        # Add content metadata
+        enhanced_analysis["content_metadata"] = {
+            "has_media": shitpost.get("has_media", False),
+            "mentions_count": len(shitpost.get("mentions", [])),
+            "tags_count": len(shitpost.get("tags", [])),
+            "content_length": len(shitpost.get("text", "")),
+        }
+
+        return enhanced_analysis
+
+    async def _trigger_reactive_backfill(
+        self, prediction_id: int, assets: list, post_published_at=None
+    ) -> None:
+        """Capture price snapshots and trigger market data backfill.
+
+        Captures live price snapshots first (most time-sensitive), then
+        runs the synchronous backfill service. Both run in a thread
+        executor to avoid blocking the async event loop. Failures are
+        logged but do not propagate.
 
         Args:
             prediction_id: ID of the newly created prediction
             assets: List of ticker symbols from the prediction
+            post_published_at: When the post was published (for snapshot metadata)
         """
+        # Capture live price snapshots FIRST (most time-sensitive)
+        try:
+            captured = await asyncio.to_thread(
+                self._capture_snapshots, prediction_id, assets, post_published_at
+            )
+            if captured:
+                logger.info(
+                    f"Inline snapshot capture: {captured} snapshots for prediction {prediction_id}",
+                    extra={"prediction_id": prediction_id, "snapshots": captured},
+                )
+        except Exception as e:
+            logger.warning(
+                f"Inline snapshot capture failed for prediction {prediction_id}: {e}",
+                extra={
+                    "prediction_id": prediction_id,
+                    "assets": assets,
+                    "error": str(e),
+                },
+            )
+
+        # Then backfill historical data + calculate outcomes
         try:
             result = await asyncio.to_thread(
                 auto_backfill_prediction,
@@ -551,12 +680,42 @@ class ShitpostAnalyzer:
             # Never let backfill failure break the analysis pipeline
             logger.warning(
                 f"Reactive backfill failed for prediction {prediction_id}: {e}",
-                extra={"prediction_id": prediction_id, "assets": assets, "error": str(e)},
+                extra={
+                    "prediction_id": prediction_id,
+                    "assets": assets,
+                    "error": str(e),
+                },
             )
+
+    @staticmethod
+    def _capture_snapshots(
+        prediction_id: int, assets: list, post_published_at=None
+    ) -> int:
+        """Capture live price snapshots for a prediction's assets.
+
+        Called synchronously from a thread executor. The market-data-worker
+        serves as an idempotent safety net if this fails.
+
+        Returns:
+            Number of snapshots successfully captured.
+        """
+        from shit.db.sync_session import SessionLocal
+        from shit.market_data.snapshot_service import PriceSnapshotService
+
+        with SessionLocal() as session:
+            svc = PriceSnapshotService()
+            snapshots = svc.capture_for_prediction(
+                session=session,
+                prediction_id=prediction_id,
+                assets=assets,
+                post_published_at=post_published_at,
+            )
+            session.commit()
+            return len(snapshots)
 
     async def cleanup(self):
         """Cleanup analyzer resources."""
-        if hasattr(self, 'session') and self.session:
+        if hasattr(self, "session") and self.session:
             await self.session.close()
         if self.db_client:
             await self.db_client.cleanup()


### PR DESCRIPTION
## Summary
- **Inline snapshot capture** — Price snapshots now captured within seconds of LLM analysis (in the analyzer's `_trigger_reactive_backfill`), down from 5-15 minutes via the market-data-worker cron hop. The worker stays as an idempotent safety net.
- **Live price API** — New `GET /api/prices/{symbol}/live` endpoint using `fetch_live_quote()` (~300ms via yfinance fast_info)
- **Frontend polling** — `useLiveQuote()` TanStack Query hook polls every 15 seconds. "Price Now" shows real market data with a pulsing green live indicator. Falls back to chart candle close when unavailable.

## Pipeline latency improvement
```
BEFORE: Post → Harvest(5m) → S3(5m) → Analyze(5m) → Snapshot(5m) = 20 min
AFTER:  Post → Harvest(5m) → S3(5m) → Analyze+Snapshot(seconds) = 10 min
```

## Test plan
- [x] 135 analyzer tests pass (15 reactive backfill tests including 5 new)
- [x] 84 API tests pass (14 price router tests including 3 new live quote tests)
- [x] Frontend builds cleanly (`npm run build`)
- [x] `ruff check` and `ruff format` clean
- [ ] Verify live quote polling in browser (15s interval)
- [ ] Monitor next prediction for inline snapshot capture in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)