### PR TITLE
feat: data model audit — 12 findings across 5 workstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Provider-aware predictions** — `check_prediction_exists()` and `get_unprocessed_*()` queries accept `llm_provider`/`llm_model` params, enabling multiple LLM predictions per post without code changes to callers
+- **Slim analyzer dict** — `get_unprocessed_shitposts()` returns 18 fields actually consumed by the analyzer instead of 53 (all data preserved in `raw_api_data`)
+- **Batch price lookups** — `get_price_on_date()` replaced 7-query backward walk with single bounded SQL query; outcome calculator and ticker registry batch-check existence before per-asset loops
+- **Feed query consolidation** — Merged outcomes + snapshots into single SQL JOIN, eliminating Python-side merge and 1 DB round trip per feed request (3 queries → 2)
+- **Statistics consolidation** — `get_database_stats()` reduced from 8 separate queries to 2 using CASE WHEN aggregation
+- **Notifications decoupled from legacy table** — `get_new_predictions_since()` uses `predictions.post_timestamp` instead of JOIN to `truth_social_shitposts`, now picks up signal-based predictions
+- **TelegramSubscription model moved** — From `shitvault/shitpost_models.py` to `notifications/models.py` (proper separation of concerns, re-exported for compatibility)
+
+### Added
+- **Sentiment CHECK constraint** — `prediction_outcomes.prediction_sentiment` enforced to `bullish`/`bearish`/`neutral`/NULL at DB level
+- **Symbol FK constraints** — `prediction_outcomes.symbol` and `price_snapshots.symbol` now reference `ticker_registry.symbol`
+- **Sector snapshot on outcomes** — `prediction_outcomes.sector` populated from `ticker_registry` at outcome creation for backtesting analytics
+- **Migration script 008** — Adds sentiment CHECK, symbol FKs, drops dead `market_volatility` and `notes` columns
+
 ### Added
 - **Live price quotes** — New `/api/prices/{symbol}/live` endpoint using yfinance fast_info (~300ms); `useLiveQuote()` TanStack Query hook polls every 15 seconds; PriceKPIs shows pulsing green dot when live data is active
 - **Inline snapshot capture** — Price snapshots now captured within seconds of LLM analysis (in analyzer's `_trigger_reactive_backfill`), down from 5-15 minutes via the market-data-worker cron hop; worker stays as idempotent safety net

--- a/api/queries/feed_queries.py
+++ b/api/queries/feed_queries.py
@@ -86,13 +86,16 @@ def get_analyzed_post_at_offset(
 
 
 def get_outcomes_for_prediction(prediction_id: int) -> list[dict[str, Any]]:
-    """Get all prediction_outcomes for a given prediction.
+    """Get all prediction_outcomes with ticker fundamentals and price snapshots.
+
+    Single query joins outcomes, ticker_registry, and price_snapshots,
+    eliminating the separate snapshot query and Python-side merge.
 
     Args:
         prediction_id: The prediction.id to look up.
 
     Returns:
-        List of outcome dicts, one per ticker symbol.
+        List of outcome dicts (one per ticker), each including snapshot fields.
     """
     query = """
         SELECT
@@ -136,44 +139,23 @@ def get_outcomes_for_prediction(prediction_id: int) -> list[dict[str, Any]]:
             tr.pe_ratio,
             tr.forward_pe,
             tr.beta,
-            tr.dividend_yield
+            tr.dividend_yield,
+            ps.price     AS snapshot_price,
+            ps.captured_at AS snapshot_captured_at,
+            ps.market_status AS snapshot_market_status,
+            ps.previous_close AS snapshot_previous_close,
+            ps.day_high  AS snapshot_day_high,
+            ps.day_low   AS snapshot_day_low
         FROM prediction_outcomes po
         LEFT JOIN ticker_registry tr ON po.symbol = tr.symbol
+        LEFT JOIN price_snapshots ps
+            ON po.prediction_id = ps.prediction_id
+            AND po.symbol = ps.symbol
         WHERE po.prediction_id = :prediction_id
         ORDER BY po.symbol
     """
 
     rows, columns = execute_query(query, {"prediction_id": prediction_id})
     return [dict(zip(columns, row)) for row in rows]
-
-
-def get_snapshots_for_prediction(
-    prediction_id: int,
-) -> dict[str, dict[str, Any]]:
-    """Get price snapshots for a prediction, keyed by symbol.
-
-    Returns:
-        Dict mapping symbol → snapshot data dict.
-    """
-    query = """
-        SELECT
-            symbol, price, captured_at,
-            market_status, previous_close,
-            day_high, day_low
-        FROM price_snapshots
-        WHERE prediction_id = :prediction_id
-        ORDER BY symbol
-    """
-    rows, columns = execute_query(
-        query, {"prediction_id": prediction_id}
-    )
-    result = {}
-    for row in rows:
-        d = dict(zip(columns, row))
-        sym = d.pop("symbol")
-        if hasattr(d.get("captured_at"), "isoformat"):
-            d["captured_at"] = d["captured_at"].isoformat()
-        result[sym] = d
-    return result
 
 

--- a/api/services/feed_service.py
+++ b/api/services/feed_service.py
@@ -6,7 +6,6 @@ from typing import Any
 from api.queries.feed_queries import (
     get_analyzed_post_at_offset,
     get_outcomes_for_prediction,
-    get_snapshots_for_prediction,
 )
 from api.schemas.feed import (
     Correct,
@@ -54,13 +53,10 @@ class FeedService:
         post = self.build_post(row, market_timing, minutes_to_market)
         prediction = self.build_prediction(row)
 
-        # Fetch price snapshots for this prediction
-        snapshots_by_symbol = get_snapshots_for_prediction(row["prediction_id"])
-
-        # Build outcomes
+        # Build outcomes — snapshot data is now in the same query result
         outcomes = []
         for o in outcomes_raw:
-            snap_data = snapshots_by_symbol.get(o["symbol"])
+            snap_data = self._extract_snapshot(o)
             outcomes.append(self.build_outcome(o, snap_data))
 
         navigation = self.build_navigation(offset, total)
@@ -193,6 +189,35 @@ class FeedService:
             prediction_date=pred_date_str,
             marker_dates=marker_dates,
         )
+
+    @staticmethod
+    def _extract_snapshot(o: dict[str, Any]) -> dict[str, Any] | None:
+        """Extract snapshot fields from a merged outcome+snapshot query row.
+
+        Pops the snapshot_ prefixed keys from the outcome dict and returns
+        them as a standalone snapshot dict, or None if no snapshot exists.
+        """
+        price = o.pop("snapshot_price", None)
+        captured_at = o.pop("snapshot_captured_at", None)
+        market_status = o.pop("snapshot_market_status", None)
+        previous_close = o.pop("snapshot_previous_close", None)
+        day_high = o.pop("snapshot_day_high", None)
+        day_low = o.pop("snapshot_day_low", None)
+
+        if price is None:
+            return None
+
+        if hasattr(captured_at, "isoformat"):
+            captured_at = captured_at.isoformat()
+
+        return {
+            "price": price,
+            "captured_at": captured_at,
+            "market_status": market_status,
+            "previous_close": previous_close,
+            "day_high": day_high,
+            "day_low": day_low,
+        }
 
     @staticmethod
     def build_navigation(offset: int, total: int) -> Navigation:

--- a/notifications/db.py
+++ b/notifications/db.py
@@ -369,9 +369,9 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
     results = _execute_read(
         """
         SELECT
-            tss.timestamp,
-            tss.text,
-            tss.shitpost_id,
+            p.post_timestamp AS timestamp,
+            p.shitpost_id,
+            p.signal_id,
             p.id as prediction_id,
             p.assets,
             p.market_impact,
@@ -380,8 +380,6 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
             p.analysis_status,
             p.created_at as prediction_created_at
         FROM predictions p
-        INNER JOIN truth_social_shitposts tss
-            ON tss.shitpost_id = p.shitpost_id
         WHERE p.analysis_status = 'completed'
             AND p.created_at > :since
             AND p.confidence IS NOT NULL

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -1,0 +1,77 @@
+"""
+Notification Models
+SQLAlchemy models for the notifications subsystem.
+"""
+
+from datetime import datetime
+from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String, Text
+
+from shit.db.data_models import Base, TimestampMixin, IDMixin
+
+
+class TelegramSubscription(Base, IDMixin, TimestampMixin):
+    """
+    Model for Telegram alert subscriptions.
+
+    Supports multi-tenant architecture where one bot serves many users/groups.
+    Each subscription has its own alert preferences.
+    """
+
+    __tablename__ = "telegram_subscriptions"
+
+    # Telegram identifiers
+    chat_id = Column(
+        String(50), unique=True, nullable=False, index=True
+    )  # Telegram chat ID
+    chat_type = Column(
+        String(20), nullable=False, default="private"
+    )  # private, group, supergroup, channel
+
+    # User/group info (captured from Telegram API)
+    username = Column(String(100), nullable=True)  # @username (optional)
+    first_name = Column(String(100), nullable=True)  # User's first name
+    last_name = Column(String(100), nullable=True)  # User's last name
+    title = Column(
+        String(200), nullable=True
+    )  # Group/channel title (for non-private chats)
+
+    # Subscription status
+    is_active = Column(Boolean, default=True, index=True)
+    subscribed_at = Column(DateTime, default=datetime.utcnow)
+    unsubscribed_at = Column(DateTime, nullable=True)
+
+    # Alert preferences (stored as JSON for flexibility)
+    alert_preferences = Column(
+        JSON,
+        default=lambda: {
+            "min_confidence": 0.7,
+            "assets_of_interest": [],  # Empty = all assets
+            "sentiment_filter": "all",  # all, bullish, bearish, neutral
+            "quiet_hours_enabled": False,
+            "quiet_hours_start": "22:00",
+            "quiet_hours_end": "08:00",
+        },
+    )
+
+    # Rate limiting and tracking
+    last_alert_at = Column(DateTime, nullable=True)
+    alerts_sent_count = Column(Integer, default=0)
+    last_interaction_at = Column(
+        DateTime, default=datetime.utcnow
+    )  # Last command received
+
+    # Error tracking
+    consecutive_errors = Column(Integer, default=0)  # For auto-disabling broken chats
+    last_error = Column(Text, nullable=True)
+
+    def __repr__(self):
+        name = self.username or self.first_name or self.title or self.chat_id
+        return f"<TelegramSubscription(chat_id={self.chat_id}, name='{name}', active={self.is_active})>"
+
+    def get_display_name(self) -> str:
+        """Get a human-readable name for this subscription."""
+        if self.chat_type == "private":
+            if self.username:
+                return f"@{self.username}"
+            return self.first_name or f"User {self.chat_id}"
+        return self.title or f"Chat {self.chat_id}"

--- a/scripts/008_schema_cleanup.sql
+++ b/scripts/008_schema_cleanup.sql
@@ -1,0 +1,26 @@
+-- 008_schema_cleanup.sql
+-- Data model audit WS-D: schema cleanup
+-- Run on production Neon DB before deploying the corresponding code changes.
+
+-- 1. Add CHECK constraint on prediction_outcomes.prediction_sentiment
+ALTER TABLE prediction_outcomes
+    ADD CONSTRAINT ck_prediction_outcomes_sentiment
+    CHECK (prediction_sentiment IN ('bullish', 'bearish', 'neutral') OR prediction_sentiment IS NULL);
+
+-- 2. Add FK from prediction_outcomes.symbol to ticker_registry.symbol
+-- (all existing symbols should already be in ticker_registry; verify first)
+-- SELECT DISTINCT po.symbol FROM prediction_outcomes po
+--   LEFT JOIN ticker_registry tr ON po.symbol = tr.symbol
+--   WHERE tr.symbol IS NULL;
+ALTER TABLE prediction_outcomes
+    ADD CONSTRAINT fk_prediction_outcomes_symbol
+    FOREIGN KEY (symbol) REFERENCES ticker_registry(symbol);
+
+-- 3. Add FK from price_snapshots.symbol to ticker_registry.symbol
+ALTER TABLE price_snapshots
+    ADD CONSTRAINT fk_price_snapshots_symbol
+    FOREIGN KEY (symbol) REFERENCES ticker_registry(symbol);
+
+-- 4. Drop dead columns from prediction_outcomes
+ALTER TABLE prediction_outcomes DROP COLUMN IF EXISTS market_volatility;
+ALTER TABLE prediction_outcomes DROP COLUMN IF EXISTS notes;

--- a/shit/market_data/client.py
+++ b/shit/market_data/client.py
@@ -298,52 +298,32 @@ class MarketDataClient:
     ) -> Optional[MarketPrice]:
         """Get price for a specific date, with fallback for non-trading days.
 
-        Uses the market calendar to walk backward through actual trading days
-        rather than calendar days. If target_date is a weekend or holiday,
-        this returns the most recent trading day's close.
+        Uses a single bounded query to find the most recent price on or before
+        the target date within the lookback window. If target_date is a weekend
+        or holiday, this returns the most recent trading day's close.
         """
-        from shit.market_data.market_calendar import MarketCalendar
-
+        # Single query: find most recent price on or before target within lookback window
+        lookback_date = target_date - timedelta(days=lookback_days * 2)  # Calendar days > trading days
         price = (
             self.session.query(MarketPrice)
-            .filter(and_(MarketPrice.symbol == symbol, MarketPrice.date == target_date))
+            .filter(
+                and_(
+                    MarketPrice.symbol == symbol,
+                    MarketPrice.date <= target_date,
+                    MarketPrice.date >= lookback_date,
+                )
+            )
+            .order_by(MarketPrice.date.desc())
             .first()
         )
 
         if price:
-            return price
-
-        logger.debug(
-            f"No price found for {symbol} on {target_date}, checking previous trading days",
-            extra={"symbol": symbol, "target_date": str(target_date)},
-        )
-
-        # Use market calendar to find the most recent trading day
-        calendar = MarketCalendar()
-        check_date = target_date
-        for _ in range(lookback_days):
-            try:
-                check_date = calendar.previous_trading_day(check_date)
-            except Exception:
-                # Fallback to naive walk if calendar fails
-                check_date = check_date - timedelta(days=1)
-                while check_date.weekday() >= 5:
-                    check_date -= timedelta(days=1)
-
-            price = (
-                self.session.query(MarketPrice)
-                .filter(
-                    and_(MarketPrice.symbol == symbol, MarketPrice.date == check_date)
-                )
-                .first()
-            )
-
-            if price:
+            if price.date != target_date:
                 logger.debug(
-                    f"Found price for {symbol} on {check_date} (nearest trading day before {target_date})",
-                    extra={"symbol": symbol, "price_date": str(check_date)},
+                    f"Found price for {symbol} on {price.date} (nearest trading day before {target_date})",
+                    extra={"symbol": symbol, "price_date": str(price.date)},
                 )
-                return price
+            return price
 
         logger.warning(
             f"No price found for {symbol} within {lookback_days} trading days of {target_date}",

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -84,7 +84,9 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
     )
 
     # Asset being tracked
-    symbol = Column(String(20), nullable=False, index=True)  # Ticker symbol
+    symbol = Column(
+        String(20), ForeignKey("ticker_registry.symbol"), nullable=False, index=True
+    )  # Ticker symbol
 
     # Prediction details (denormalized for easier querying)
     prediction_date = Column(
@@ -226,7 +228,7 @@ class PriceSnapshot(Base, IDMixin, TimestampMixin):
     prediction_id = Column(
         Integer, ForeignKey("predictions.id"), nullable=False, index=True
     )
-    symbol = Column(String(20), nullable=False)
+    symbol = Column(String(20), ForeignKey("ticker_registry.symbol"), nullable=False)
 
     # Captured price data
     price = Column(Float, nullable=False)

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -72,6 +72,10 @@ class PredictionOutcome(Base, IDMixin, TimestampMixin):
             "prediction_id", "symbol",
             name="uq_prediction_outcomes_pred_symbol",
         ),
+        CheckConstraint(
+            "prediction_sentiment IN ('bullish', 'bearish', 'neutral') OR prediction_sentiment IS NULL",
+            name="ck_prediction_outcomes_sentiment",
+        ),
     )
 
     # Link to prediction

--- a/shit/market_data/outcome_calculator.py
+++ b/shit/market_data/outcome_calculator.py
@@ -222,6 +222,7 @@ class OutcomeCalculator:
                 prediction_date=prediction_date,
                 prediction_sentiment=sentiment,
                 prediction_confidence=confidence,
+                sector=self._lookup_sector(symbol),
             )
         )
 
@@ -261,6 +262,17 @@ class OutcomeCalculator:
         )
 
         return outcome
+
+    def _lookup_sector(self, symbol: str) -> Optional[str]:
+        """Look up the sector for a symbol from the ticker registry."""
+        from shit.market_data.models import TickerRegistry
+
+        row = (
+            self.session.query(TickerRegistry.sector)
+            .filter(TickerRegistry.symbol == symbol)
+            .first()
+        )
+        return row.sector if row else None
 
     def _resolve_base_price(
         self,

--- a/shit/market_data/outcome_calculator.py
+++ b/shit/market_data/outcome_calculator.py
@@ -118,6 +118,14 @@ class OutcomeCalculator:
 
         outcomes = []
 
+        # Batch-query existing outcomes for this prediction (avoids N+1)
+        existing_outcomes = {
+            row.symbol: row
+            for row in self.session.query(PredictionOutcome)
+            .filter(PredictionOutcome.prediction_id == prediction_id)
+            .all()
+        }
+
         # Calculate outcome for each asset
         for asset in prediction.assets:
             try:
@@ -136,6 +144,7 @@ class OutcomeCalculator:
                     confidence=prediction.confidence,
                     force_refresh=force_refresh,
                     post_datetime=post_datetime,
+                    existing_outcome=existing_outcomes.get(asset),
                 )
                 if outcome:
                     outcomes.append(outcome)
@@ -164,6 +173,7 @@ class OutcomeCalculator:
         confidence: Optional[float],
         force_refresh: bool = False,
         post_datetime: Optional[datetime] = None,
+        existing_outcome: Optional[PredictionOutcome] = None,
     ) -> Optional[PredictionOutcome]:
         """Calculate outcome for a single asset prediction."""
 
@@ -175,17 +185,19 @@ class OutcomeCalculator:
             )
             return None
 
-        # Check if outcome already exists
-        existing = (
-            self.session.query(PredictionOutcome)
-            .filter(
-                and_(
-                    PredictionOutcome.prediction_id == prediction_id,
-                    PredictionOutcome.symbol == symbol,
+        # Use pre-fetched outcome from batch query, or query if not provided
+        existing = existing_outcome
+        if existing is None:
+            existing = (
+                self.session.query(PredictionOutcome)
+                .filter(
+                    and_(
+                        PredictionOutcome.prediction_id == prediction_id,
+                        PredictionOutcome.symbol == symbol,
+                    )
                 )
+                .first()
             )
-            .first()
-        )
 
         if existing and not force_refresh:
             if existing.is_complete:

--- a/shit/market_data/ticker_registry.py
+++ b/shit/market_data/ticker_registry.py
@@ -45,25 +45,30 @@ class TickerRegistryService:
         already_known = []
 
         with get_session() as session:
+            # Validate and normalize symbols
+            valid_symbols = []
             for symbol in symbols:
                 symbol = symbol.strip().upper()
-
-                # Validate symbol format
                 if not symbol or len(symbol) > 20 or " " in symbol:
                     logger.warning(f"Skipping invalid symbol format: '{symbol}'")
                     continue
+                valid_symbols.append(symbol)
 
-                # Check if already registered
-                existing = (
-                    session.query(TickerRegistry)
-                    .filter(TickerRegistry.symbol == symbol)
-                    .first()
+            # Batch-query existing tickers (avoids N+1)
+            existing_set = set()
+            if valid_symbols:
+                existing_rows = (
+                    session.query(TickerRegistry.symbol)
+                    .filter(TickerRegistry.symbol.in_(valid_symbols))
+                    .all()
                 )
+                existing_set = {row.symbol for row in existing_rows}
 
-                if existing:
+            for symbol in valid_symbols:
+                if symbol in existing_set:
                     already_known.append(symbol)
                     logger.debug(
-                        f"Ticker {symbol} already registered (status={existing.status})"
+                        f"Ticker {symbol} already registered"
                     )
                     continue
 

--- a/shit_tests/api/test_feed_service.py
+++ b/shit_tests/api/test_feed_service.py
@@ -362,10 +362,6 @@ class TestGetFeedResponse:
             patch(
                 "api.services.feed_service.get_outcomes_for_prediction", return_value=[]
             ),
-            patch(
-                "api.services.feed_service.get_snapshots_for_prediction",
-                return_value={},
-            ),
         ):
             service = FeedService()
             result = service.get_feed_response(0)

--- a/shit_tests/shit/market_data/test_client.py
+++ b/shit_tests/shit/market_data/test_client.py
@@ -258,33 +258,35 @@ class TestStoreRawRecords:
 class TestGetPriceOnDate:
     def test_returns_exact_date_match(self, client, mock_session):
         mock_price = MagicMock(spec=MarketPrice)
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_price
+        mock_price.date = date(2026, 1, 15)
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_price
 
         result = client.get_price_on_date("AAPL", date(2026, 1, 15))
         assert result is mock_price
 
     def test_returns_none_when_not_found(self, client, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
 
         result = client.get_price_on_date("AAPL", date(2026, 1, 15))
         assert result is None
 
-    def test_looks_back_when_market_closed(self, client, mock_session):
+    def test_returns_nearest_trading_day(self, client, mock_session):
+        """Single bounded query returns the nearest trading day before target."""
         mock_price = MagicMock(spec=MarketPrice)
-        mock_session.query.return_value.filter.return_value.first.side_effect = [
-            None,  # exact date
-            mock_price,  # 1 day back
-        ]
+        mock_price.date = date(2026, 1, 13)  # Monday before target Wednesday
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_price
 
         result = client.get_price_on_date("AAPL", date(2026, 1, 15))
         assert result is mock_price
 
-    def test_respects_lookback_limit(self, client, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
+    def test_single_query_instead_of_loop(self, client, mock_session):
+        """Verify only 1 query is issued regardless of lookback window."""
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
 
-        result = client.get_price_on_date("AAPL", date(2026, 1, 15), lookback_days=3)
+        result = client.get_price_on_date("AAPL", date(2026, 1, 15), lookback_days=7)
         assert result is None
-        assert mock_session.query.return_value.filter.return_value.first.call_count == 4
+        # Single query, not N queries walking backward
+        assert mock_session.query.call_count == 1
 
 
 class TestGetLatestPrice:

--- a/shit_tests/shit/market_data/test_ticker_registry.py
+++ b/shit_tests/shit/market_data/test_ticker_registry.py
@@ -32,7 +32,8 @@ class TestRegisterTickers:
 
     def test_registers_new_ticker_successfully(self):
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        # Batch query returns no existing symbols
+        session.query.return_value.filter.return_value.all.return_value = []
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -44,8 +45,10 @@ class TestRegisterTickers:
 
     def test_skips_already_registered_ticker(self):
         ctx, session = _mock_session()
-        existing = MagicMock(status="active")
-        session.query.return_value.filter.return_value.first.return_value = existing
+        # Batch query returns AAPL as existing
+        existing_row = MagicMock()
+        existing_row.symbol = "AAPL"
+        session.query.return_value.filter.return_value.all.return_value = [existing_row]
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -57,12 +60,10 @@ class TestRegisterTickers:
 
     def test_returns_newly_registered_and_already_known_lists(self):
         ctx, session = _mock_session()
-        existing = MagicMock(status="active")
-        # First call returns None (new), second returns existing
-        session.query.return_value.filter.return_value.first.side_effect = [
-            None,
-            existing,
-        ]
+        # Batch query returns AAPL as existing, NVDA not present
+        existing_row = MagicMock()
+        existing_row.symbol = "AAPL"
+        session.query.return_value.filter.return_value.all.return_value = [existing_row]
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -110,7 +111,7 @@ class TestRegisterTickers:
 
     def test_uppercases_symbols(self):
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.all.return_value = []
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -120,7 +121,7 @@ class TestRegisterTickers:
 
     def test_sets_source_prediction_id(self):
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.all.return_value = []
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -131,7 +132,7 @@ class TestRegisterTickers:
 
     def test_sets_first_seen_date_to_today(self):
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.all.return_value = []
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -142,7 +143,7 @@ class TestRegisterTickers:
 
     def test_default_status_is_active(self):
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.all.return_value = []
 
         with patch(SESSION_PATCH, return_value=ctx):
             service = TickerRegistryService()
@@ -155,7 +156,7 @@ class TestRegisterTickers:
         from sqlalchemy.exc import IntegrityError
 
         ctx, session = _mock_session()
-        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.all.return_value = []
         session.commit.side_effect = IntegrityError("dup", {}, None)
 
         with patch(SESSION_PATCH, return_value=ctx):
@@ -437,8 +438,9 @@ class TestRegisterTickersFundamentals:
 
     def test_does_not_fetch_fundamentals_when_no_new_tickers(self):
         ctx, session = _mock_session()
-        existing = MagicMock(status="active")
-        session.query.return_value.filter.return_value.first.return_value = existing
+        existing_row = MagicMock()
+        existing_row.symbol = "AAPL"
+        session.query.return_value.filter.return_value.all.return_value = [existing_row]
 
         with (
             patch(SESSION_PATCH, return_value=ctx),

--- a/shit_tests/shitvault/test_shitpost_operations.py
+++ b/shit_tests/shitvault/test_shitpost_operations.py
@@ -392,5 +392,5 @@ class TestShitpostOperations:
         assert 'id' in result[0]
         assert 'shitpost_id' in result[0]
         assert 'content' in result[0]
-        assert 'created_at' in result[0]
-        assert 'updated_at' in result[0]
+        assert 'has_media' in result[0]
+        assert 'is_repost' in result[0]

--- a/shit_tests/shitvault/test_statistics.py
+++ b/shit_tests/shitvault/test_statistics.py
@@ -112,54 +112,38 @@ class TestStatistics:
 
     @pytest.mark.asyncio
     async def test_get_database_stats_success(self, statistics, mock_db_ops):
-        """Test successful database stats retrieval."""
-        # Mock shitpost count
-        mock_shitpost_result = MagicMock()
-        mock_shitpost_result.scalar.return_value = 100
-        
-        # Mock analysis count
-        mock_analysis_result = MagicMock()
-        mock_analysis_result.scalar.return_value = 75
-        
-        # Mock status counts
-        mock_completed = MagicMock()
-        mock_completed.scalar.return_value = 60
-        mock_bypassed = MagicMock()
-        mock_bypassed.scalar.return_value = 10
-        mock_error = MagicMock()
-        mock_error.scalar.return_value = 3
-        mock_pending = MagicMock()
-        mock_pending.scalar.return_value = 2
-        
-        # Mock average confidence
-        mock_confidence_result = MagicMock()
-        mock_confidence_result.scalar.return_value = 0.85
-        
-        # Mock date ranges
+        """Test successful database stats retrieval (2 consolidated queries)."""
         min_date = datetime(2024, 1, 1, 12, 0, 0)
         max_date = datetime(2024, 1, 31, 18, 0, 0)
-        
-        mock_min_date = MagicMock()
-        mock_min_date.scalar.return_value = min_date
-        mock_max_date = MagicMock()
-        mock_max_date.scalar.return_value = max_date
-        
+
+        # Query 1: shitpost aggregates
+        shitpost_row = MagicMock()
+        shitpost_row.shitpost_count = 100
+        shitpost_row.min_date = min_date
+        shitpost_row.max_date = max_date
+        mock_shitpost_result = MagicMock()
+        mock_shitpost_result.one.return_value = shitpost_row
+
+        # Query 2: prediction aggregates
+        pred_row = MagicMock()
+        pred_row.total = 75
+        pred_row.avg_confidence = 0.85
+        pred_row.completed_count = 60
+        pred_row.bypassed_count = 10
+        pred_row.error_count = 3
+        pred_row.pending_count = 2
+        pred_row.min_analysis_date = min_date
+        pred_row.max_analysis_date = max_date
+        mock_pred_result = MagicMock()
+        mock_pred_result.one.return_value = pred_row
+
         mock_db_ops.session.execute.side_effect = [
-            mock_shitpost_result,  # shitpost count
-            mock_analysis_result,  # analysis count
-            mock_completed,        # completed count
-            mock_bypassed,         # bypassed count
-            mock_error,            # error count
-            mock_pending,          # pending count
-            mock_confidence_result, # avg confidence
-            mock_min_date,         # min date
-            mock_max_date,         # max date
-            mock_min_date,         # min analysis date
-            mock_max_date,         # max analysis date
+            mock_shitpost_result,
+            mock_pred_result,
         ]
-        
+
         result = await statistics.get_database_stats()
-        
+
         assert result['total_shitposts'] == 100
         assert result['total_analyses'] == 75
         assert result['average_confidence'] == 0.85
@@ -172,35 +156,38 @@ class TestStatistics:
         assert result['latest_post'] == max_date.isoformat()
         assert result['earliest_analyzed_post'] == min_date.isoformat()
         assert result['latest_analyzed_post'] == max_date.isoformat()
+        # Only 2 queries now instead of 8+
+        assert mock_db_ops.session.execute.call_count == 2
 
     @pytest.mark.asyncio
     async def test_get_database_stats_no_dates(self, statistics, mock_db_ops):
         """Test database stats with no dates (empty database)."""
-        mock_count = MagicMock()
-        mock_count.scalar.return_value = 0
-        
-        mock_confidence = MagicMock()
-        mock_confidence.scalar.return_value = 0.0
-        
-        mock_no_date = MagicMock()
-        mock_no_date.scalar.return_value = None
-        
+        shitpost_row = MagicMock()
+        shitpost_row.shitpost_count = 0
+        shitpost_row.min_date = None
+        shitpost_row.max_date = None
+        mock_shitpost_result = MagicMock()
+        mock_shitpost_result.one.return_value = shitpost_row
+
+        pred_row = MagicMock()
+        pred_row.total = 0
+        pred_row.avg_confidence = None
+        pred_row.completed_count = 0
+        pred_row.bypassed_count = 0
+        pred_row.error_count = 0
+        pred_row.pending_count = 0
+        pred_row.min_analysis_date = None
+        pred_row.max_analysis_date = None
+        mock_pred_result = MagicMock()
+        mock_pred_result.one.return_value = pred_row
+
         mock_db_ops.session.execute.side_effect = [
-            mock_count,     # shitpost count
-            mock_count,     # analysis count
-            mock_count,     # completed count
-            mock_count,     # bypassed count
-            mock_count,     # error count
-            mock_count,     # pending count
-            mock_confidence, # avg confidence
-            mock_no_date,   # min date
-            mock_no_date,   # max date
-            mock_no_date,   # min analysis date
-            mock_no_date,   # max analysis date
+            mock_shitpost_result,
+            mock_pred_result,
         ]
-        
+
         result = await statistics.get_database_stats()
-        
+
         assert result['earliest_post'] is None
         assert result['latest_post'] is None
         assert result['earliest_analyzed_post'] is None
@@ -210,10 +197,9 @@ class TestStatistics:
     async def test_get_database_stats_error_handling(self, statistics, mock_db_ops):
         """Test error handling in get_database_stats."""
         mock_db_ops.session.execute.side_effect = Exception("Database error")
-        
+
         result = await statistics.get_database_stats()
-        
-        # Should return default values on error
+
         assert result['total_shitposts'] == 0
         assert result['total_analyses'] == 0
         assert result['average_confidence'] == 0.0
@@ -230,78 +216,65 @@ class TestStatistics:
     @pytest.mark.asyncio
     async def test_get_database_stats_partial_analysis(self, statistics, mock_db_ops):
         """Test database stats with partial analysis."""
-        # More shitposts than analyses
+        now = datetime.now()
+        shitpost_row = MagicMock()
+        shitpost_row.shitpost_count = 200
+        shitpost_row.min_date = now
+        shitpost_row.max_date = now
         mock_shitpost_result = MagicMock()
-        mock_shitpost_result.scalar.return_value = 200
-        
-        mock_analysis_result = MagicMock()
-        mock_analysis_result.scalar.return_value = 100
-        
-        mock_status_count = MagicMock()
-        mock_status_count.scalar.return_value = 25
-        
-        mock_confidence_result = MagicMock()
-        mock_confidence_result.scalar.return_value = 0.75
-        
-        mock_date = MagicMock()
-        mock_date.scalar.return_value = datetime.now()
-        
+        mock_shitpost_result.one.return_value = shitpost_row
+
+        pred_row = MagicMock()
+        pred_row.total = 100
+        pred_row.avg_confidence = 0.75
+        pred_row.completed_count = 25
+        pred_row.bypassed_count = 25
+        pred_row.error_count = 25
+        pred_row.pending_count = 25
+        pred_row.min_analysis_date = now
+        pred_row.max_analysis_date = now
+        mock_pred_result = MagicMock()
+        mock_pred_result.one.return_value = pred_row
+
         mock_db_ops.session.execute.side_effect = [
-            mock_shitpost_result,  # shitpost count
-            mock_analysis_result,  # analysis count
-            mock_status_count,     # completed
-            mock_status_count,     # bypassed
-            mock_status_count,     # error
-            mock_status_count,     # pending
-            mock_confidence_result, # avg confidence
-            mock_date,             # min date
-            mock_date,             # max date
-            mock_date,             # min analysis date
-            mock_date,             # max analysis date
+            mock_shitpost_result,
+            mock_pred_result,
         ]
-        
+
         result = await statistics.get_database_stats()
-        
+
         assert result['analysis_rate'] == 0.5  # 100/200
 
     @pytest.mark.asyncio
     async def test_get_database_stats_all_statuses(self, statistics, mock_db_ops):
         """Test that all analysis statuses are counted."""
-        mock_count = MagicMock()
-        mock_count.scalar.return_value = 10
-        
-        mock_completed = MagicMock()
-        mock_completed.scalar.return_value = 5
-        mock_bypassed = MagicMock()
-        mock_bypassed.scalar.return_value = 3
-        mock_error = MagicMock()
-        mock_error.scalar.return_value = 1
-        mock_pending = MagicMock()
-        mock_pending.scalar.return_value = 1
-        
-        mock_confidence = MagicMock()
-        mock_confidence.scalar.return_value = 0.8
-        
-        mock_date = MagicMock()
-        mock_date.scalar.return_value = datetime.now()
-        
+        now = datetime.now()
+        shitpost_row = MagicMock()
+        shitpost_row.shitpost_count = 10
+        shitpost_row.min_date = now
+        shitpost_row.max_date = now
+        mock_shitpost_result = MagicMock()
+        mock_shitpost_result.one.return_value = shitpost_row
+
+        pred_row = MagicMock()
+        pred_row.total = 10
+        pred_row.avg_confidence = 0.8
+        pred_row.completed_count = 5
+        pred_row.bypassed_count = 3
+        pred_row.error_count = 1
+        pred_row.pending_count = 1
+        pred_row.min_analysis_date = now
+        pred_row.max_analysis_date = now
+        mock_pred_result = MagicMock()
+        mock_pred_result.one.return_value = pred_row
+
         mock_db_ops.session.execute.side_effect = [
-            mock_count,     # shitpost count
-            mock_count,     # analysis count
-            mock_completed, # completed count
-            mock_bypassed,  # bypassed count
-            mock_error,     # error count
-            mock_pending,   # pending count
-            mock_confidence, # avg confidence
-            mock_date,      # min date
-            mock_date,      # max date
-            mock_date,      # min analysis date
-            mock_date,      # max analysis date
+            mock_shitpost_result,
+            mock_pred_result,
         ]
-        
+
         result = await statistics.get_database_stats()
-        
-        # Verify all status counts
+
         assert result['completed_count'] == 5
         assert result['bypassed_count'] == 3
         assert result['error_count'] == 1
@@ -312,60 +285,54 @@ class TestStatistics:
         """Test that confidence and analysis rate are properly rounded."""
         mock_shitpost_result = MagicMock()
         mock_shitpost_result.scalar.return_value = 7
-        
+
         mock_analysis_result = MagicMock()
         mock_analysis_result.scalar.return_value = 5
-        
+
         mock_confidence_result = MagicMock()
         mock_confidence_result.scalar.return_value = 0.876543
-        
+
         mock_db_ops.session.execute.side_effect = [
             mock_shitpost_result,
             mock_analysis_result,
             mock_confidence_result
         ]
-        
+
         result = await statistics.get_analysis_stats()
-        
-        # Should be rounded to 3 decimal places
+
         assert result['average_confidence'] == 0.877
         assert result['analysis_rate'] == 0.714  # 5/7 = 0.714...
 
     @pytest.mark.asyncio
     async def test_get_database_stats_rounding(self, statistics, mock_db_ops):
         """Test that database stats values are properly rounded."""
+        now = datetime.now()
+        shitpost_row = MagicMock()
+        shitpost_row.shitpost_count = 7
+        shitpost_row.min_date = now
+        shitpost_row.max_date = now
         mock_shitpost_result = MagicMock()
-        mock_shitpost_result.scalar.return_value = 7
-        
-        mock_analysis_result = MagicMock()
-        mock_analysis_result.scalar.return_value = 5
-        
-        mock_status_count = MagicMock()
-        mock_status_count.scalar.return_value = 1
-        
-        mock_confidence_result = MagicMock()
-        mock_confidence_result.scalar.return_value = 0.876543
-        
-        mock_date = MagicMock()
-        mock_date.scalar.return_value = datetime.now()
-        
+        mock_shitpost_result.one.return_value = shitpost_row
+
+        pred_row = MagicMock()
+        pred_row.total = 5
+        pred_row.avg_confidence = 0.876543
+        pred_row.completed_count = 1
+        pred_row.bypassed_count = 1
+        pred_row.error_count = 1
+        pred_row.pending_count = 1
+        pred_row.min_analysis_date = now
+        pred_row.max_analysis_date = now
+        mock_pred_result = MagicMock()
+        mock_pred_result.one.return_value = pred_row
+
         mock_db_ops.session.execute.side_effect = [
             mock_shitpost_result,
-            mock_analysis_result,
-            mock_status_count,
-            mock_status_count,
-            mock_status_count,
-            mock_status_count,
-            mock_confidence_result,
-            mock_date,
-            mock_date,
-            mock_date,
-            mock_date,
+            mock_pred_result,
         ]
-        
+
         result = await statistics.get_database_stats()
-        
-        # Should be rounded to 3 decimal places
+
         assert result['average_confidence'] == 0.877
         assert result['analysis_rate'] == 0.714
 

--- a/shitvault/prediction_operations.py
+++ b/shitvault/prediction_operations.py
@@ -7,7 +7,7 @@ Extracted from ShitpostDatabase for modularity.
 
 from typing import Dict, Optional, Any
 from datetime import datetime
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from shit.db.database_operations import DatabaseOperations
 from shit.db.database_utils import DatabaseUtils
@@ -186,18 +186,38 @@ class PredictionOperations:
             return None
     
     
-    async def check_prediction_exists(self, content_id: str, *, use_signal: bool = False) -> bool:
+    async def check_prediction_exists(
+        self,
+        content_id: str,
+        *,
+        use_signal: bool = False,
+        llm_provider: Optional[str] = None,
+        llm_model: Optional[str] = None,
+    ) -> bool:
         """Check if a prediction already exists for content.
+
+        Provider-aware: when llm_provider/llm_model are given, checks for
+        a prediction from that specific provider+model combination, allowing
+        multiple LLM predictions per post.
 
         Args:
             content_id: Signal ID or shitpost ID to check.
             use_signal: If True, check signal_id; otherwise check shitpost_id.
+            llm_provider: If set, only match predictions from this provider.
+            llm_model: If set, only match predictions from this model.
         """
         try:
             if use_signal:
-                stmt = select(Prediction.id).where(Prediction.signal_id == content_id)
+                conditions = [Prediction.signal_id == content_id]
             else:
-                stmt = select(Prediction.id).where(Prediction.shitpost_id == content_id)
+                conditions = [Prediction.shitpost_id == content_id]
+
+            if llm_provider is not None:
+                conditions.append(Prediction.llm_provider == llm_provider)
+            if llm_model is not None:
+                conditions.append(Prediction.llm_model == llm_model)
+
+            stmt = select(Prediction.id).where(and_(*conditions))
             result = await self.db_ops.session.execute(stmt)
             return result.scalar_one_or_none() is not None
 

--- a/shitvault/shitpost_models.py
+++ b/shitvault/shitpost_models.py
@@ -189,72 +189,8 @@ class Prediction(Base, IDMixin, TimestampMixin):
         return f"<Prediction(id={self.id}, confidence={self.confidence}, assets={self.assets})>"
 
 
-class TelegramSubscription(Base, IDMixin, TimestampMixin):
-    """
-    Model for Telegram alert subscriptions.
-
-    Supports multi-tenant architecture where one bot serves many users/groups.
-    Each subscription has its own alert preferences.
-    """
-
-    __tablename__ = "telegram_subscriptions"
-
-    # Telegram identifiers
-    chat_id = Column(
-        String(50), unique=True, nullable=False, index=True
-    )  # Telegram chat ID
-    chat_type = Column(
-        String(20), nullable=False, default="private"
-    )  # private, group, supergroup, channel
-
-    # User/group info (captured from Telegram API)
-    username = Column(String(100), nullable=True)  # @username (optional)
-    first_name = Column(String(100), nullable=True)  # User's first name
-    last_name = Column(String(100), nullable=True)  # User's last name
-    title = Column(
-        String(200), nullable=True
-    )  # Group/channel title (for non-private chats)
-
-    # Subscription status
-    is_active = Column(Boolean, default=True, index=True)
-    subscribed_at = Column(DateTime, default=datetime.utcnow)
-    unsubscribed_at = Column(DateTime, nullable=True)
-
-    # Alert preferences (stored as JSON for flexibility)
-    alert_preferences = Column(
-        JSON,
-        default=lambda: {
-            "min_confidence": 0.7,
-            "assets_of_interest": [],  # Empty = all assets
-            "sentiment_filter": "all",  # all, bullish, bearish, neutral
-            "quiet_hours_enabled": False,
-            "quiet_hours_start": "22:00",
-            "quiet_hours_end": "08:00",
-        },
-    )
-
-    # Rate limiting and tracking
-    last_alert_at = Column(DateTime, nullable=True)
-    alerts_sent_count = Column(Integer, default=0)
-    last_interaction_at = Column(
-        DateTime, default=datetime.utcnow
-    )  # Last command received
-
-    # Error tracking
-    consecutive_errors = Column(Integer, default=0)  # For auto-disabling broken chats
-    last_error = Column(Text, nullable=True)
-
-    def __repr__(self):
-        name = self.username or self.first_name or self.title or self.chat_id
-        return f"<TelegramSubscription(chat_id={self.chat_id}, name='{name}', active={self.is_active})>"
-
-    def get_display_name(self) -> str:
-        """Get a human-readable name for this subscription."""
-        if self.chat_type == "private":
-            if self.username:
-                return f"@{self.username}"
-            return self.first_name or f"User {self.chat_id}"
-        return self.title or f"Chat {self.chat_id}"
+# TelegramSubscription moved to notifications/models.py — re-export for compatibility
+from notifications.models import TelegramSubscription  # noqa: F401
 
 
 # Domain-specific utility functions (using generic model_to_dict)

--- a/shitvault/shitpost_operations.py
+++ b/shitvault/shitpost_operations.py
@@ -134,39 +134,54 @@ class ShitpostOperations:
             logger.error(f"Error storing shitpost {shitpost_data.get('shitpost_id')}: {e}")
             raise
     
-    async def get_unprocessed_shitposts(self, launch_date: str, limit: int = 10) -> List[Dict]:
+    async def get_unprocessed_shitposts(
+        self,
+        launch_date: str,
+        limit: int = 10,
+        llm_provider: Optional[str] = None,
+        llm_model: Optional[str] = None,
+    ) -> List[Dict]:
         """
         Get shitposts that need LLM analysis.
-        
+
+        Provider-aware: when llm_provider/llm_model are given, returns posts
+        that haven't been analyzed by that specific provider+model, even if
+        other providers have already analyzed them.
+
         Criteria:
         1. Shitpost timestamp is after system launch date
-        2. Shitpost has no existing prediction
+        2. Shitpost has no existing prediction (for the given provider/model)
         3. Shitpost has sufficient content for analysis
         """
         try:
             # Parse launch date
             launch_datetime = datetime.fromisoformat(launch_date.replace('Z', '+00:00'))
-            
-            # Subquery to check if prediction exists
-            prediction_exists = select(Prediction.id).where(Prediction.shitpost_id == TruthSocialShitpost.shitpost_id)
-            
+
+            # Subquery to check if prediction exists (provider-aware)
+            pred_conditions = [Prediction.shitpost_id == TruthSocialShitpost.shitpost_id]
+            if llm_provider is not None:
+                pred_conditions.append(Prediction.llm_provider == llm_provider)
+            if llm_model is not None:
+                pred_conditions.append(Prediction.llm_model == llm_model)
+
+            prediction_exists = select(Prediction.id).where(and_(*pred_conditions))
+
             # Main query - Get posts that need analysis
             # Include ALL posts (even those with no text) so they can be bypassed
             stmt = select(TruthSocialShitpost).where(
                 and_(
                     TruthSocialShitpost.timestamp >= launch_datetime,
                     not_(exists(prediction_exists))
-                    # Removed text filters so posts with no text can be processed and bypassed
                 )
             ).order_by(TruthSocialShitpost.timestamp.desc()).limit(limit)
-            
+
             result = await self.db_ops.session.execute(stmt)
             shitposts = result.scalars().all()
-            
-            # Convert to dict format
+
+            # Convert to dict — only fields consumed by the analyzer pipeline
             shitpost_dicts = []
             for shitpost in shitposts:
-                shitpost_dict = {
+                shitpost_dicts.append({
                     'id': shitpost.id,
                     'shitpost_id': shitpost.shitpost_id,
                     'content': shitpost.content,
@@ -174,58 +189,22 @@ class ShitpostOperations:
                     'timestamp': shitpost.timestamp,
                     'username': shitpost.username,
                     'platform': shitpost.platform,
-                    'language': shitpost.language,
-                    'visibility': shitpost.visibility,
-                    'sensitive': shitpost.sensitive,
-                    'uri': shitpost.uri,
-                    'url': shitpost.url,
                     'replies_count': shitpost.replies_count,
                     'reblogs_count': shitpost.reblogs_count,
                     'favourites_count': shitpost.favourites_count,
                     'upvotes_count': shitpost.upvotes_count,
-                    'downvotes_count': shitpost.downvotes_count,
-                    'account_id': shitpost.account_id,
-                    'account_display_name': shitpost.account_display_name,
-                    'account_followers_count': shitpost.account_followers_count,
-                    'account_following_count': shitpost.account_following_count,
-                    'account_statuses_count': shitpost.account_statuses_count,
                     'account_verified': shitpost.account_verified,
-                    'account_website': shitpost.account_website,
+                    'account_followers_count': shitpost.account_followers_count,
                     'has_media': shitpost.has_media,
-                    'media_attachments': shitpost.media_attachments,
                     'mentions': shitpost.mentions,
                     'tags': shitpost.tags,
-                    'in_reply_to_id': shitpost.in_reply_to_id,
-                    'quote_id': shitpost.quote_id,
-                    'in_reply_to_account_id': shitpost.in_reply_to_account_id,
-                    'card': shitpost.card,
-                    'group': shitpost.group,
-                    'quote': shitpost.quote,
-                    'in_reply_to': shitpost.in_reply_to,
                     'reblog': shitpost.reblog,
-                    'sponsored': shitpost.sponsored,
-                    'reaction': shitpost.reaction,
-                    'favourited': shitpost.favourited,
-                    'reblogged': shitpost.reblogged,
-                    'muted': shitpost.muted,
-                    'pinned': shitpost.pinned,
-                    'bookmarked': shitpost.bookmarked,
-                    'poll': shitpost.poll,
-                    'emojis': shitpost.emojis,
-                    'votable': shitpost.votable,
-                    'edited_at': shitpost.edited_at,
-                    'version': shitpost.version,
-                    'editable': shitpost.editable,
-                    'title': shitpost.title,
-                    'raw_api_data': shitpost.raw_api_data,
-                    'created_at': shitpost.created_at,
-                    'updated_at': shitpost.updated_at
-                }
-                shitpost_dicts.append(shitpost_dict)
-            
+                    'is_repost': shitpost.reblog is not None,
+                })
+
             logger.info(f"Retrieved {len(shitpost_dicts)} unprocessed shitposts")
             return shitpost_dicts
-            
+
         except Exception as e:
             logger.error(f"Error retrieving unprocessed shitposts: {e}")
             raise

--- a/shitvault/signal_operations.py
+++ b/shitvault/signal_operations.py
@@ -65,20 +65,31 @@ class SignalOperations:
             raise
 
     async def get_unprocessed_signals(
-        self, launch_date: str, limit: int = 10, source: Optional[str] = None
+        self,
+        launch_date: str,
+        limit: int = 10,
+        source: Optional[str] = None,
+        llm_provider: Optional[str] = None,
+        llm_model: Optional[str] = None,
     ) -> List[Dict]:
         """
         Get signals that need LLM analysis.
 
+        Provider-aware: when llm_provider/llm_model are given, returns signals
+        that haven't been analyzed by that specific provider+model, even if
+        other providers have already analyzed them.
+
         Criteria:
         1. Signal published_at is after launch date
-        2. No existing prediction for this signal
+        2. No existing prediction for this signal (for the given provider/model)
         3. Optionally filtered by source
 
         Args:
             launch_date: ISO date string for minimum timestamp
             limit: Maximum signals to return
             source: Optional source filter
+            llm_provider: If set, only match predictions from this provider.
+            llm_model: If set, only match predictions from this model.
 
         Returns:
             List of signal dictionaries (includes backward-compatible aliases)
@@ -88,8 +99,14 @@ class SignalOperations:
                 launch_date.replace("Z", "+00:00")
             )
 
+            pred_conditions = [Prediction.signal_id == Signal.signal_id]
+            if llm_provider is not None:
+                pred_conditions.append(Prediction.llm_provider == llm_provider)
+            if llm_model is not None:
+                pred_conditions.append(Prediction.llm_model == llm_model)
+
             prediction_exists = select(Prediction.id).where(
-                Prediction.signal_id == Signal.signal_id
+                and_(*pred_conditions)
             )
 
             conditions = [

--- a/shitvault/statistics.py
+++ b/shitvault/statistics.py
@@ -6,7 +6,7 @@ Extracted from ShitpostDatabase for modularity.
 
 
 from typing import Dict, Any
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 
 from shit.db.database_operations import DatabaseOperations
 from shitvault.shitpost_models import TruthSocialShitpost, Prediction
@@ -64,56 +64,34 @@ class Statistics:
     async def get_database_stats(self) -> Dict[str, Any]:
         """Get comprehensive database statistics."""
         try:
-            # Count shitposts
-            shitpost_count_result = await self.db_ops.session.execute(
-                select(func.count(TruthSocialShitpost.id))
+            # Query 1: All shitpost + prediction stats in one shot
+            stats_stmt = select(
+                func.count(TruthSocialShitpost.id).label("shitpost_count"),
+                func.min(TruthSocialShitpost.timestamp).label("min_date"),
+                func.max(TruthSocialShitpost.timestamp).label("max_date"),
             )
-            shitpost_count = shitpost_count_result.scalar()
-            
-            # Count analyses
-            analysis_count_result = await self.db_ops.session.execute(
-                select(func.count(Prediction.id))
+            stats_result = await self.db_ops.session.execute(stats_stmt)
+            row = stats_result.one()
+            shitpost_count = row.shitpost_count or 0
+            min_date = row.min_date
+            max_date = row.max_date
+
+            # Query 2: All prediction aggregates including status counts + analysis date range
+            pred_stmt = select(
+                func.count(Prediction.id).label("total"),
+                func.avg(Prediction.confidence).label("avg_confidence"),
+                func.count(case((Prediction.analysis_status == 'completed', 1))).label("completed_count"),
+                func.count(case((Prediction.analysis_status == 'bypassed', 1))).label("bypassed_count"),
+                func.count(case((Prediction.analysis_status == 'error', 1))).label("error_count"),
+                func.count(case((Prediction.analysis_status == 'pending', 1))).label("pending_count"),
+                func.min(Prediction.post_timestamp).label("min_analysis_date"),
+                func.max(Prediction.post_timestamp).label("max_analysis_date"),
             )
-            analysis_count = analysis_count_result.scalar()
-            
-            # Count by analysis status
-            status_counts = {}
-            for status in ['completed', 'bypassed', 'error', 'pending']:
-                status_result = await self.db_ops.session.execute(
-                    select(func.count(Prediction.id)).where(Prediction.analysis_status == status)
-                )
-                status_counts[f'{status}_count'] = status_result.scalar()
-            
-            # Average confidence
-            avg_confidence_result = await self.db_ops.session.execute(
-                select(func.avg(Prediction.confidence))
-            )
-            avg_confidence = avg_confidence_result.scalar() or 0.0
-            
-            # Date range (using actual Truth Social post timestamps)
-            date_range_result = await self.db_ops.session.execute(
-                select(func.min(TruthSocialShitpost.timestamp))
-            )
-            min_date = date_range_result.scalar()
-            
-            date_range_result = await self.db_ops.session.execute(
-                select(func.max(TruthSocialShitpost.timestamp))
-            )
-            max_date = date_range_result.scalar()
-            
-            # Analysis date range (using actual Truth Social post timestamps for analyzed posts)
-            analysis_date_range_result = await self.db_ops.session.execute(
-                select(func.min(TruthSocialShitpost.timestamp))
-                .join(Prediction, TruthSocialShitpost.shitpost_id == Prediction.shitpost_id)
-            )
-            min_analysis_date = analysis_date_range_result.scalar()
-            
-            analysis_date_range_result = await self.db_ops.session.execute(
-                select(func.max(TruthSocialShitpost.timestamp))
-                .join(Prediction, TruthSocialShitpost.shitpost_id == Prediction.shitpost_id)
-            )
-            max_analysis_date = analysis_date_range_result.scalar()
-            
+            pred_result = await self.db_ops.session.execute(pred_stmt)
+            pred = pred_result.one()
+            analysis_count = pred.total or 0
+            avg_confidence = pred.avg_confidence or 0.0
+
             return {
                 'total_shitposts': shitpost_count,
                 'total_analyses': analysis_count,
@@ -121,11 +99,14 @@ class Statistics:
                 'analysis_rate': round(analysis_count / max(shitpost_count, 1), 3),
                 'earliest_post': min_date.isoformat() if min_date else None,
                 'latest_post': max_date.isoformat() if max_date else None,
-                'earliest_analyzed_post': min_analysis_date.isoformat() if min_analysis_date else None,
-                'latest_analyzed_post': max_analysis_date.isoformat() if max_analysis_date else None,
-                **status_counts
+                'earliest_analyzed_post': pred.min_analysis_date.isoformat() if pred.min_analysis_date else None,
+                'latest_analyzed_post': pred.max_analysis_date.isoformat() if pred.max_analysis_date else None,
+                'completed_count': pred.completed_count,
+                'bypassed_count': pred.bypassed_count,
+                'error_count': pred.error_count,
+                'pending_count': pred.pending_count,
             }
-            
+
         except Exception as e:
             logger.error(f"Error fetching database stats: {e}")
             return {


### PR DESCRIPTION
## Summary
- **WS-A: Multi-LLM Readiness** — Provider-aware existence checks + unprocessed queries, slim analyzer dict (53→18 fields), sentiment CHECK constraint
- **WS-B: Price Query Performance** — Single bounded query replaces 7-query backward walk, batch existence checks in outcome calculator + ticker registry, statistics 8→2 queries
- **WS-C: Feed API Cleanup** — Merged outcomes + snapshots into single SQL JOIN (3 queries→2 per feed request), eliminated Python-side merge
- **WS-D: Schema Cleanup** — FK constraints on symbol columns, sector population on outcomes, migration script 008 for production
- **WS-E: Notifications Fix** — Decoupled from truth_social_shitposts (uses predictions.post_timestamp), moved TelegramSubscription to notifications/models.py

## Test plan
- [x] Full test suite: 1763 passed, 0 failures
- [x] All 5 workstreams committed independently with targeted test runs
- [ ] Run migration script `scripts/008_schema_cleanup.sql` on production Neon before deploy
- [ ] Verify feed API returns snapshot data in merged query format
- [ ] Verify notifications pick up new predictions without truth_social_shitposts dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)