### PR TITLE
feat: visible timestamps, price tooltips, and closer nav arrows

### DIFF
--- a/frontend/src/components/NavigationArrows.tsx
+++ b/frontend/src/components/NavigationArrows.tsx
@@ -40,7 +40,7 @@ export function NavigationArrows({ hasNewer, hasOlder, onNewer, onOlder }: Props
         className="nav-arrow"
         style={{
           ...arrowBase,
-          left: "12px",
+          left: "calc(50% - 368px)",
           ...(hasNewer ? {} : disabledStyle),
         }}
         onClick={onNewer}
@@ -56,7 +56,7 @@ export function NavigationArrows({ hasNewer, hasOlder, onNewer, onOlder }: Props
         className="nav-arrow"
         style={{
           ...arrowBase,
-          right: "12px",
+          right: "calc(50% - 368px)",
           ...(hasOlder ? {} : disabledStyle),
         }}
         onClick={onOlder}

--- a/frontend/src/components/PriceKPIs.tsx
+++ b/frontend/src/components/PriceKPIs.tsx
@@ -1,5 +1,6 @@
-import { CSSProperties, useEffect, useRef, useState } from "react";
+import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 import { formatPrice, formatDollar, formatPercent } from "../utils/format";
+import { formatTimestamp } from "../utils/time";
 
 const cardStyle: CSSProperties = {
   background: "var(--bg-card)",
@@ -104,13 +105,23 @@ interface Props {
   currentPrice: number | null;
   isLive?: boolean;
   capturedAt?: string;
+  snapshotCapturedAt?: string;
 }
 
-export function PriceKPIs({ priceAtPost, currentPrice, isLive, capturedAt }: Props) {
+export function PriceKPIs({ priceAtPost, currentPrice, isLive, capturedAt, snapshotCapturedAt }: Props) {
   if (priceAtPost == null && currentPrice == null) return null;
 
   const flashColor = useFlashColor(currentPrice);
   const updatedAgo = useUpdatedAgo(isLive ?? false, capturedAt);
+
+  const postPriceTooltip = useMemo(
+    () => snapshotCapturedAt ? `Captured: ${formatTimestamp(snapshotCapturedAt)}` : undefined,
+    [snapshotCapturedAt],
+  );
+  const livePriceTooltip = useMemo(
+    () => capturedAt ? `Captured: ${formatTimestamp(capturedAt)}` : undefined,
+    [capturedAt],
+  );
 
   const hasChange = priceAtPost != null && currentPrice != null && priceAtPost !== 0;
   const dollarChange = hasChange ? currentPrice - priceAtPost : null;
@@ -127,15 +138,12 @@ export function PriceKPIs({ priceAtPost, currentPrice, isLive, capturedAt }: Pro
 
   return (
     <div style={cardStyle}>
-      <style>{`
-        @keyframes livePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
-      `}</style>
       <div style={rowStyle}>
-        <div>
+        <div title={postPriceTooltip}>
           <div style={labelStyle}>Price at Post</div>
           <div style={priceStyle}>{formatPrice(priceAtPost)}</div>
         </div>
-        <div style={{ textAlign: "right" }}>
+        <div style={{ textAlign: "right" }} title={livePriceTooltip}>
           <div style={labelStyle}>
             {isLive && <span style={liveDotStyle} />}
             Price Now

--- a/frontend/src/components/ShitpostCard.tsx
+++ b/frontend/src/components/ShitpostCard.tsx
@@ -299,8 +299,8 @@ export function ShitpostCard({ post }: Props) {
 
       {/* Timestamp with market timing context */}
       <div style={timestampRowStyle}>
-        <time title={formatTimestamp(post.timestamp)}>
-          {timeAgo}
+        <time dateTime={post.timestamp}>
+          {timeAgo} · {formatTimestamp(post.timestamp)}
         </time>
         {post.minutes_to_market && (
           <>

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -180,6 +180,7 @@ export function FeedPage() {
                   currentPrice={currentPrice}
                   isLive={liveQuote.data != null}
                   capturedAt={liveQuote.data?.captured_at}
+                  snapshotCapturedAt={activeOutcome?.price_snapshot?.captured_at}
                 />
 
                 <MetricBubbles outcome={activeOutcome} />

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,3 +1,6 @@
+/* Shared keyframes */
+@keyframes livePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+
 /* Responsive breakpoints for Shitpost Alpha */
 
 /* Tablet: 768px and below */
@@ -11,6 +14,14 @@
   .nav-arrow {
     width: 36px !important;
     height: 36px !important;
+    left: auto !important;
+    right: auto !important;
+  }
+  .nav-arrow:first-child {
+    left: 8px !important;
+  }
+  .nav-arrow:last-child {
+    right: 8px !important;
   }
   .price-chart-container {
     height: 260px !important;


### PR DESCRIPTION
## Summary
- **Inline exact timestamps** — Post card now shows "1d ago · Apr 5, 2:34 PM EST" instead of hiding the exact time in a hover tooltip
- **Price capture tooltips** — Hovering "Price at Post" shows when the snapshot was captured; hovering "Price Now" shows the live quote capture time
- **Nav arrows repositioned** — Moved from viewport edges (`left/right: 12px`) to just outside the 640px content column via `calc(50% - 368px)`, with tablet/mobile fallbacks

## Code quality (from /simplify review)
- Memoized `formatTimestamp` tooltip strings in PriceKPIs to avoid `toLocaleString` running every 1s from `useUpdatedAgo` interval
- Moved `@keyframes livePulse` from inline `<style>` tag to `responsive.css`
- Added `dateTime` attribute to `<time>` element for semantic HTML

## Test plan
- [x] `npm run build` — TypeScript + Vite build clean
- [x] `pytest shit_tests/api/ -v` — 84/84 tests pass
- [ ] Visual check: post timestamps show exact time inline
- [ ] Visual check: price KPI tooltips appear on hover
- [ ] Visual check: arrows sit near content column, not viewport edges
- [ ] Visual check: mobile (< 480px) bottom bar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)