### PR TITLE
feat: ticker validation — defense-in-depth against bad LLM-extracted symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Ticker validation service** — New `TickerValidator` class (`shit/market_data/ticker_validator.py`) with three-layer defense: static blocklist (DEFENSE, CRYPTO, etc.), alias remapping (RTN→RTX, FB→META, etc.), and yfinance spot-check for novel symbols
+- **Registry-first optimization** — Validator skips yfinance for symbols already active in ticker_registry (0ms cached lookup vs 300ms per yfinance call)
+- **Feed API invalid ticker filtering** — Outcomes query excludes tickers with `status='invalid'`; prediction assets filtered in API response to match
+- **Ticker cleanup CLI commands** — `python -m shit.market_data remap-tickers --dry-run` remaps delisted symbols in historical predictions; `python -m shit.market_data clean-concept-tickers --dry-run` removes non-ticker concepts
+- **29 TickerValidator tests** — Blocklist, aliases, registry-first, yfinance spot-check, fail-open, dedup, end-to-end scenarios
+
 ### Changed
+- **LLM prompt ticker guidance** — Updated `get_analysis_prompt()` and `get_detailed_analysis_prompt()` with explicit rules: use current US tickers only, no delisted/renamed/concept symbols, no foreign exchanges, omit uncertain tickers. PROMPT_VERSION bumped to 1.1
+- **Analyzer validates tickers before storage** — Extracted assets filtered through `TickerValidator` before reaching `prediction.assets`, preventing bad tickers at the source
 - **Provider-aware predictions** — `check_prediction_exists()` and `get_unprocessed_*()` queries accept `llm_provider`/`llm_model` params, enabling multiple LLM predictions per post without code changes to callers
 - **Slim analyzer dict** — `get_unprocessed_shitposts()` returns 18 fields actually consumed by the analyzer instead of 53 (all data preserved in `raw_api_data`)
 - **Batch price lookups** — `get_price_on_date()` replaced 7-query backward walk with single bounded SQL query; outcome calculator and ticker registry batch-check existence before per-asset loops

--- a/api/queries/feed_queries.py
+++ b/api/queries/feed_queries.py
@@ -152,6 +152,7 @@ def get_outcomes_for_prediction(prediction_id: int) -> list[dict[str, Any]]:
             ON po.prediction_id = ps.prediction_id
             AND po.symbol = ps.symbol
         WHERE po.prediction_id = :prediction_id
+            AND (tr.status IS NULL OR tr.status != 'invalid')
         ORDER BY po.symbol
     """
 

--- a/api/services/feed_service.py
+++ b/api/services/feed_service.py
@@ -59,6 +59,16 @@ class FeedService:
             snap_data = self._extract_snapshot(o)
             outcomes.append(self.build_outcome(o, snap_data))
 
+        # Filter prediction.assets to exclude invalid tickers (no outcome = filtered by SQL)
+        valid_symbols = {o.symbol for o in outcomes}
+        if valid_symbols and prediction.assets:
+            prediction.assets = [a for a in prediction.assets if a in valid_symbols]
+            prediction.market_impact = {
+                k: v
+                for k, v in prediction.market_impact.items()
+                if k in valid_symbols
+            }
+
         navigation = self.build_navigation(offset, total)
 
         return FeedResponse(

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/00_INVESTIGATION.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/00_INVESTIGATION.md
@@ -1,7 +1,8 @@
 # Investigation: Missing Price Data for Tickers (RTN et al.)
 
-**Status:** IN PROGRESS
+**Status:** COMPLETE
 **Started:** 2026-04-09
+**PR:** #132
 **Date:** 2026-04-09
 **Trigger:** RTN (Raytheon) shows "No price data available" on dispatch 1 of 383
 **Root Cause:** LLM extracts delisted/renamed/conceptual symbols with no validation before registration

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/00_INVESTIGATION.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/00_INVESTIGATION.md
@@ -1,0 +1,69 @@
+# Investigation: Missing Price Data for Tickers (RTN et al.)
+
+**Status:** IN PROGRESS
+**Started:** 2026-04-09
+**Date:** 2026-04-09
+**Trigger:** RTN (Raytheon) shows "No price data available" on dispatch 1 of 383
+**Root Cause:** LLM extracts delisted/renamed/conceptual symbols with no validation before registration
+
+---
+
+## Problem Sized
+
+| Category | Count | Examples | Cause |
+|---|---|---|---|
+| **Not tickers** | 3 | DEFENSE, CRYPTO, NEWSMAX | LLM extracted concepts as ticker symbols |
+| **Delisted/renamed** | 14 | RTN→RTX, TWTR, FB→META, RDS.A→SHEL, CBS→PARA, X (US Steel) | LLM used old/invalid symbols |
+| **Active, need backfill** | 109 | AAPL, TSLA, AMZN | Auto-registered during FK migration, no prices yet |
+| **Active, backfill failed** | ~46 | Various indices, foreign tickers | yfinance couldn't find data but not marked invalid |
+
+**Impact:** 377 of 2,694 completed predictions (14%) have at least one bad ticker.
+
+## Code Path Gaps
+
+| Stage | File | Validation | Gap |
+|---|---|---|---|
+| LLM prompt | `shit/llm/prompts.py:67-72` | "Use standard ticker symbols" | No delisted/concept guidance |
+| Registration | `shit/market_data/ticker_registry.py:48-55` | Format only (length, spaces) | No yfinance validation |
+| Fundamentals | `shit/market_data/fundamentals_provider.py:82-90` | Returns `{}` on failure | Doesn't mark invalid |
+| Backfill | `shit/market_data/auto_backfill_service.py:145-158` | Marks invalid on 0 prices | Correct but runs minutes later |
+| Feed API | `api/queries/feed_queries.py:57-63` | None | Shows invalid tickers |
+| Frontend | `frontend/src/pages/FeedPage.tsx:101-114` | Null coalescing | Shows "No price data" |
+
+## Known Ticker Remappings (Corporate Actions)
+
+| Old Symbol | Current Symbol | Corporate Action |
+|---|---|---|
+| RTN | RTX | Raytheon/UTC merger (Apr 2020) |
+| TWTR | — | Twitter taken private by Musk (Oct 2022) |
+| FB | META | Facebook rebrand (Oct 2021) |
+| RDS.A / RDS.B | SHEL | Shell plc renamed (Jan 2022) |
+| CBS | PARA | CBS/Viacom merger → Paramount (Dec 2019) |
+| PTR | 0857.HK | PetroChina delisted from NYSE (Sep 2022) |
+| SNP | 0386.HK | China Petroleum delisted from NYSE (Sep 2022) |
+| AKS | CLF | AK Steel acquired by Cleveland-Cliffs (Mar 2020) |
+| X | — | US Steel — actually still listed, yfinance issue? |
+| KOL | — | VanEck Coal ETF closed (Dec 2020) |
+| OIL | — | iPath Oil ETN delisted (Apr 2021) |
+
+## Not Tickers (Concepts)
+
+- DEFENSE — military/defense concept, not a ticker
+- CRYPTO — cryptocurrency concept, not a ticker
+- NEWSMAX — media company, not publicly traded (was briefly NMAX in 2025?)
+
+---
+
+## Fix Plan: 5 Tiers
+
+See numbered docs in this directory for implementation details.
+
+### Challenge Round Decisions (2026-04-09)
+
+| # | Challenge | Decision | Rationale |
+|---|-----------|----------|-----------|
+| 1 | Analyzer vs. registry integration | **Analyzer only** | Single gate at the source. Registry is downstream, works on already-stored assets. DRY, clean separation. |
+| 2 | yfinance spot-check latency | **Include with registry-first skip** | 0ms for known-active symbols (cached query). ~300ms only for novel unknowns. Negligible vs. 3-5s LLM call. |
+| 3 | PR strategy | **One PR (Tiers 1-4), Tier 5 post-deploy** | Tightly coupled code changes ship together. Data ops run after deploy with backup. |
+| 4 | Ticker display filtering | **SQL filter only, drop frontend changes** | Frontend already handles missing outcomes. API is single source of truth. Asset list filtered in feed_service.py. |
+| 5 | Tier 5 approach | **CLI commands, not ad-hoc scripts** | Fits CLI-first pattern (13 existing commands). Repeatable for future corporate actions. |

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/01_prompt-guidance.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/01_prompt-guidance.md
@@ -1,0 +1,55 @@
+# Tier 1: Prompt Guidance
+
+**Impact:** High — prevents bad tickers at the source for all future predictions
+**Effort:** Low — prompt text change only
+**Risk:** Low — additive, doesn't affect existing data
+
+---
+
+## Problem
+
+The analysis prompt (`shit/llm/prompts.py:67-72`) says:
+```
+- Use standard ticker symbols (e.g., TSLA, AAPL, BTC, GLD)
+```
+
+This is too vague. The LLM extracts:
+- Old/delisted symbols (RTN instead of RTX, TWTR instead of noting it's private)
+- Concepts as tickers (DEFENSE, CRYPTO, NEWSMAX)
+- Foreign exchange tickers that yfinance handles differently (^BSESN, ^KLSE)
+
+## Changes
+
+### File: `shit/llm/prompts.py`
+
+Replace lines 67-73 (ANALYSIS GUIDELINES section) in `get_analysis_prompt()`:
+
+```python
+ANALYSIS GUIDELINES:
+- Focus on specific companies, stocks, or cryptocurrencies mentioned
+- Consider political influence on market sentiment
+- Be conservative with confidence scores
+- If no financial implications detected, return empty arrays
+- Use CURRENT, actively-traded US ticker symbols only:
+  - ✅ TSLA, AAPL, BTC-USD, GLD, XLE, SPY
+  - ❌ Do NOT use delisted or renamed symbols (RTN → use RTX, FB → use META, TWTR → Twitter is private)
+  - ❌ Do NOT use concepts as tickers (DEFENSE, CRYPTO, ECONOMY are not ticker symbols)
+  - ❌ Do NOT use foreign exchange tickers (use ADRs instead: e.g., BABA not 9988.HK)
+- For ETFs, prefer the most liquid US-listed version (SPY not ^GSPC, QQQ not ^IXIC)
+- If a company is mentioned but you're unsure of the current ticker, omit it rather than guess
+- Consider both direct mentions and implied references
+```
+
+Apply the same changes to `get_detailed_analysis_prompt()` (lines 104-156) which currently has no ticker guidance at all — add the same guidelines block.
+
+## Verification
+
+- Run the analyzer in dry-run mode on a few recent posts to verify the updated prompt produces clean tickers
+- Check that the LLM no longer outputs RTN, TWTR, DEFENSE, etc.
+
+## Deliverables
+
+- [ ] Updated `get_analysis_prompt()` guidelines
+- [ ] Updated `get_detailed_analysis_prompt()` guidelines
+- [ ] Bump `PROMPT_VERSION` to "1.1"
+- [ ] Dry-run verification on 3-5 posts

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/02_validation-service.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/02_validation-service.md
@@ -1,0 +1,186 @@
+# Tier 2: Ticker Validation Service
+
+**Impact:** High — catches bad tickers at the gate before storage
+**Effort:** Medium — new service + integration into analyzer flow
+**Risk:** Low — additive, validation is best-effort (doesn't block analysis)
+
+---
+
+## Problem
+
+`ticker_registry.py:register_tickers()` only validates format (length ≤ 20, no spaces). Any string that passes format check gets registered as "active" and triggers price backfill. Bad tickers waste API calls and show "No price data" in the UI.
+
+The fundamentals provider (`fundamentals_provider.py:82-90`) detects bad tickers but only logs a warning — it doesn't mark them invalid. The backfill service (`auto_backfill_service.py:145-158`) marks them invalid, but that runs minutes later via the event pipeline.
+
+## Design
+
+### New file: `shit/market_data/ticker_validator.py`
+
+A lightweight validation service that checks tickers against yfinance before registration.
+
+```python
+class TickerValidator:
+    """Validates ticker symbols against yfinance before registration."""
+
+    # Known non-ticker strings the LLM commonly extracts
+    BLOCKLIST = frozenset({
+        "DEFENSE", "CRYPTO", "ECONOMY", "NEWSMAX", "TARIFF",
+        "GDP", "CPI", "FED", "NATO", "CEO", "IPO", "ESG",
+    })
+
+    # Known delisted → current mappings
+    ALIASES = {
+        "RTN": "RTX",
+        "FB": "META",
+        "TWTR": None,       # Private, no replacement
+        "RDS.A": "SHEL",
+        "RDS.B": "SHEL",
+        "CBS": "PARA",
+        "PTR": None,         # Delisted from US exchanges
+        "SNP": None,         # Delisted from US exchanges
+        "AKS": "CLF",
+        "KOL": None,         # ETF closed
+        "OIL": None,         # ETN delisted
+    }
+
+    def __init__(self, session=None):
+        """Initialize with optional DB session for registry-first optimization."""
+        self._session = session
+        self._known_active: set[str] | None = None
+
+    def validate_symbols(self, symbols: list[str]) -> list[str]:
+        """Validate and normalize a list of ticker symbols.
+
+        Returns only valid, tradeable symbols. Applies alias
+        remapping and blocklist filtering. Checks yfinance for
+        unknown symbols (skips if already active in ticker_registry).
+
+        Args:
+            symbols: Raw ticker symbols from LLM extraction.
+
+        Returns:
+            List of validated, normalized symbols.
+        """
+        validated = []
+        for raw in symbols:
+            symbol = raw.strip().upper()
+
+            # Blocklist check
+            if symbol in self.BLOCKLIST:
+                logger.info(f"Blocked non-ticker symbol: {symbol}")
+                continue
+
+            # Alias remapping
+            if symbol in self.ALIASES:
+                replacement = self.ALIASES[symbol]
+                if replacement is None:
+                    logger.info(f"Filtered delisted ticker with no replacement: {symbol}")
+                    continue
+                logger.info(f"Remapped {symbol} → {replacement}")
+                symbol = replacement
+
+            # Registry-first optimization: skip yfinance for known-active symbols
+            if self._is_known_active(symbol):
+                validated.append(symbol)
+                continue
+
+            # yfinance spot-check for unknown symbols
+            if not self._is_tradeable(symbol):
+                logger.info(f"yfinance validation failed for {symbol}")
+                continue
+
+            validated.append(symbol)
+
+        return validated
+
+    def _is_known_active(self, symbol: str) -> bool:
+        """Check if symbol is already active in ticker_registry. 0ms for cached lookups."""
+        if self._session is None:
+            return False
+        if self._known_active is None:
+            from shit.market_data.models import TickerRegistry
+            rows = self._session.query(TickerRegistry.symbol).filter(
+                TickerRegistry.status == "active"
+            ).all()
+            self._known_active = {r.symbol for r in rows}
+        return symbol in self._known_active
+
+    def _is_tradeable(self, symbol: str) -> bool:
+        """Quick check if yfinance recognizes this as a tradeable symbol."""
+        try:
+            import yfinance as yf
+            ticker = yf.Ticker(symbol)
+            info = ticker.info or {}
+            # Must have a quoteType that indicates it's a real security
+            quote_type = info.get("quoteType", "")
+            if quote_type in ("EQUITY", "ETF", "MUTUALFUND", "CRYPTOCURRENCY", "FUTURE", "INDEX"):
+                return True
+            # Fallback: check if fast_info has a price
+            fast = ticker.fast_info
+            if hasattr(fast, "last_price") and fast.last_price is not None:
+                return True
+            return False
+        except Exception:
+            # Network errors shouldn't block registration
+            return True  # Fail open — let backfill handle it later
+```
+
+### ~~Integration point: `ticker_registry.py:register_tickers()`~~ — REMOVED
+
+**Challenge Round Decision:** Registry-level validation removed. The analyzer is the single gate.
+`register_tickers()` is downstream of `store_analysis()` — it works on already-stored assets.
+Validating there is redundant (double-filtering) and muddies separation of concerns.
+The CLI `register-tickers` command is a manual operator tool — operators are responsible for their input.
+
+### Integration point: `shitpost_ai/shitpost_analyzer.py`
+
+Single integration point — validate extracted assets before storing:
+
+```python
+# In _analyze_shitpost(), after LLM returns analysis
+# Before calling store_analysis()
+from shit.market_data.ticker_validator import TickerValidator
+validator = TickerValidator()
+analysis["assets"] = validator.validate_symbols(analysis.get("assets", []))
+# Also update market_impact to match filtered assets
+analysis["market_impact"] = {
+    k: v for k, v in analysis.get("market_impact", {}).items()
+    if k in analysis["assets"]
+}
+```
+
+This way, bad tickers never reach the prediction record at all.
+
+## Design Decisions
+
+1. **Validate at extraction, not registration** — prevents bad tickers from appearing in `prediction.assets` entirely
+2. **Single integration point (analyzer only)** — registry-level validation removed; register_tickers() is downstream and works on already-stored assets (Challenge Round)
+3. **Fail open on network errors** — don't block analysis because yfinance is slow
+4. **Static blocklist + aliases** — fast, no API call needed for known-bad symbols
+5. **yfinance spot-check for unknowns** — catches novel bad tickers at ~300ms cost per symbol
+6. **Registry-first optimization** — skip yfinance for symbols already active in ticker_registry (0ms) (Challenge Round)
+7. **Aliases as a dict, not a DB table** — these change rarely (corporate actions are infrequent), code is easier to maintain than a table
+
+## Performance Consideration
+
+The yfinance `_is_tradeable()` check adds ~300ms per unknown symbol. For a typical prediction with 3-5 assets:
+- Blocklist/alias hits: 0ms (dict lookups)
+- Already-registered symbols: 0ms (registry-first cache, single query on first call)
+- Novel symbols: ~300ms each, 1-2 per prediction typically
+
+Total added latency: <1s per prediction, which is negligible compared to the LLM call (~3-5s).
+
+## Verification
+
+- Unit tests for blocklist, aliases, and yfinance integration
+- Test with known bad symbols: RTN, DEFENSE, TWTR, CRYPTO
+- Test with known good symbols: AAPL, TSLA, SPY, BTC-USD
+- Test fail-open behavior when yfinance is unreachable
+
+## Deliverables
+
+- [ ] New `shit/market_data/ticker_validator.py` with `TickerValidator` class
+- [ ] Integration in `shitpost_analyzer.py` (pre-storage validation)
+- [ ] Unit tests in `shit_tests/shit/market_data/test_ticker_validator.py`
+- [ ] Blocklist seeded with known bad symbols
+- [ ] Aliases seeded with known corporate actions

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/03_manual-remapping.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/03_manual-remapping.md
@@ -1,0 +1,55 @@
+# Tier 3: Manual Remapping (Aliases)
+
+**Impact:** Medium — fixes known corporate action issues for past and future predictions
+**Effort:** Low — data dict in the validation service (Tier 2)
+**Risk:** Low — remapping is deterministic and auditable
+
+---
+
+## Problem
+
+Corporate actions (mergers, renames, delistings) create a mismatch between the symbol the LLM extracts and the symbol yfinance can price. This is a recurring problem — every corporate action creates a new stale ticker.
+
+## Design
+
+The alias mapping lives as a static dict in `TickerValidator` (Tier 2). This is deliberate:
+
+1. **Not a DB table** — corporate actions happen ~monthly, not daily. A code dict is version-controlled, testable, and reviewable. A DB table adds operational complexity for a problem that changes slowly.
+2. **Applied at extraction time** — before the ticker reaches `prediction.assets`, so the stored prediction always has the current symbol.
+3. **Null mappings** — `TWTR: None` means "this ticker has no valid replacement, filter it out."
+
+## Known Aliases (Seed Data)
+
+| Old | Current | Action | Date |
+|---|---|---|---|
+| RTN | RTX | Raytheon/UTC merger | Apr 2020 |
+| FB | META | Facebook rebrand | Oct 2021 |
+| RDS.A | SHEL | Shell plc rename | Jan 2022 |
+| RDS.B | SHEL | Shell plc rename | Jan 2022 |
+| CBS | PARA | CBS/Viacom → Paramount | Dec 2019 |
+| AKS | CLF | AK Steel → Cleveland-Cliffs | Mar 2020 |
+| TWTR | None | Twitter taken private | Oct 2022 |
+| PTR | None | PetroChina delisted from NYSE | Sep 2022 |
+| SNP | None | China Petroleum delisted | Sep 2022 |
+| KOL | None | VanEck Coal ETF closed | Dec 2020 |
+| OIL | None | iPath Oil ETN delisted | Apr 2021 |
+
+## Maintenance Process
+
+When a new corporate action is identified:
+1. Add entry to `ALIASES` dict in `ticker_validator.py`
+2. Add to the Known Aliases table in this doc
+3. Run retroactive fix (Tier 5) if old symbol exists in historical predictions
+
+## Existing Prediction Remediation
+
+For the 17 currently-invalid tickers, Tier 5 (retroactive cleanup) will:
+1. Update `prediction.assets` JSON to use the new symbol where a mapping exists
+2. Update `prediction.market_impact` JSON keys to match
+3. Re-trigger outcome calculation for remapped predictions
+
+## Deliverables
+
+- [ ] ALIASES dict seeded in `TickerValidator` (covered by Tier 2)
+- [ ] Known aliases documented in this file
+- [ ] Maintenance process documented

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/04_feed-api-filtering.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/04_feed-api-filtering.md
@@ -1,0 +1,61 @@
+# Tier 4: Feed API Filtering
+
+**Impact:** Medium — immediate UX improvement, hides invalid tickers from display
+**Effort:** Low — SQL WHERE clause addition
+**Risk:** Low — filtering only, doesn't modify data
+
+---
+
+## Problem
+
+The feed API (`api/queries/feed_queries.py:88-159`) returns outcomes for ALL tickers in a prediction, including those marked "invalid" in the ticker registry. The frontend then shows "No price data available" for these tickers.
+
+The main post query (`feed_queries.py:57-63`) selects predictions with non-empty assets, but doesn't check whether those assets are valid/priceable.
+
+## Changes
+
+### File: `api/queries/feed_queries.py`
+
+**Change 1: Filter outcomes to valid tickers only**
+
+In `get_outcomes_for_prediction()`, add a WHERE clause to exclude invalid tickers:
+
+```sql
+-- Current (line 142):
+WHERE po.prediction_id = :prediction_id
+
+-- Updated:
+WHERE po.prediction_id = :prediction_id
+  AND (tr.status IS NULL OR tr.status != 'invalid')
+```
+
+The `LEFT JOIN ticker_registry tr` already exists. `tr.status IS NULL` handles tickers not yet in the registry (should be rare after Tier 2, but defensive). `tr.status != 'invalid'` filters out known-bad tickers.
+
+**Change 2: Filter `prediction.assets` in API response**
+
+In `api/services/feed_service.py`, filter the assets list to exclude invalid tickers before sending to frontend. This is a 2-line change — the API decides what's valid, the frontend displays what it receives.
+
+```python
+# In build_prediction() or the service method that assembles the response
+# Filter assets to only include tickers that have outcomes
+valid_assets = [a for a in assets if a in {o["symbol"] for o in outcomes}]
+```
+
+**Challenge Round Decision:** Frontend changes (Options A/B on TickerSelector.tsx) removed.
+The frontend already handles missing outcomes gracefully (`activeOutcome` is undefined, components show null).
+Filtering in both SQL and frontend would be double-filtering. The API is the single source of truth for what's valid.
+After Tiers 1-2 deploy, new predictions won't have invalid tickers in `prediction.assets` at all.
+After Tier 5 retroactive cleanup, historical data will be fixed too. This is a diminishing problem.
+
+## Verification
+
+- Load feed page, navigate to a dispatch with previously-invalid tickers (e.g., RTN post)
+- Verify invalid tickers no longer appear in ticker pills
+- Verify valid tickers on the same prediction still display correctly
+- Verify predictions with ALL invalid tickers still show (with thesis, no ticker pills)
+
+## Deliverables
+
+- [ ] Updated `get_outcomes_for_prediction()` WHERE clause
+- [ ] API-level asset filtering in `feed_service.py`
+- [ ] Manual verification on production feed

--- a/documentation/planning/investigations/ticker-validation_2026-04-09/05_retroactive-cleanup.md
+++ b/documentation/planning/investigations/ticker-validation_2026-04-09/05_retroactive-cleanup.md
@@ -1,0 +1,123 @@
+# Tier 5: Retroactive Cleanup
+
+**Impact:** Medium — fixes existing bad data, fills gaps in price coverage
+**Effort:** Medium — CLI commands + backfill runs
+**Risk:** Medium — modifies existing prediction records (requires backup)
+
+---
+
+## Problem
+
+Historical predictions contain bad ticker symbols that will never resolve. Three sub-problems:
+
+1. **109 active tickers with 0 prices** — legitimate tickers auto-registered during FK migration, need price backfill
+2. **17 invalid tickers** — some have remappings (RTN→RTX), some are concepts (DEFENSE), some are truly dead
+3. **Remappable predictions** — predictions that reference old tickers where a current equivalent exists
+
+## Step 1: Backfill Prices for Active Tickers
+
+These 109 tickers were auto-registered for FK constraint compliance. Most are legitimate symbols (AAPL, TSLA, AMZN, etc.) that just need price data fetched.
+
+```bash
+# Safe — additive operation, no data modification
+python -m shit.market_data backfill-all-missing
+```
+
+This will:
+- Iterate over active tickers with 0 price records
+- Fetch price history from yfinance
+- Mark any that fail as "invalid"
+- Expected: ~100 tickers get prices, ~9 get marked invalid (indices, foreign tickers)
+
+## Step 2: Re-validate "Active" Tickers That Failed
+
+After backfill, some tickers will still have 0 records but remain "active" (yfinance timeout, temporary API issue). Run a targeted re-check:
+
+```python
+from shit.db.sync_session import engine
+from sqlalchemy import text
+
+with engine.connect() as conn:
+    # Find active tickers that still have 0 records after backfill
+    result = conn.execute(text('''
+        SELECT symbol FROM ticker_registry
+        WHERE status = 'active' AND total_price_records = 0
+    '''))
+    stale = [r[0] for r in result]
+    print(f"Still-empty active tickers: {len(stale)}")
+    print(stale)
+```
+
+For each, check yfinance manually and mark invalid if appropriate.
+
+## Step 3: Remap Historical Predictions via CLI (Requires Backup)
+
+**⚠️ This modifies existing prediction records. Create a Neon backup branch first.**
+
+**Challenge Round Decision:** Replaced ad-hoc SQL scripts with CLI commands. Fits the codebase's CLI-first pattern (13 existing Click commands in market_data). Makes operations repeatable for future corporate actions.
+
+### New CLI command: `python -m shit.market_data remap-tickers`
+
+```bash
+# Dry run — shows what would change, no modifications
+python -m shit.market_data remap-tickers --dry-run
+
+# Execute remapping (requires Neon backup first)
+python -m shit.market_data remap-tickers
+```
+
+The command imports `ALIASES` from `TickerValidator` (single source of truth for remappings) and for each alias with a non-None replacement:
+- Updates `predictions.assets` JSON array (old symbol → new symbol)
+- Updates `predictions.market_impact` JSON keys (old key → new key)
+- Reports affected row counts per symbol
+
+Implementation lives in `cli_registry.py`, logic in a service method on `TickerRegistryService`.
+
+## Step 4: Remove Concept "Tickers" via CLI
+
+### New CLI command: `python -m shit.market_data clean-concept-tickers`
+
+```bash
+# Dry run — shows what would change
+python -m shit.market_data clean-concept-tickers --dry-run
+
+# Execute removal
+python -m shit.market_data clean-concept-tickers
+```
+
+The command imports `BLOCKLIST` from `TickerValidator` and for each concept found in predictions:
+- Removes from `predictions.assets` JSON array
+- Removes from `predictions.market_impact` JSON keys
+- Reports affected row counts per concept
+
+## Step 5: Re-trigger Outcome Calculation for Remapped Predictions
+
+After remapping RTN→RTX in a prediction, the prediction now references RTX but has no `prediction_outcome` for RTX. Use the existing CLI:
+
+```bash
+# Recalculate outcomes for all predictions (safe — skips already-complete ones)
+python -m shit.market_data calculate-outcomes
+```
+
+## Execution Order
+
+1. Create Neon backup branch
+2. Run `backfill-all-missing` (Step 1)
+3. Re-validate remaining empty tickers (Step 2)
+4. Count affected predictions for each remap (dry run)
+5. Execute remaps (Step 3) — user approval required
+6. Remove concepts (Step 4) — user approval required
+7. Re-trigger outcomes (Step 5)
+8. Verify feed displays correctly
+
+## Deliverables
+
+- [ ] `remap-tickers` CLI command with `--dry-run` flag
+- [ ] `clean-concept-tickers` CLI command with `--dry-run` flag
+- [ ] Neon backup branch created
+- [ ] Price backfill run for 109 active tickers
+- [ ] Stale active tickers re-validated and marked invalid
+- [ ] Historical predictions remapped via `remap-tickers`
+- [ ] Concept tickers removed via `clean-concept-tickers`
+- [ ] Outcomes recalculated for remapped predictions
+- [ ] Feed verification on production

--- a/shit/llm/prompts.py
+++ b/shit/llm/prompts.py
@@ -15,7 +15,7 @@ SYSTEM_MESSAGES = {
 }
 
 # Prompt versions for consistency
-PROMPT_VERSION = "1.0"
+PROMPT_VERSION = "1.1"
 
 
 def get_analysis_prompt(content: str, context: Optional[Dict] = None) -> str:
@@ -69,7 +69,13 @@ ANALYSIS GUIDELINES:
 - Consider political influence on market sentiment
 - Be conservative with confidence scores
 - If no financial implications detected, return empty arrays
-- Use standard ticker symbols (e.g., TSLA, AAPL, BTC, GLD)
+- Use CURRENT, actively-traded US ticker symbols only:
+  - Good: TSLA, AAPL, BTC-USD, GLD, XLE, SPY
+  - Do NOT use delisted or renamed symbols (RTN → use RTX, FB → use META, TWTR → Twitter is private)
+  - Do NOT use concepts as tickers (DEFENSE, CRYPTO, ECONOMY are not ticker symbols)
+  - Do NOT use foreign exchange tickers (use ADRs instead: e.g., BABA not 9988.HK)
+- For ETFs, prefer the most liquid US-listed version (SPY not ^GSPC, QQQ not ^IXIC)
+- If a company is mentioned but you're unsure of the current ticker, omit it rather than guess
 - Consider both direct mentions and implied references
 
 EXAMPLES:
@@ -149,6 +155,15 @@ OUTPUT FORMAT:
     "risks": ["List of potential confounding factors"],
     "confidence": 0.85
 }}
+
+TICKER GUIDELINES:
+- Use CURRENT, actively-traded US ticker symbols only:
+  - Good: TSLA, AAPL, BTC-USD, GLD, XLE, SPY
+  - Do NOT use delisted or renamed symbols (RTN → use RTX, FB → use META, TWTR → Twitter is private)
+  - Do NOT use concepts as tickers (DEFENSE, CRYPTO, ECONOMY are not ticker symbols)
+  - Do NOT use foreign exchange tickers (use ADRs instead: e.g., BABA not 9988.HK)
+- For ETFs, prefer the most liquid US-listed version (SPY not ^GSPC, QQQ not ^IXIC)
+- If a company is mentioned but you're unsure of the current ticker, omit it rather than guess
 
 Now provide your detailed analysis:
 """

--- a/shit/market_data/cli.py
+++ b/shit/market_data/cli.py
@@ -29,6 +29,8 @@ from shit.market_data.cli_outcomes import (
 from shit.market_data.cli_registry import (
     ticker_registry_cmd,
     register_tickers_cmd,
+    remap_tickers_cmd,
+    clean_concept_tickers_cmd,
 )
 
 
@@ -56,6 +58,8 @@ cli.add_command(auto_pipeline)
 # Registry commands
 cli.add_command(ticker_registry_cmd)
 cli.add_command(register_tickers_cmd)
+cli.add_command(remap_tickers_cmd)
+cli.add_command(clean_concept_tickers_cmd)
 
 
 if __name__ == "__main__":

--- a/shit/market_data/cli_registry.py
+++ b/shit/market_data/cli_registry.py
@@ -1,13 +1,15 @@
 """
 Market Data CLI — Ticker Registry Commands
 
-Commands for managing the ticker registry.
+Commands for managing the ticker registry, including retroactive
+cleanup of historical predictions (remap aliases, remove concepts).
 """
 
 import click
 from rich.console import Console
 from rich.table import Table
 from rich import print as rprint
+from sqlalchemy import text
 
 from shit.logging import print_success, print_error, print_info
 from shit.db.sync_session import get_session
@@ -91,4 +93,170 @@ def register_tickers_cmd(symbols: tuple):
 
     except Exception as e:
         print_error(f"Error registering tickers: {e}")
+        raise click.Abort()
+
+
+@click.command(name="remap-tickers")
+@click.option("--dry-run", is_flag=True, help="Show what would change without modifying data")
+def remap_tickers_cmd(dry_run: bool):
+    """Remap historical predictions with delisted/renamed tickers using ALIASES.
+
+    Updates predictions.assets and predictions.market_impact for tickers
+    that have a known replacement (e.g., RTN→RTX, FB→META).
+    """
+    from shit.market_data.ticker_validator import TickerValidator
+
+    aliases_with_replacement = {
+        old: new for old, new in TickerValidator.ALIASES.items() if new is not None
+    }
+
+    if not aliases_with_replacement:
+        print_info("No aliases with replacements configured")
+        return
+
+    try:
+        total_remapped = 0
+        with get_session() as session:
+            for old_symbol, new_symbol in aliases_with_replacement.items():
+                # Count affected predictions
+                result = session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM predictions "
+                        "WHERE assets::text LIKE :pattern"
+                    ),
+                    {"pattern": f'%"{old_symbol}"%'},
+                )
+                count = result.scalar()
+
+                if count == 0:
+                    continue
+
+                if dry_run:
+                    rprint(
+                        f"  [yellow]Would remap[/yellow] {old_symbol} → {new_symbol}: "
+                        f"[bold]{count}[/bold] predictions"
+                    )
+                else:
+                    # Update assets array
+                    session.execute(
+                        text("""
+                            UPDATE predictions
+                            SET assets = (
+                                SELECT jsonb_agg(
+                                    CASE WHEN elem = :old THEN :new ELSE elem END
+                                )
+                                FROM jsonb_array_elements_text(assets::jsonb) AS elem
+                            )::json
+                            WHERE assets::text LIKE :pattern
+                        """),
+                        {"old": old_symbol, "new": new_symbol, "pattern": f'%"{old_symbol}"%'},
+                    )
+                    # Update market_impact keys
+                    session.execute(
+                        text("""
+                            UPDATE predictions
+                            SET market_impact = (
+                                market_impact::jsonb - :old
+                                || jsonb_build_object(:new, market_impact::jsonb -> :old)
+                            )::json
+                            WHERE market_impact::text LIKE :pattern
+                        """),
+                        {"old": old_symbol, "new": new_symbol, "pattern": f'%"{old_symbol}"%'},
+                    )
+                    rprint(
+                        f"  [green]Remapped[/green] {old_symbol} → {new_symbol}: "
+                        f"[bold]{count}[/bold] predictions"
+                    )
+                total_remapped += count
+
+            if not dry_run:
+                session.commit()
+
+        if total_remapped == 0:
+            print_info("No predictions to remap")
+        elif dry_run:
+            rprint(f"\n[yellow]Dry run:[/yellow] {total_remapped} predictions would be remapped")
+        else:
+            print_success(f"Remapped {total_remapped} predictions")
+
+    except Exception as e:
+        print_error(f"Error remapping tickers: {e}")
+        raise click.Abort()
+
+
+@click.command(name="clean-concept-tickers")
+@click.option("--dry-run", is_flag=True, help="Show what would change without modifying data")
+def clean_concept_tickers_cmd(dry_run: bool):
+    """Remove non-ticker concepts (DEFENSE, CRYPTO, etc.) from historical predictions.
+
+    Removes concept strings from predictions.assets arrays and
+    predictions.market_impact dicts.
+    """
+    from shit.market_data.ticker_validator import TickerValidator
+
+    concepts = sorted(TickerValidator.BLOCKLIST)
+
+    try:
+        total_cleaned = 0
+        with get_session() as session:
+            for concept in concepts:
+                # Count affected predictions
+                result = session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM predictions "
+                        "WHERE assets::text LIKE :pattern"
+                    ),
+                    {"pattern": f'%"{concept}"%'},
+                )
+                count = result.scalar()
+
+                if count == 0:
+                    continue
+
+                if dry_run:
+                    rprint(
+                        f"  [yellow]Would remove[/yellow] {concept}: "
+                        f"[bold]{count}[/bold] predictions"
+                    )
+                else:
+                    # Remove from assets array
+                    session.execute(
+                        text("""
+                            UPDATE predictions
+                            SET assets = (
+                                SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
+                                FROM jsonb_array_elements_text(assets::jsonb) AS elem
+                                WHERE elem != :concept
+                            )::json
+                            WHERE assets::text LIKE :pattern
+                        """),
+                        {"concept": concept, "pattern": f'%"{concept}"%'},
+                    )
+                    # Remove from market_impact
+                    session.execute(
+                        text("""
+                            UPDATE predictions
+                            SET market_impact = (market_impact::jsonb - :concept)::json
+                            WHERE market_impact::text LIKE :pattern
+                        """),
+                        {"concept": concept, "pattern": f'%"{concept}"%'},
+                    )
+                    rprint(
+                        f"  [green]Removed[/green] {concept}: "
+                        f"[bold]{count}[/bold] predictions"
+                    )
+                total_cleaned += count
+
+            if not dry_run:
+                session.commit()
+
+        if total_cleaned == 0:
+            print_info("No concept tickers found in predictions")
+        elif dry_run:
+            rprint(f"\n[yellow]Dry run:[/yellow] {total_cleaned} predictions would be cleaned")
+        else:
+            print_success(f"Cleaned {total_cleaned} predictions")
+
+    except Exception as e:
+        print_error(f"Error cleaning concept tickers: {e}")
         raise click.Abort()

--- a/shit/market_data/ticker_validator.py
+++ b/shit/market_data/ticker_validator.py
@@ -1,0 +1,152 @@
+"""
+Ticker Validation Service
+
+Validates and normalizes ticker symbols extracted by LLMs before they
+reach prediction storage. Three layers of defense:
+
+1. Static blocklist — known non-ticker strings (DEFENSE, CRYPTO, etc.)
+2. Alias remapping — delisted/renamed symbols (RTN→RTX, FB→META, etc.)
+3. yfinance spot-check — catches novel bad tickers (~300ms per symbol)
+
+Registry-first optimization: symbols already active in ticker_registry
+skip the yfinance check entirely (0ms cached lookup).
+"""
+
+import logging
+from typing import Optional
+
+import yfinance as yf
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+class TickerValidator:
+    """Validates ticker symbols against blocklist, aliases, and yfinance."""
+
+    # Known non-ticker strings the LLM commonly extracts
+    BLOCKLIST: frozenset[str] = frozenset({
+        "DEFENSE", "CRYPTO", "ECONOMY", "NEWSMAX", "TARIFF",
+        "GDP", "CPI", "FED", "NATO", "CEO", "IPO", "ESG",
+    })
+
+    # Known delisted → current mappings (None = no replacement, filter out)
+    ALIASES: dict[str, Optional[str]] = {
+        "RTN": "RTX",
+        "FB": "META",
+        "TWTR": None,       # Twitter taken private (Oct 2022)
+        "RDS.A": "SHEL",
+        "RDS.B": "SHEL",
+        "CBS": "PARA",
+        "PTR": None,         # PetroChina delisted from NYSE (Sep 2022)
+        "SNP": None,         # China Petroleum delisted from NYSE (Sep 2022)
+        "AKS": "CLF",
+        "KOL": None,         # VanEck Coal ETF closed (Dec 2020)
+        "OIL": None,         # iPath Oil ETN delisted (Apr 2021)
+    }
+
+    def __init__(self, session: Optional[Session] = None):
+        """Initialize with optional DB session for registry-first optimization.
+
+        Args:
+            session: SQLAlchemy session for querying ticker_registry.
+                     If None, yfinance check runs for all unknown symbols.
+        """
+        self._session = session
+        self._known_active: Optional[set[str]] = None
+
+    def validate_symbols(self, symbols: list[str]) -> list[str]:
+        """Validate and normalize a list of ticker symbols.
+
+        Returns only valid, tradeable symbols. Applies blocklist filtering,
+        alias remapping, and yfinance spot-check (skipped for known-active).
+
+        Args:
+            symbols: Raw ticker symbols from LLM extraction.
+
+        Returns:
+            List of validated, normalized symbols (deduped, order preserved).
+        """
+        validated = []
+        seen: set[str] = set()
+
+        for raw in symbols:
+            symbol = raw.strip().upper()
+            if not symbol:
+                continue
+
+            # Blocklist check
+            if symbol in self.BLOCKLIST:
+                logger.info(f"Blocked non-ticker symbol: {symbol}")
+                continue
+
+            # Alias remapping
+            if symbol in self.ALIASES:
+                replacement = self.ALIASES[symbol]
+                if replacement is None:
+                    logger.info(
+                        f"Filtered delisted ticker with no replacement: {symbol}"
+                    )
+                    continue
+                logger.info(f"Remapped {symbol} → {replacement}")
+                symbol = replacement
+
+            # Dedup (e.g., RDS.A and RDS.B both map to SHEL)
+            if symbol in seen:
+                continue
+            seen.add(symbol)
+
+            # Registry-first optimization: skip yfinance for known-active symbols
+            if self._is_known_active(symbol):
+                validated.append(symbol)
+                continue
+
+            # yfinance spot-check for unknown symbols
+            if not self._is_tradeable(symbol):
+                logger.info(f"yfinance validation failed for {symbol}")
+                continue
+
+            validated.append(symbol)
+
+        return validated
+
+    def _is_known_active(self, symbol: str) -> bool:
+        """Check if symbol is already active in ticker_registry.
+
+        Caches the full active set on first call (single query).
+        Returns False if no session provided.
+        """
+        if self._session is None:
+            return False
+        if self._known_active is None:
+            from shit.market_data.models import TickerRegistry
+            rows = self._session.query(TickerRegistry.symbol).filter(
+                TickerRegistry.status == "active"
+            ).all()
+            self._known_active = {r.symbol for r in rows}
+        return symbol in self._known_active
+
+    def _is_tradeable(self, symbol: str) -> bool:
+        """Quick yfinance check if this is a tradeable symbol.
+
+        Fails open on network errors — don't block analysis because
+        yfinance is slow. The backfill service will catch it later.
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info or {}
+            # Must have a quoteType that indicates it's a real security
+            quote_type = info.get("quoteType", "")
+            if quote_type in (
+                "EQUITY", "ETF", "MUTUALFUND", "CRYPTOCURRENCY",
+                "FUTURE", "INDEX",
+            ):
+                return True
+            # Fallback: check if fast_info has a price
+            fast = ticker.fast_info
+            if hasattr(fast, "last_price") and fast.last_price is not None:
+                return True
+            return False
+        except Exception:
+            # Network errors shouldn't block registration — fail open
+            return True

--- a/shit_tests/api/test_feed_service.py
+++ b/shit_tests/api/test_feed_service.py
@@ -371,3 +371,102 @@ class TestGetFeedResponse:
         assert result.prediction.assets == ["SPY"]
         assert result.outcomes == []
         assert result.navigation.total_posts == 10
+
+    def test_filters_invalid_tickers_from_assets(self):
+        """Assets in prediction that have no outcome (filtered by SQL) should be removed."""
+        row = {
+            "shitpost_id": "post_2",
+            "text": "Defense and stocks",
+            "content_html": None,
+            "timestamp": datetime(2026, 3, 25, 14, 30, 0),
+            "username": "user",
+            "url": None,
+            "replies_count": 0,
+            "reblogs_count": 0,
+            "favourites_count": 0,
+            "upvotes_count": 0,
+            "downvotes_count": 0,
+            "account_verified": False,
+            "account_followers_count": None,
+            "card": None,
+            "media_attachments": None,
+            "in_reply_to": None,
+            "reblog": None,
+            "prediction_id": 2,
+            "assets": ["RTX", "RTN", "DEFENSE"],
+            "market_impact": {"RTX": "bullish", "RTN": "bullish", "DEFENSE": "bullish"},
+            "confidence": 0.7,
+            "thesis": "Defense spending",
+            "analysis_status": "completed",
+            "engagement_score": None,
+            "viral_score": None,
+            "sentiment_score": None,
+            "urgency_score": None,
+        }
+
+        # Only RTX has an outcome (RTN and DEFENSE filtered by SQL)
+        outcomes_raw = [
+            {
+                "symbol": "RTX",
+                "prediction_sentiment": "bullish",
+                "prediction_confidence": 0.7,
+                "prediction_date": date(2026, 3, 25),
+                "price_at_prediction": 120.0,
+                "price_at_post": None,
+                "return_same_day": None,
+                "return_1h": None,
+                "return_t1": 1.5,
+                "return_t3": None,
+                "return_t7": None,
+                "return_t30": None,
+                "correct_same_day": None,
+                "correct_1h": None,
+                "correct_t1": True,
+                "correct_t3": None,
+                "correct_t7": None,
+                "correct_t30": None,
+                "pnl_same_day": None,
+                "pnl_1h": None,
+                "pnl_t1": 15.0,
+                "pnl_t3": None,
+                "pnl_t7": None,
+                "pnl_t30": None,
+                "is_complete": False,
+                "company_name": "RTX Corporation",
+                "asset_type": "stock",
+                "exchange": "NYSE",
+                "sector": "Industrials",
+                "industry": "Aerospace & Defense",
+                "market_cap": 150000000000,
+                "pe_ratio": 22.0,
+                "forward_pe": 20.0,
+                "beta": 0.9,
+                "dividend_yield": 0.02,
+                "snapshot_price": None,
+                "snapshot_captured_at": None,
+                "snapshot_market_status": None,
+                "snapshot_previous_close": None,
+                "snapshot_day_high": None,
+                "snapshot_day_low": None,
+            }
+        ]
+
+        with (
+            patch(
+                "api.services.feed_service.get_analyzed_post_at_offset",
+                return_value=(row, 5),
+            ),
+            patch(
+                "api.services.feed_service.get_outcomes_for_prediction",
+                return_value=outcomes_raw,
+            ),
+        ):
+            service = FeedService()
+            result = service.get_feed_response(0)
+
+        assert result is not None
+        # Only RTX should remain in assets (RTN and DEFENSE filtered)
+        assert result.prediction.assets == ["RTX"]
+        assert result.prediction.market_impact == {"RTX": "bullish"}
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].symbol == "RTX"

--- a/shit_tests/shit/market_data/test_market_data_cli.py
+++ b/shit_tests/shit/market_data/test_market_data_cli.py
@@ -349,6 +349,118 @@ class TestCliGroupRegistration:
             "backfill-all-missing",
             "accuracy-report",
             "price-stats",
+            "remap-tickers",
+            "clean-concept-tickers",
         ]
         for cmd in expected_commands:
             assert cmd in result.output, f"Command '{cmd}' not found in CLI help"
+
+
+class TestRemapTickersCommand:
+    """Test remap-tickers CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_help_shows_description(self, runner):
+        result = runner.invoke(cli, ["remap-tickers", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+
+    def test_dry_run_shows_counts(self, runner):
+        """Dry run should show affected prediction counts without modifying data."""
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        # Simulate RTN having 3 affected predictions
+        def mock_execute(query, params=None):
+            result = MagicMock()
+            if params and "RTN" in str(params.get("pattern", "")):
+                result.scalar.return_value = 3
+            else:
+                result.scalar.return_value = 0
+            return result
+
+        mock_session.execute.side_effect = mock_execute
+
+        with patch("shit.market_data.cli_registry.get_session", return_value=mock_ctx):
+            result = runner.invoke(cli, ["remap-tickers", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would remap" in result.output
+        # Should NOT commit in dry-run
+        mock_session.commit.assert_not_called()
+
+    def test_no_affected_predictions(self, runner):
+        """When no predictions need remapping, show info message."""
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        result_mock = MagicMock()
+        result_mock.scalar.return_value = 0
+        mock_session.execute.return_value = result_mock
+
+        with patch("shit.market_data.cli_registry.get_session", return_value=mock_ctx):
+            result = runner.invoke(cli, ["remap-tickers", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "No predictions to remap" in result.output
+
+
+class TestCleanConceptTickersCommand:
+    """Test clean-concept-tickers CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_help_shows_description(self, runner):
+        result = runner.invoke(cli, ["clean-concept-tickers", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+
+    def test_dry_run_shows_counts(self, runner):
+        """Dry run should show affected prediction counts without modifying data."""
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        def mock_execute(query, params=None):
+            result = MagicMock()
+            if params and "DEFENSE" in str(params.get("pattern", "")):
+                result.scalar.return_value = 5
+            else:
+                result.scalar.return_value = 0
+            return result
+
+        mock_session.execute.side_effect = mock_execute
+
+        with patch("shit.market_data.cli_registry.get_session", return_value=mock_ctx):
+            result = runner.invoke(cli, ["clean-concept-tickers", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would remove" in result.output
+        mock_session.commit.assert_not_called()
+
+    def test_no_concepts_found(self, runner):
+        """When no concept tickers exist, show info message."""
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        result_mock = MagicMock()
+        result_mock.scalar.return_value = 0
+        mock_session.execute.return_value = result_mock
+
+        with patch("shit.market_data.cli_registry.get_session", return_value=mock_ctx):
+            result = runner.invoke(cli, ["clean-concept-tickers", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "No concept tickers found" in result.output

--- a/shit_tests/shit/market_data/test_ticker_validator.py
+++ b/shit_tests/shit/market_data/test_ticker_validator.py
@@ -1,0 +1,247 @@
+"""
+Tests for shit/market_data/ticker_validator.py - TickerValidator.
+
+Tests cover: blocklist, alias remapping, registry-first optimization,
+yfinance spot-check, fail-open behavior, and deduplication.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from shit.market_data.ticker_validator import TickerValidator
+
+
+class TestBlocklist:
+    """Tests for static blocklist filtering."""
+
+    def test_blocks_known_concepts(self):
+        validator = TickerValidator()
+        result = validator.validate_symbols(["DEFENSE", "CRYPTO", "ECONOMY"])
+        assert result == []
+
+    def test_blocklist_is_case_insensitive(self):
+        validator = TickerValidator()
+        result = validator.validate_symbols(["defense", "Crypto"])
+        assert result == []
+
+    def test_passes_valid_tickers(self):
+        """Valid tickers should pass blocklist check (yfinance mocked)."""
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["AAPL", "TSLA"])
+        assert result == ["AAPL", "TSLA"]
+
+    def test_mixed_valid_and_blocked(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["AAPL", "DEFENSE", "TSLA", "CEO"])
+        assert result == ["AAPL", "TSLA"]
+
+    def test_all_blocklist_entries_are_uppercase(self):
+        """Ensure blocklist doesn't have lowercase entries that would be missed."""
+        for entry in TickerValidator.BLOCKLIST:
+            assert entry == entry.upper(), f"Blocklist entry '{entry}' should be uppercase"
+
+    def test_empty_input(self):
+        validator = TickerValidator()
+        assert validator.validate_symbols([]) == []
+
+    def test_whitespace_only_input(self):
+        validator = TickerValidator()
+        assert validator.validate_symbols(["", "  ", "\t"]) == []
+
+
+class TestAliases:
+    """Tests for alias remapping (corporate actions)."""
+
+    def test_remaps_rtn_to_rtx(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["RTN"])
+        assert result == ["RTX"]
+
+    def test_remaps_fb_to_meta(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["FB"])
+        assert result == ["META"]
+
+    def test_filters_delisted_with_no_replacement(self):
+        validator = TickerValidator()
+        result = validator.validate_symbols(["TWTR", "PTR", "SNP", "KOL", "OIL"])
+        assert result == []
+
+    def test_remaps_shell_variants(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["RDS.A"])
+        assert result == ["SHEL"]
+
+    def test_alias_applied_before_blocklist(self):
+        """Aliases are checked before yfinance, so a remapped symbol gets spot-checked."""
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True) as mock:
+            validator.validate_symbols(["RTN"])
+        # Should check RTX (the remapped symbol), not RTN
+        mock.assert_called_once_with("RTX")
+
+    def test_all_aliases_have_string_keys(self):
+        for key, val in TickerValidator.ALIASES.items():
+            assert isinstance(key, str)
+            assert val is None or isinstance(val, str)
+
+
+class TestDeduplication:
+    """Tests for dedup behavior."""
+
+    def test_deduplicates_identical_symbols(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["AAPL", "AAPL", "TSLA"])
+        assert result == ["AAPL", "TSLA"]
+
+    def test_deduplicates_after_remapping(self):
+        """RDS.A and RDS.B both map to SHEL — should appear once."""
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["RDS.A", "RDS.B"])
+        assert result == ["SHEL"]
+
+    def test_preserves_order(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(["TSLA", "AAPL", "MSFT"])
+        assert result == ["TSLA", "AAPL", "MSFT"]
+
+
+class TestRegistryFirstOptimization:
+    """Tests for skipping yfinance when ticker is already active in registry."""
+
+    def test_skips_yfinance_for_known_active(self):
+        mock_session = MagicMock()
+        mock_row = MagicMock()
+        mock_row.symbol = "AAPL"
+        mock_session.query.return_value.filter.return_value.all.return_value = [mock_row]
+
+        validator = TickerValidator(session=mock_session)
+        with patch.object(validator, "_is_tradeable") as mock_tradeable:
+            result = validator.validate_symbols(["AAPL"])
+
+        assert result == ["AAPL"]
+        mock_tradeable.assert_not_called()
+
+    def test_checks_yfinance_for_unknown_symbol(self):
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+
+        validator = TickerValidator(session=mock_session)
+        with patch.object(validator, "_is_tradeable", return_value=True) as mock_tradeable:
+            result = validator.validate_symbols(["NEWSTOCK"])
+
+        assert result == ["NEWSTOCK"]
+        mock_tradeable.assert_called_once_with("NEWSTOCK")
+
+    def test_caches_registry_query(self):
+        """Second call should not re-query the database."""
+        mock_session = MagicMock()
+        mock_row = MagicMock()
+        mock_row.symbol = "AAPL"
+        mock_session.query.return_value.filter.return_value.all.return_value = [mock_row]
+
+        validator = TickerValidator(session=mock_session)
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            validator.validate_symbols(["AAPL"])
+            validator.validate_symbols(["AAPL"])
+
+        # query().filter().all() should only be called once
+        assert mock_session.query.return_value.filter.return_value.all.call_count == 1
+
+    def test_no_session_always_checks_yfinance(self):
+        validator = TickerValidator(session=None)
+        with patch.object(validator, "_is_tradeable", return_value=True) as mock_tradeable:
+            validator.validate_symbols(["AAPL"])
+        mock_tradeable.assert_called_once_with("AAPL")
+
+
+class TestYfinanceSpotCheck:
+    """Tests for _is_tradeable yfinance integration."""
+
+    def test_equity_returns_true(self):
+        validator = TickerValidator()
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"quoteType": "EQUITY"}
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.return_value = mock_ticker
+            assert validator._is_tradeable("AAPL") is True
+
+    def test_etf_returns_true(self):
+        validator = TickerValidator()
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"quoteType": "ETF"}
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.return_value = mock_ticker
+            assert validator._is_tradeable("SPY") is True
+
+    def test_unknown_quote_type_with_price_returns_true(self):
+        validator = TickerValidator()
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"quoteType": ""}
+        mock_ticker.fast_info.last_price = 150.0
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.return_value = mock_ticker
+            assert validator._is_tradeable("SOMETHING") is True
+
+    def test_no_quote_type_no_price_returns_false(self):
+        validator = TickerValidator()
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+        mock_ticker.fast_info.last_price = None
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.return_value = mock_ticker
+            assert validator._is_tradeable("GARBAGE") is False
+
+    def test_network_error_fails_open(self):
+        """Network errors should return True (fail open)."""
+        validator = TickerValidator()
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.side_effect = Exception("Connection timeout")
+            assert validator._is_tradeable("AAPL") is True
+
+    def test_none_info_fails_open(self):
+        validator = TickerValidator()
+        mock_ticker = MagicMock()
+        mock_ticker.info = None
+        mock_ticker.fast_info.last_price = None
+        with patch("shit.market_data.ticker_validator.yf") as mock_yf:
+            mock_yf.Ticker.return_value = mock_ticker
+            assert validator._is_tradeable("MAYBE") is False
+
+
+class TestEndToEnd:
+    """Integration-style tests combining multiple layers."""
+
+    def test_realistic_llm_output(self):
+        """Simulate a typical LLM extraction with a mix of good and bad tickers."""
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", return_value=True):
+            result = validator.validate_symbols(
+                ["RTN", "DEFENSE", "AAPL", "TWTR", "TSLA", "CRYPTO"]
+            )
+        # RTN→RTX, DEFENSE blocked, AAPL passes, TWTR filtered (no replacement),
+        # TSLA passes, CRYPTO blocked
+        assert result == ["RTX", "AAPL", "TSLA"]
+
+    def test_all_bad_tickers_returns_empty(self):
+        validator = TickerValidator()
+        result = validator.validate_symbols(["DEFENSE", "TWTR", "KOL", "CEO"])
+        assert result == []
+
+    def test_yfinance_rejects_novel_bad_ticker(self):
+        validator = TickerValidator()
+        with patch.object(validator, "_is_tradeable", side_effect=lambda s: s != "NOTREAL"):
+            result = validator.validate_symbols(["AAPL", "NOTREAL", "TSLA"])
+        assert result == ["AAPL", "TSLA"]

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -463,6 +463,24 @@ class ShitpostAnalyzer:
                 analysis, shitpost
             )
 
+            # Validate and normalize extracted ticker symbols
+            raw_assets = enhanced_analysis.get("assets", [])
+            if raw_assets:
+                from shit.market_data.ticker_validator import TickerValidator
+                validator = TickerValidator()
+                validated_assets = validator.validate_symbols(raw_assets)
+                if validated_assets != raw_assets:
+                    logger.info(
+                        f"Ticker validation: {raw_assets} → {validated_assets}"
+                    )
+                enhanced_analysis["assets"] = validated_assets
+                # Filter market_impact to match validated assets
+                enhanced_analysis["market_impact"] = {
+                    k: v
+                    for k, v in enhanced_analysis.get("market_impact", {}).items()
+                    if k in validated_assets
+                }
+
             if not dry_run:
                 # Store analysis in database
                 analysis_id = await self.prediction_ops.store_analysis(


### PR DESCRIPTION
## Summary
- **Tier 1:** Updated LLM prompts with explicit ticker guidelines (current US symbols only, no delisted/concepts/foreign)
- **Tier 2:** New `TickerValidator` service with blocklist (12 entries), alias remapping (11 entries), registry-first cache optimization, and yfinance spot-check for novel symbols
- **Tier 3:** Alias dict for corporate actions (RTN→RTX, FB→META, CBS→PARA, etc.) — integrated into Tier 2
- **Tier 4:** Feed API filters outcomes by `tr.status != 'invalid'`; prediction assets filtered in API response to match
- **Tier 5:** New CLI commands `remap-tickers --dry-run` and `clean-concept-tickers --dry-run` for retroactive cleanup of historical predictions

**Context:** 14% of predictions (377 of 2,694) had at least one bad ticker — delisted symbols (RTN, TWTR), concepts (DEFENSE, CRYPTO), or tickers needing backfill. This PR prevents new bad tickers at the source and provides tooling to clean up historical data.

**Challenge round decisions:** Single integration point (analyzer only, not registry), registry-first optimization (0ms for known symbols), SQL-only filtering (no frontend changes needed), CLI commands instead of ad-hoc scripts.

## Test plan
- [x] 29 new TickerValidator tests (blocklist, aliases, registry-first, yfinance, fail-open, dedup, e2e)
- [x] 1 new feed service test (invalid ticker filtering)
- [x] 6 new CLI tests (remap-tickers, clean-concept-tickers help/dry-run/empty)
- [x] Full suite: 1799 passed, 0 failures
- [x] Lint: all new files clean
- [ ] Post-merge: run `remap-tickers --dry-run` and `clean-concept-tickers --dry-run` to verify counts
- [ ] Post-merge: run `backfill-all-missing` for 109 auto-registered tickers
- [ ] Post-merge: verify feed displays correctly after Tier 5 operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)