### PR TITLE
feat: Historical Echoes — semantic similarity search with market outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Historical Echoes** — Semantic similarity search over past posts to surface actual market outcomes alongside new predictions
+  - `EchoService` in `shit/echoes/` — embed, search (pgvector cosine similarity), and aggregate historical outcomes (returns, win rate, P&L)
+  - `EmbeddingClient` in `shit/llm/embeddings.py` — OpenAI `text-embedding-3-small` (1536 dimensions) with batch support
+  - `PostEmbedding` model with pgvector column for `post_embeddings` table
+  - Analyzer integration: embeds post text after prediction storage via `asyncio.to_thread`
+  - Telegram alert enrichment: echo section with avg return, win rate, P&L from similar past posts
+  - API endpoint `GET /api/echoes/for-prediction/{id}` with configurable timeframe
+  - Backfill CLI `python -m shit.echoes.backfill` (also serves as retry for failed embeddings)
+  - 31 new tests across 6 test files
 - **Fundamentals-enriched LLM prompts** — Pre-extracts tickers from post text (via $TICKER regex, company name matching, and active-set lookup), looks up fundamentals from `ticker_registry` (sector, market cap, P/E, beta, dividend yield), and injects an ASSET CONTEXT block into the LLM prompt so the model can calibrate confidence based on company size and volatility
   - `TickerValidator._load_registry()` builds `_company_names` dict alongside `_known_active` in a single DB query
   - `get_analysis_prompt()` gains `has_fundamentals` param with conditional `FUNDAMENTALS_GUIDANCE` rules

--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from api.routers import feed, prices, telegram
+from api.routers import echoes, feed, prices, telegram
 
 
 @asynccontextmanager
@@ -46,6 +46,7 @@ app.add_middleware(
 )
 
 # API routers
+app.include_router(echoes.router, prefix="/api/echoes", tags=["echoes"])
 app.include_router(feed.router, prefix="/api/feed", tags=["feed"])
 app.include_router(prices.router, prefix="/api/prices", tags=["prices"])
 app.include_router(telegram.router, tags=["telegram"])

--- a/api/routers/echoes.py
+++ b/api/routers/echoes.py
@@ -1,0 +1,29 @@
+"""API router for Historical Echoes — semantic similarity matches."""
+
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+
+@router.get("/for-prediction/{prediction_id}")
+def get_echoes(prediction_id: int, timeframe: str = "t7", limit: int = 5):
+    """Get historical echo matches for a prediction.
+
+    Args:
+        prediction_id: The prediction to find echoes for.
+        timeframe: Outcome timeframe to aggregate (t1, t3, t7, t30).
+        limit: Max number of similar posts to return.
+    """
+    from shit.echoes.echo_service import EchoService
+
+    service = EchoService()
+    embedding = service.get_embedding(prediction_id)
+    if embedding is None:
+        raise HTTPException(404, "No embedding found for this prediction")
+
+    matches = service.find_similar_posts(
+        embedding=embedding,
+        limit=limit,
+        exclude_prediction_id=prediction_id,
+    )
+    return service.aggregate_echoes(matches, timeframe=timeframe)

--- a/api/schemas/echoes.py
+++ b/api/schemas/echoes.py
@@ -1,0 +1,32 @@
+"""Pydantic response models for the Historical Echoes API."""
+
+from pydantic import BaseModel
+from typing import Any, Optional
+
+
+class EchoOutcome(BaseModel):
+    symbol: str
+    return_value: Optional[float] = None
+    correct: Optional[bool] = None
+
+
+class EchoMatch(BaseModel):
+    prediction_id: int
+    similarity: float
+    assets: list[Any]
+    thesis: str
+    post_timestamp: Optional[str] = None
+    outcomes: list[EchoOutcome]
+
+
+class EchoResponse(BaseModel):
+    count: int
+    timeframe: str
+    avg_return: Optional[float] = None
+    median_return: Optional[float] = None
+    win_rate: Optional[float] = None
+    correct: int = 0
+    incorrect: int = 0
+    pending: int = 0
+    avg_pnl: Optional[float] = None
+    matches: list[EchoMatch]

--- a/documentation/planning/product-brainstorm_2026-04-09/04_HISTORICAL_ECHOES.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/04_HISTORICAL_ECHOES.md
@@ -2,8 +2,10 @@
 
 **Feature**: When a new post is analyzed, find the 3-5 most semantically similar past posts and attach their actual market outcomes.
 
-**Status**: IN PROGRESS
+**Status**: COMPLETE
 **Started**: 2026-04-09
+**Completed**: 2026-04-09
+**PR**: #134
 
 ### Challenge Round Resolutions (2026-04-09)
 

--- a/documentation/planning/product-brainstorm_2026-04-09/04_HISTORICAL_ECHOES.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/04_HISTORICAL_ECHOES.md
@@ -2,7 +2,16 @@
 
 **Feature**: When a new post is analyzed, find the 3-5 most semantically similar past posts and attach their actual market outcomes.
 
-**Status**: Planning
+**Status**: IN PROGRESS
+**Started**: 2026-04-09
+
+### Challenge Round Resolutions (2026-04-09)
+
+1. **No IVFFlat index in initial schema.** Exact cosine search is ~10-50ms for <10k rows. IVFFlat requires `10*lists` minimum rows to build. Ship without vector index; document HNSW as future optimization at 10k+.
+2. **`shit/echoes/` is correct location.** Shared service consumed by analyzer, notifications, and API. Follows pattern of `shit/events/`, `shit/market_data/`, `shit/content/`. Keeps dependency arrows inward.
+3. **Event consumer only for v1.** Monolith retired; event-driven is production path. `alert_engine.py` is dead code. EchoService is shared — alert engine can call it later if resurrected.
+4. **Separate API endpoint, not inline in feed.** Separation of concerns: `/api/echoes/for-prediction/{id}` lets frontend lazy-load, keeps feed fast, can be cached independently. Removed feed_service.py modification.
+5. **No retry mechanism. Backfill CLI doubles as retry.** The backfill query finds predictions without embeddings — naturally picks up failures. Alerts fire without echoes (fail-open).
 **Date**: 2026-04-09
 **Estimated Effort**: Large (3-4 sessions)
 
@@ -265,12 +274,10 @@ CREATE TABLE post_embeddings (
     CONSTRAINT uq_post_embeddings_prediction UNIQUE (prediction_id)
 );
 
--- Index for cosine similarity search
-CREATE INDEX idx_post_embeddings_cosine ON post_embeddings
-    USING ivfflat (embedding vector_cosine_ops)
-    WITH (lists = 10);
--- Note: IVFFlat requires at least 10*lists rows to build. For <100 rows,
--- use exact search (no index needed). Add HNSW index at 10,000+ rows.
+-- No vector index needed for <10k rows (exact cosine is ~10-50ms).
+-- At 10,000+ rows, add HNSW index:
+-- CREATE INDEX idx_post_embeddings_hnsw ON post_embeddings
+--     USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 
 -- Index for joining
 CREATE INDEX idx_post_embeddings_prediction_id ON post_embeddings(prediction_id);
@@ -565,9 +572,9 @@ if analysis_id and not dry_run:
         logger.warning(f"Failed to generate embedding: {e}")
 ```
 
-### 2. Alert Formatting (Telegram)
+### 2. Alert Formatting (Telegram — event consumer path only)
 
-Modify the alert engine to include echo data when available:
+Modify `format_telegram_alert()` to render echoes when present in the alert dict. The event consumer (production path) enriches alerts with echo data before formatting. `alert_engine.py` (retired cron path) is NOT modified.
 
 **File**: `notifications/telegram_sender.py`, in `format_telegram_alert()`:
 
@@ -591,9 +598,11 @@ def format_telegram_alert(alert: dict) -> str:
     return msg
 ```
 
-### 3. Frontend API
+### 3. Frontend API (separate endpoint, not inline in feed)
 
-**New endpoint**: `GET /api/posts/{prediction_id}/echoes`
+Echoes are a separate concern from the feed. A dedicated endpoint lets the frontend lazy-load echoes on demand, keeps the feed response fast, and can be cached independently.
+
+**New endpoint**: `GET /api/echoes/for-prediction/{prediction_id}`
 
 ```python
 # File: api/routers/echoes.py
@@ -603,7 +612,7 @@ from api.schemas.echoes import EchoResponse
 
 router = APIRouter()
 
-@router.get("/posts/{prediction_id}/echoes", response_model=EchoResponse)
+@router.get("/for-prediction/{prediction_id}", response_model=EchoResponse)
 def get_echoes(prediction_id: int):
     """Get historical echo matches for a prediction."""
     from shit.echoes.echo_service import EchoService
@@ -656,35 +665,7 @@ class EchoResponse(BaseModel):
     matches: list[EchoMatch]
 ```
 
-### 4. Feed Response Enhancement
-
-Add echoes to the existing `FeedResponse` so the frontend can display them inline:
-
-```python
-# In api/services/feed_service.py, add echo lookup to get_feed_response():
-def get_feed_response(self, offset: int) -> Optional[dict]:
-    # ... existing code ...
-
-    # Fetch echoes for this prediction
-    try:
-        from shit.echoes.echo_service import EchoService
-        service = EchoService()
-        embedding = service.get_embedding(prediction_id)
-        if embedding:
-            matches = service.find_similar_posts(
-                embedding, limit=3, exclude_prediction_id=prediction_id,
-            )
-            echoes = service.aggregate_echoes(matches)
-        else:
-            echoes = None
-    except Exception:
-        echoes = None
-
-    response["echoes"] = echoes
-    return response
-```
-
-### 5. LLM Prompt Enrichment (Future, Not in v1)
+### 4. LLM Prompt Enrichment (Future, Not in v1)
 
 In a future iteration, echo outcomes could be injected into the analysis prompt (similar to fundamentals enrichment in Doc 02):
 
@@ -1028,13 +1009,12 @@ shit/llm/
 | `api/main.py` | Modify | Register echoes router |
 | `shitpost_ai/shitpost_analyzer.py` | Modify | Call embed_and_store after prediction creation |
 | `notifications/telegram_sender.py` | Modify | Include echo summary in alert format |
-| `notifications/event_consumer.py` | Modify | Look up echoes when dispatching alerts |
-| `api/services/feed_service.py` | Modify | Include echoes in feed response |
+| `notifications/event_consumer.py` | Modify | Look up echoes when dispatching alerts (production path) |
 | `requirements.txt` | Modify | Add `pgvector>=0.3.0` |
 | `shit_tests/echoes/test_echo_service.py` | Create | Unit tests for echo service |
 | `shit_tests/echoes/test_similarity.py` | Create | Unit tests for similarity search |
 | `shit_tests/echoes/test_aggregation.py` | Create | Unit tests for aggregation |
-| `shit_tests/llm/test_embeddings.py` | Create | Unit tests for embedding client |
+| `shit_tests/shit/llm/test_embeddings.py` | Create | Unit tests for embedding client |
 
 ---
 

--- a/notifications/event_consumer.py
+++ b/notifications/event_consumer.py
@@ -63,6 +63,22 @@ class NotificationsWorker(EventWorker):
             "text": "",
         }
 
+        # Enrich alert with Historical Echoes
+        try:
+            from shit.echoes.echo_service import EchoService
+
+            echo_service = EchoService()
+            embedding = echo_service.get_embedding(prediction_id)
+            if embedding:
+                matches = echo_service.find_similar_posts(
+                    embedding,
+                    limit=5,
+                    exclude_prediction_id=prediction_id,
+                )
+                alert["echoes"] = echo_service.aggregate_echoes(matches, timeframe="t7")
+        except Exception as e:
+            logger.debug(f"Echo lookup skipped for prediction {prediction_id}: {e}")
+
         results = {"alerts_sent": 0, "alerts_failed": 0, "filtered": 0}
 
         subscriptions = get_active_subscriptions()

--- a/notifications/telegram_sender.py
+++ b/notifications/telegram_sender.py
@@ -150,9 +150,45 @@ _{escape_markdown(text)}_
 \U0001f4a1 *Thesis:*
 {escape_markdown(thesis)}
 
-\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
+{_format_echo_section(alert)}\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
 """
     return message.strip()
+
+
+def _format_echo_section(alert: Dict[str, Any]) -> str:
+    """Format the Historical Echoes section for a Telegram alert.
+
+    Returns an empty string if no echoes are available.
+    """
+    echoes = alert.get("echoes")
+    if not echoes or echoes.get("count", 0) == 0:
+        return ""
+
+    lines = [f"\U0001f4ca *Historical Echoes* \\({echoes['count']} similar posts\\):"]
+
+    if echoes.get("avg_return") is not None:
+        val = escape_markdown(f"{echoes['avg_return']:+.1f}%")
+        lines.append(f"\u2022 Avg T\\+7 return: {val}")
+
+    if echoes.get("win_rate") is not None:
+        wr = echoes["win_rate"] * 100
+        c, ic = echoes.get("correct", 0), echoes.get("incorrect", 0)
+        lines.append(
+            f"\u2022 Win rate: {c}/{c + ic} \\({escape_markdown(f'{wr:.0f}%')}\\)"
+        )
+
+    if echoes.get("avg_pnl") is not None:
+        val = escape_markdown(f"${echoes['avg_pnl']:+.0f}")
+        lines.append(f"\u2022 Avg P&L \\($1k\\): {val}")
+
+    pending = echoes.get("pending", 0)
+    if pending > 0 and echoes.get("correct", 0) + echoes.get("incorrect", 0) == 0:
+        lines = [
+            lines[0],
+            f"\u2022 Outcomes: {pending} pending \\(too recent to evaluate\\)",
+        ]
+
+    return "\n".join(lines) + "\n\n"
 
 
 def escape_markdown(text: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ openai>=2.0.0,<3.0.0
 anthropic>=0.83.0
 
 # Database
+pgvector>=0.3.0  # pgvector support for semantic similarity search (post_embeddings)
 psycopg[binary]>=3.3.0  # Async PostgreSQL driver (used by shit/db/database_client.py)
 psycopg2-binary>=2.9.0  # Sync PostgreSQL driver for shit/db/sync_session.py (CLIs, notifications)
 asyncpg>=0.29.0  # Legacy: only referenced in URL cleanup (sync_session.py:22), not directly imported

--- a/shit/db/sync_session.py
+++ b/shit/db/sync_session.py
@@ -77,5 +77,6 @@ def create_tables():
     from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
     from shitvault.signal_models import Signal
     from shit.events.models import Event  # noqa: F401
+    from shit.echoes.models import PostEmbedding  # noqa: F401
 
     Base.metadata.create_all(engine)

--- a/shit/echoes/__init__.py
+++ b/shit/echoes/__init__.py
@@ -1,0 +1,6 @@
+"""
+Historical Echoes
+
+Semantic similarity search over past posts to surface historical
+market outcomes alongside new predictions.
+"""

--- a/shit/echoes/backfill.py
+++ b/shit/echoes/backfill.py
@@ -1,0 +1,101 @@
+"""
+Backfill embeddings for existing analyzed posts.
+
+Usage:
+    python -m shit.echoes.backfill [--batch-size 100]
+
+Also serves as a retry mechanism: any prediction without an embedding
+(including those that failed on first attempt) will be picked up.
+"""
+
+import argparse
+
+from sqlalchemy import text
+
+from shit.db.sync_session import get_session
+from shit.echoes.echo_service import EchoService
+from shit.logging import get_service_logger, setup_cli_logging
+
+logger = get_service_logger("echo_backfill")
+
+
+def backfill_embeddings(batch_size: int = 100) -> int:
+    """Embed all existing analyzed posts that don't have embeddings yet.
+
+    Args:
+        batch_size: Number of texts to embed per OpenAI API call.
+
+    Returns:
+        Total number of embeddings generated.
+    """
+    with get_session() as session:
+        predictions = session.execute(
+            text("""
+                SELECT p.id, p.shitpost_id, p.signal_id,
+                       COALESCE(s.text, ts.text) as post_text
+                FROM predictions p
+                LEFT JOIN signals s ON s.signal_id = p.signal_id
+                LEFT JOIN truth_social_shitposts ts ON ts.shitpost_id = p.shitpost_id
+                LEFT JOIN post_embeddings pe ON pe.prediction_id = p.id
+                WHERE p.analysis_status = 'completed'
+                    AND pe.id IS NULL
+                    AND COALESCE(s.text, ts.text) IS NOT NULL
+                ORDER BY p.id
+            """)
+        ).fetchall()
+
+    total = len(predictions)
+    if total == 0:
+        logger.info("No predictions need embedding")
+        return 0
+
+    logger.info(f"Backfilling embeddings for {total} predictions")
+    service = EchoService()
+    embedded = 0
+
+    for i in range(0, total, batch_size):
+        batch = predictions[i : i + batch_size]
+        texts = [row[3] for row in batch]
+
+        embeddings = service.embedding_client.embed_batch(texts)
+
+        import hashlib
+
+        from shit.echoes.models import PostEmbedding
+
+        with get_session() as session:
+            for j, (pred_id, shitpost_id, signal_id, post_text) in enumerate(batch):
+                text_hash = hashlib.sha256(post_text.encode()).hexdigest()
+                record = PostEmbedding(
+                    prediction_id=pred_id,
+                    shitpost_id=shitpost_id,
+                    signal_id=signal_id,
+                    text_hash=text_hash,
+                    embedding=embeddings[j],
+                    model=service.embedding_client.model,
+                )
+                session.add(record)
+
+        embedded += len(batch)
+        logger.info(f"Backfilled {min(i + batch_size, total)}/{total} embeddings")
+
+    logger.info(f"Backfill complete: {embedded} embeddings generated")
+    return embedded
+
+
+def main() -> None:
+    """CLI entry point."""
+    setup_cli_logging(verbose=True)
+    parser = argparse.ArgumentParser(description="Backfill post embeddings")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Texts per OpenAI API call (default: 100)",
+    )
+    args = parser.parse_args()
+    backfill_embeddings(batch_size=args.batch_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/shit/echoes/echo_service.py
+++ b/shit/echoes/echo_service.py
@@ -1,0 +1,260 @@
+"""
+EchoService — Historical similarity search and outcome aggregation.
+
+Embeds post text, stores embeddings in pgvector, finds similar past posts,
+and aggregates their realized market outcomes.
+"""
+
+import hashlib
+from typing import Optional
+
+from sqlalchemy import text as sql_text
+
+from shit.db.sync_session import get_session
+from shit.llm.embeddings import EmbeddingClient
+from shit.logging import get_service_logger
+
+logger = get_service_logger("echo_service")
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+DEFAULT_SIMILARITY_THRESHOLD = 0.65
+DEFAULT_MATCH_LIMIT = 5
+
+
+class EchoService:
+    """Manages post embeddings and historical similarity search.
+
+    Usage:
+        service = EchoService()
+        service.embed_and_store(prediction_id=123, text="...", shitpost_id="abc")
+        matches = service.find_similar_posts(embedding, limit=5)
+        echoes = service.aggregate_echoes(matches, timeframe="t7")
+    """
+
+    def __init__(self, embedding_client: Optional[EmbeddingClient] = None):
+        self.embedding_client = embedding_client or EmbeddingClient(
+            model=EMBEDDING_MODEL
+        )
+
+    def embed_and_store(
+        self,
+        prediction_id: int,
+        text: str,
+        shitpost_id: str | None = None,
+        signal_id: str | None = None,
+    ) -> bool:
+        """Generate embedding for a post and store it.
+
+        Returns True if stored, False if error or already exists.
+        """
+        if not text or not text.strip():
+            logger.debug(f"Skipping empty text for prediction {prediction_id}")
+            return False
+
+        from shit.echoes.models import PostEmbedding
+
+        with get_session() as session:
+            existing = (
+                session.query(PostEmbedding)
+                .filter(PostEmbedding.prediction_id == prediction_id)
+                .first()
+            )
+            if existing:
+                logger.debug(f"Embedding already exists for prediction {prediction_id}")
+                return False
+
+        embedding = self.embedding_client.embed(text)
+
+        with get_session() as session:
+            text_hash = hashlib.sha256(text.encode()).hexdigest()
+            record = PostEmbedding(
+                prediction_id=prediction_id,
+                shitpost_id=shitpost_id,
+                signal_id=signal_id,
+                text_hash=text_hash,
+                embedding=embedding,
+                model=EMBEDDING_MODEL,
+            )
+            session.add(record)
+
+        logger.info(f"Stored embedding for prediction {prediction_id}")
+        return True
+
+    def get_embedding(self, prediction_id: int) -> Optional[list[float]]:
+        """Retrieve the stored embedding for a prediction."""
+        from shit.echoes.models import PostEmbedding
+
+        with get_session() as session:
+            record = (
+                session.query(PostEmbedding)
+                .filter(PostEmbedding.prediction_id == prediction_id)
+                .first()
+            )
+            if record:
+                return list(record.embedding)
+        return None
+
+    def find_similar_posts(
+        self,
+        embedding: list[float],
+        limit: int = DEFAULT_MATCH_LIMIT,
+        min_similarity: float = DEFAULT_SIMILARITY_THRESHOLD,
+        exclude_prediction_id: int | None = None,
+    ) -> list[dict]:
+        """Find the most similar historical posts by embedding cosine similarity.
+
+        Args:
+            embedding: The query embedding vector.
+            limit: Maximum number of matches to return.
+            min_similarity: Minimum cosine similarity threshold (0-1).
+            exclude_prediction_id: Exclude this prediction from results.
+
+        Returns:
+            List of dicts with prediction_id, similarity, text preview, etc.
+        """
+        max_distance = 1.0 - min_similarity
+
+        query = sql_text("""
+            SELECT
+                pe.prediction_id,
+                pe.shitpost_id,
+                pe.signal_id,
+                1 - (pe.embedding <=> :query_vec) AS similarity,
+                p.assets,
+                p.market_impact,
+                p.confidence,
+                p.thesis,
+                p.post_timestamp
+            FROM post_embeddings pe
+            JOIN predictions p ON p.id = pe.prediction_id
+            WHERE pe.prediction_id != COALESCE(:exclude_id, -1)
+                AND p.analysis_status = 'completed'
+                AND (pe.embedding <=> :query_vec) <= :max_dist
+            ORDER BY pe.embedding <=> :query_vec
+            LIMIT :lim
+        """)
+
+        with get_session() as session:
+            result = session.execute(
+                query,
+                {
+                    "query_vec": str(embedding),
+                    "exclude_id": exclude_prediction_id,
+                    "max_dist": max_distance,
+                    "lim": limit,
+                },
+            )
+
+            matches = []
+            for row in result.fetchall():
+                matches.append(
+                    {
+                        "prediction_id": row[0],
+                        "shitpost_id": row[1],
+                        "signal_id": row[2],
+                        "similarity": round(float(row[3]), 4),
+                        "assets": row[4],
+                        "market_impact": row[5],
+                        "confidence": row[6],
+                        "thesis": row[7],
+                        "post_timestamp": row[8],
+                    }
+                )
+
+        return matches
+
+    def aggregate_echoes(
+        self,
+        matches: list[dict],
+        timeframe: str = "t7",
+    ) -> dict:
+        """Aggregate outcomes from similar historical posts.
+
+        Args:
+            matches: List of match dicts from find_similar_posts().
+            timeframe: Which timeframe to aggregate ("t1", "t3", "t7", "t30").
+
+        Returns:
+            Aggregated echo statistics dict.
+        """
+        if not matches:
+            return {"count": 0, "timeframe": timeframe, "matches": []}
+
+        prediction_ids = [m["prediction_id"] for m in matches]
+
+        from shit.market_data.models import PredictionOutcome
+
+        with get_session() as session:
+            outcomes = (
+                session.query(PredictionOutcome)
+                .filter(PredictionOutcome.prediction_id.in_(prediction_ids))
+                .all()
+            )
+
+        outcomes_by_pred: dict[int, list] = {}
+        for o in outcomes:
+            outcomes_by_pred.setdefault(o.prediction_id, []).append(o)
+
+        returns: list[float] = []
+        correct_count = 0
+        incorrect_count = 0
+        pnl_values: list[float] = []
+        match_details = []
+
+        for match in matches:
+            pred_outcomes = outcomes_by_pred.get(match["prediction_id"], [])
+            for o in pred_outcomes:
+                ret = getattr(o, f"return_{timeframe}", None)
+                corr = getattr(o, f"correct_{timeframe}", None)
+                pnl = getattr(o, f"pnl_{timeframe}", None)
+
+                if ret is not None:
+                    returns.append(ret)
+                if corr is True:
+                    correct_count += 1
+                elif corr is False:
+                    incorrect_count += 1
+                if pnl is not None:
+                    pnl_values.append(pnl)
+
+            match_details.append(
+                {
+                    "prediction_id": match["prediction_id"],
+                    "similarity": match["similarity"],
+                    "assets": match.get("assets", []),
+                    "thesis": (match.get("thesis") or "")[:100],
+                    "post_timestamp": match.get("post_timestamp"),
+                    "outcomes": [
+                        {
+                            "symbol": o.symbol,
+                            f"return_{timeframe}": getattr(
+                                o, f"return_{timeframe}", None
+                            ),
+                            f"correct_{timeframe}": getattr(
+                                o, f"correct_{timeframe}", None
+                            ),
+                        }
+                        for o in pred_outcomes
+                    ],
+                }
+            )
+
+        evaluated = correct_count + incorrect_count
+        return {
+            "count": len(matches),
+            "timeframe": timeframe,
+            "avg_return": round(sum(returns) / len(returns), 4) if returns else None,
+            "median_return": (
+                round(sorted(returns)[len(returns) // 2], 4) if returns else None
+            ),
+            "win_rate": (
+                round(correct_count / evaluated, 4) if evaluated > 0 else None
+            ),
+            "correct": correct_count,
+            "incorrect": incorrect_count,
+            "pending": len(matches) - evaluated,
+            "avg_pnl": (
+                round(sum(pnl_values) / len(pnl_values), 2) if pnl_values else None
+            ),
+            "matches": match_details,
+        }

--- a/shit/echoes/models.py
+++ b/shit/echoes/models.py
@@ -1,0 +1,34 @@
+"""
+PostEmbedding model for storing text embeddings with pgvector.
+"""
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.sql import func
+
+from shit.db.data_models import Base
+
+
+class PostEmbedding(Base):
+    """Stores text embeddings for semantic similarity search."""
+
+    __tablename__ = "post_embeddings"
+
+    id = Column(Integer, primary_key=True)
+    prediction_id = Column(
+        Integer,
+        ForeignKey("predictions.id"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    shitpost_id = Column(String(255), nullable=True)
+    signal_id = Column(String(255), nullable=True)
+    text_hash = Column(String(64), nullable=False)
+    embedding = Column(Vector(1536), nullable=False)
+    model = Column(String(50), nullable=False, default="text-embedding-3-small")
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    def __repr__(self) -> str:
+        src = self.shitpost_id or self.signal_id or "?"
+        return f"<PostEmbedding(prediction_id={self.prediction_id}, source={src})>"

--- a/shit/llm/embeddings.py
+++ b/shit/llm/embeddings.py
@@ -1,0 +1,59 @@
+"""
+OpenAI Embedding Client
+
+Generates text embeddings via the OpenAI embeddings API for semantic
+similarity search in the Historical Echoes feature.
+"""
+
+from openai import OpenAI
+
+from shit.config.shitpost_settings import settings
+from shit.logging import get_service_logger
+
+logger = get_service_logger("embeddings")
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIMENSIONS = 1536
+
+
+class EmbeddingClient:
+    """Client for generating text embeddings via OpenAI API."""
+
+    def __init__(self, model: str = EMBEDDING_MODEL):
+        self.model = model
+        self._client = OpenAI(api_key=settings.OPENAI_API_KEY)
+
+    def embed(self, text: str) -> list[float]:
+        """Generate embedding for a single text.
+
+        Args:
+            text: Text to embed.
+
+        Returns:
+            List of floats (1536 dimensions).
+        """
+        text = text[:8000]
+        response = self._client.embeddings.create(
+            model=self.model,
+            input=text,
+        )
+        return response.data[0].embedding
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts.
+
+        Args:
+            texts: List of texts to embed (max 2048 per API call).
+
+        Returns:
+            List of embedding vectors, one per input text.
+        """
+        if not texts:
+            return []
+
+        truncated = [t[:8000] for t in texts]
+        response = self._client.embeddings.create(
+            model=self.model,
+            input=truncated,
+        )
+        return [item.embedding for item in response.data]

--- a/shit_tests/echoes/test_aggregation.py
+++ b/shit_tests/echoes/test_aggregation.py
@@ -1,0 +1,175 @@
+"""
+Tests for EchoService.aggregate_echoes — outcome aggregation.
+
+Covers: full outcomes, no outcomes, partial outcomes, empty matches.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from unittest.mock import patch, MagicMock
+
+from shit.echoes.echo_service import EchoService
+
+_SESSION_PATCH = "shit.echoes.echo_service.get_session"
+
+
+def _mock_embedding_client():
+    mock = MagicMock()
+    mock.model = "text-embedding-3-small"
+    return mock
+
+
+def _make_outcome(prediction_id, symbol, return_t7=None, correct_t7=None, pnl_t7=None):
+    """Create a mock PredictionOutcome."""
+    o = MagicMock()
+    o.prediction_id = prediction_id
+    o.symbol = symbol
+    o.return_t7 = return_t7
+    o.correct_t7 = correct_t7
+    o.pnl_t7 = pnl_t7
+    return o
+
+
+def _mock_outcomes_session(outcomes):
+    """Create a mock session that returns given outcomes from query."""
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.all.return_value = outcomes
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    return mock_ctx
+
+
+class TestAggregateEchoes:
+    def test_empty_matches(self):
+        service = EchoService(embedding_client=_mock_embedding_client())
+        result = service.aggregate_echoes([], timeframe="t7")
+        assert result["count"] == 0
+        assert result["matches"] == []
+
+    def test_with_outcomes(self):
+        matches = [
+            {
+                "prediction_id": 10,
+                "similarity": 0.90,
+                "assets": ["XLE"],
+                "thesis": "Energy",
+                "post_timestamp": None,
+            },
+            {
+                "prediction_id": 20,
+                "similarity": 0.80,
+                "assets": ["OXY"],
+                "thesis": "Oil",
+                "post_timestamp": None,
+            },
+        ]
+        outcomes = [
+            _make_outcome(10, "XLE", return_t7=3.2, correct_t7=True, pnl_t7=32.0),
+            _make_outcome(20, "OXY", return_t7=-1.0, correct_t7=False, pnl_t7=-10.0),
+        ]
+        mock_ctx = _mock_outcomes_session(outcomes)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.aggregate_echoes(matches, timeframe="t7")
+
+        assert result["count"] == 2
+        assert result["timeframe"] == "t7"
+        assert result["avg_return"] == round((3.2 + -1.0) / 2, 4)
+        assert result["win_rate"] == round(1 / 2, 4)
+        assert result["correct"] == 1
+        assert result["incorrect"] == 1
+        assert result["avg_pnl"] == round((32.0 + -10.0) / 2, 2)
+
+    def test_no_outcomes_yet(self):
+        """Matches exist but no prediction_outcomes recorded."""
+        matches = [
+            {
+                "prediction_id": 10,
+                "similarity": 0.85,
+                "assets": ["XLE"],
+                "thesis": "Energy",
+                "post_timestamp": None,
+            },
+        ]
+        mock_ctx = _mock_outcomes_session([])
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.aggregate_echoes(matches, timeframe="t7")
+
+        assert result["count"] == 1
+        assert result["avg_return"] is None
+        assert result["win_rate"] is None
+        assert result["pending"] == 1
+
+    def test_partial_outcomes(self):
+        """Some matches have outcomes, some don't."""
+        matches = [
+            {
+                "prediction_id": 10,
+                "similarity": 0.90,
+                "assets": ["XLE"],
+                "thesis": "A",
+                "post_timestamp": None,
+            },
+            {
+                "prediction_id": 20,
+                "similarity": 0.80,
+                "assets": ["OXY"],
+                "thesis": "B",
+                "post_timestamp": None,
+            },
+            {
+                "prediction_id": 30,
+                "similarity": 0.70,
+                "assets": ["CVX"],
+                "thesis": "C",
+                "post_timestamp": None,
+            },
+        ]
+        outcomes = [
+            _make_outcome(10, "XLE", return_t7=2.0, correct_t7=True, pnl_t7=20.0),
+            # prediction 20 and 30 have no outcomes
+        ]
+        mock_ctx = _mock_outcomes_session(outcomes)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.aggregate_echoes(matches, timeframe="t7")
+
+        assert result["count"] == 3
+        assert result["correct"] == 1
+        assert result["incorrect"] == 0
+        assert result["pending"] == 2
+        assert result["avg_return"] == 2.0
+
+    def test_match_details_included(self):
+        matches = [
+            {
+                "prediction_id": 10,
+                "similarity": 0.90,
+                "assets": ["XLE"],
+                "thesis": "Drill baby drill",
+                "post_timestamp": "2025-11-15",
+            },
+        ]
+        outcomes = [
+            _make_outcome(10, "XLE", return_t7=3.2, correct_t7=True, pnl_t7=32.0),
+        ]
+        mock_ctx = _mock_outcomes_session(outcomes)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.aggregate_echoes(matches, timeframe="t7")
+
+        assert len(result["matches"]) == 1
+        detail = result["matches"][0]
+        assert detail["prediction_id"] == 10
+        assert detail["similarity"] == 0.90
+        assert detail["thesis"] == "Drill baby drill"
+        assert len(detail["outcomes"]) == 1
+        assert detail["outcomes"][0]["symbol"] == "XLE"

--- a/shit_tests/echoes/test_alert_integration.py
+++ b/shit_tests/echoes/test_alert_integration.py
@@ -1,0 +1,196 @@
+"""
+Tests for echo integration in Telegram alerts and event consumer.
+
+Covers: format_telegram_alert echo rendering, event consumer echo enrichment.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from unittest.mock import patch, MagicMock
+
+from notifications.telegram_sender import format_telegram_alert, _format_echo_section
+
+
+class TestFormatEchoSection:
+    def test_no_echoes_returns_empty(self):
+        assert _format_echo_section({}) == ""
+        assert _format_echo_section({"echoes": None}) == ""
+        assert _format_echo_section({"echoes": {"count": 0}}) == ""
+
+    def test_with_full_echoes(self):
+        alert = {
+            "echoes": {
+                "count": 3,
+                "avg_return": 1.8,
+                "win_rate": 0.6667,
+                "correct": 2,
+                "incorrect": 1,
+                "pending": 0,
+                "avg_pnl": 18.0,
+            }
+        }
+        result = _format_echo_section(alert)
+        assert "Historical Echoes" in result
+        assert "3 similar posts" in result
+        assert "1\\.8%" in result  # escape_markdown escapes the dot
+        assert "2/3" in result
+        assert "\\+18" in result  # escape_markdown escapes the plus
+
+    def test_pending_only(self):
+        alert = {
+            "echoes": {
+                "count": 2,
+                "avg_return": None,
+                "win_rate": None,
+                "correct": 0,
+                "incorrect": 0,
+                "pending": 2,
+                "avg_pnl": None,
+            }
+        }
+        result = _format_echo_section(alert)
+        assert "pending" in result
+        assert "too recent" in result
+
+    def test_partial_data_with_evaluated_outcomes(self):
+        """When some outcomes are evaluated, show return stats but not win rate if None."""
+        alert = {
+            "echoes": {
+                "count": 2,
+                "avg_return": 2.5,
+                "win_rate": None,
+                "correct": 1,
+                "incorrect": 0,
+                "pending": 1,
+                "avg_pnl": None,
+            }
+        }
+        result = _format_echo_section(alert)
+        assert "2\\.5%" in result  # escape_markdown escapes the dot
+        assert "P&L" not in result  # avg_pnl is None
+
+
+class TestFormatTelegramAlertWithEchoes:
+    def test_alert_with_echoes_included(self):
+        alert = {
+            "sentiment": "bullish",
+            "confidence": 0.82,
+            "assets": ["XLE", "OXY"],
+            "text": "Drill baby drill!",
+            "thesis": "Pro-energy policy signals",
+            "echoes": {
+                "count": 3,
+                "avg_return": 1.8,
+                "win_rate": 0.6667,
+                "correct": 2,
+                "incorrect": 1,
+                "pending": 0,
+                "avg_pnl": 18.0,
+            },
+        }
+        result = format_telegram_alert(alert)
+        assert "SHITPOST ALPHA ALERT" in result
+        assert "Historical Echoes" in result
+        assert "NOT financial advice" in result
+
+    def test_alert_without_echoes_unchanged(self):
+        alert = {
+            "sentiment": "bullish",
+            "confidence": 0.82,
+            "assets": ["XLE"],
+            "text": "Energy is great",
+            "thesis": "Bullish energy",
+        }
+        result = format_telegram_alert(alert)
+        assert "SHITPOST ALPHA ALERT" in result
+        assert "Historical Echoes" not in result
+
+
+class TestEventConsumerEchoEnrichment:
+    def test_echo_enrichment_added_to_alert(self):
+        """Verify event consumer adds echoes to the alert dict before dispatch."""
+        from notifications.event_consumer import NotificationsWorker
+
+        mock_echo_data = {
+            "count": 2,
+            "timeframe": "t7",
+            "avg_return": 1.5,
+            "win_rate": 0.5,
+            "correct": 1,
+            "incorrect": 1,
+            "pending": 0,
+            "avg_pnl": 15.0,
+            "matches": [],
+        }
+
+        worker = NotificationsWorker.__new__(NotificationsWorker)
+
+        with (
+            patch(
+                "notifications.db.get_active_subscriptions",
+                return_value=[],
+            ),
+            patch("shit.echoes.echo_service.EchoService") as MockService,
+        ):
+            mock_svc = MagicMock()
+            mock_svc.get_embedding.return_value = [0.1] * 1536
+            mock_svc.find_similar_posts.return_value = [{"prediction_id": 10}]
+            mock_svc.aggregate_echoes.return_value = mock_echo_data
+            MockService.return_value = mock_svc
+
+            worker.process_event(
+                "prediction_created",
+                {
+                    "prediction_id": 1,
+                    "analysis_status": "completed",
+                    "assets": ["XLE"],
+                    "confidence": 0.8,
+                },
+            )
+
+        # No subscribers, so 0 alerts sent, but the echo lookup was attempted
+        mock_svc.get_embedding.assert_called_once_with(1)
+
+    def test_echo_failure_does_not_break_alert(self):
+        """If echo lookup fails, alert should still dispatch."""
+        from notifications.event_consumer import NotificationsWorker
+
+        worker = NotificationsWorker.__new__(NotificationsWorker)
+
+        with (
+            patch(
+                "notifications.db.get_active_subscriptions",
+                return_value=[{"chat_id": "123", "alert_preferences": {}}],
+            ),
+            patch(
+                "notifications.alert_engine.filter_predictions_by_preferences",
+                side_effect=lambda alerts, _: alerts,
+            ),
+            patch(
+                "notifications.telegram_sender.format_telegram_alert",
+                return_value="test message",
+            ),
+            patch(
+                "notifications.telegram_sender.send_telegram_message",
+                return_value=(True, None),
+            ),
+            patch(
+                "notifications.db.record_alert_sent",
+            ),
+            patch(
+                "shit.echoes.echo_service.EchoService", side_effect=Exception("DB down")
+            ),
+        ):
+            result = worker.process_event(
+                "prediction_created",
+                {
+                    "prediction_id": 1,
+                    "analysis_status": "completed",
+                    "assets": ["XLE"],
+                    "confidence": 0.8,
+                },
+            )
+
+        assert result["alerts_sent"] == 1

--- a/shit_tests/echoes/test_api.py
+++ b/shit_tests/echoes/test_api.py
@@ -1,0 +1,72 @@
+"""
+Tests for the Historical Echoes API endpoint.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+class TestEchoesEndpoint:
+    def test_returns_echoes_for_prediction(self):
+        mock_echo_data = {
+            "count": 2,
+            "timeframe": "t7",
+            "avg_return": 1.5,
+            "win_rate": 0.5,
+            "correct": 1,
+            "incorrect": 1,
+            "pending": 0,
+            "avg_pnl": 15.0,
+            "matches": [],
+        }
+
+        with patch("shit.echoes.echo_service.EchoService") as MockService:
+            mock_svc = MagicMock()
+            mock_svc.get_embedding.return_value = [0.1] * 1536
+            mock_svc.find_similar_posts.return_value = [{"prediction_id": 10}]
+            mock_svc.aggregate_echoes.return_value = mock_echo_data
+            MockService.return_value = mock_svc
+
+            resp = client.get("/api/echoes/for-prediction/1")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 2
+        assert data["avg_return"] == 1.5
+
+    def test_404_when_no_embedding(self):
+        with patch("shit.echoes.echo_service.EchoService") as MockService:
+            mock_svc = MagicMock()
+            mock_svc.get_embedding.return_value = None
+            MockService.return_value = mock_svc
+
+            resp = client.get("/api/echoes/for-prediction/999")
+
+        assert resp.status_code == 404
+
+    def test_custom_timeframe_param(self):
+        with patch("shit.echoes.echo_service.EchoService") as MockService:
+            mock_svc = MagicMock()
+            mock_svc.get_embedding.return_value = [0.1] * 1536
+            mock_svc.find_similar_posts.return_value = []
+            mock_svc.aggregate_echoes.return_value = {
+                "count": 0,
+                "timeframe": "t30",
+                "matches": [],
+            }
+            MockService.return_value = mock_svc
+
+            resp = client.get("/api/echoes/for-prediction/1?timeframe=t30")
+
+        assert resp.status_code == 200
+        mock_svc.aggregate_echoes.assert_called_once_with([], timeframe="t30")

--- a/shit_tests/echoes/test_echo_service.py
+++ b/shit_tests/echoes/test_echo_service.py
@@ -1,0 +1,104 @@
+"""
+Tests for shit/echoes/echo_service.py — EchoService core operations.
+
+Covers: embed_and_store, get_embedding, duplicate detection, empty text handling.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from unittest.mock import patch, MagicMock
+
+from shit.echoes.echo_service import EchoService
+
+_SESSION_PATCH = "shit.echoes.echo_service.get_session"
+
+
+def _mock_embedding_client(vector=None):
+    """Create a mock EmbeddingClient that returns a fixed vector."""
+    if vector is None:
+        vector = [0.1] * 1536
+    mock = MagicMock()
+    mock.embed.return_value = vector
+    mock.embed_batch.return_value = [vector]
+    mock.model = "text-embedding-3-small"
+    return mock
+
+
+def _mock_session_ctx(query_results=None):
+    """Create a mock get_session context manager."""
+    mock_session = MagicMock()
+    if query_results is not None:
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            query_results
+        )
+    else:
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    return mock_ctx, mock_session
+
+
+class TestEmbedAndStore:
+    def test_stores_new_embedding(self):
+        mock_client = _mock_embedding_client()
+        mock_ctx, mock_session = _mock_session_ctx(query_results=None)
+
+        service = EchoService(embedding_client=mock_client)
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.embed_and_store(
+                prediction_id=1, text="Drill baby drill!", shitpost_id="abc123"
+            )
+
+        assert result is True
+        mock_client.embed.assert_called_once_with("Drill baby drill!")
+        assert mock_session.add.called
+
+    def test_skips_duplicate(self):
+        mock_client = _mock_embedding_client()
+        existing = MagicMock()  # Simulate existing record
+        mock_ctx, mock_session = _mock_session_ctx(query_results=existing)
+
+        service = EchoService(embedding_client=mock_client)
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.embed_and_store(prediction_id=1, text="Some text")
+
+        assert result is False
+        mock_client.embed.assert_not_called()
+
+    def test_empty_text_returns_false(self):
+        mock_client = _mock_embedding_client()
+        service = EchoService(embedding_client=mock_client)
+
+        assert service.embed_and_store(prediction_id=1, text="") is False
+        assert service.embed_and_store(prediction_id=2, text="   ") is False
+        mock_client.embed.assert_not_called()
+
+    def test_none_text_returns_false(self):
+        mock_client = _mock_embedding_client()
+        service = EchoService(embedding_client=mock_client)
+        assert service.embed_and_store(prediction_id=1, text=None) is False
+
+
+class TestGetEmbedding:
+    def test_returns_embedding_when_exists(self):
+        mock_record = MagicMock()
+        mock_record.embedding = [0.5] * 1536
+        mock_ctx, _ = _mock_session_ctx(query_results=mock_record)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.get_embedding(prediction_id=1)
+
+        assert result == [0.5] * 1536
+
+    def test_returns_none_when_not_found(self):
+        mock_ctx, _ = _mock_session_ctx(query_results=None)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.get_embedding(prediction_id=999)
+
+        assert result is None

--- a/shit_tests/echoes/test_similarity.py
+++ b/shit_tests/echoes/test_similarity.py
@@ -1,0 +1,120 @@
+"""
+Tests for EchoService similarity search (find_similar_posts).
+
+Since pgvector queries require PostgreSQL, these tests mock the raw SQL
+execution to verify query construction and result mapping.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+from shit.echoes.echo_service import EchoService
+
+_SESSION_PATCH = "shit.echoes.echo_service.get_session"
+
+
+def _mock_embedding_client():
+    mock = MagicMock()
+    mock.model = "text-embedding-3-small"
+    return mock
+
+
+def _make_similarity_rows(rows):
+    """Create mock fetchall() result rows.
+
+    Each row: (prediction_id, shitpost_id, signal_id, similarity,
+               assets, market_impact, confidence, thesis, post_timestamp)
+    """
+    return rows
+
+
+class TestFindSimilarPosts:
+    def test_returns_matches_in_order(self):
+        mock_rows = [
+            (
+                10,
+                "post_a",
+                None,
+                0.92,
+                ["XLE"],
+                {"XLE": "bullish"},
+                0.85,
+                "Energy thesis",
+                datetime(2025, 11, 15),
+            ),
+            (
+                20,
+                "post_b",
+                None,
+                0.78,
+                ["TSLA"],
+                {"TSLA": "bearish"},
+                0.70,
+                "Tesla thesis",
+                datetime(2025, 12, 1),
+            ),
+        ]
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.return_value = mock_rows
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.find_similar_posts(
+                embedding=[0.1] * 1536, limit=5, exclude_prediction_id=99
+            )
+
+        assert len(result) == 2
+        assert result[0]["prediction_id"] == 10
+        assert result[0]["similarity"] == 0.92
+        assert result[0]["assets"] == ["XLE"]
+        assert result[1]["prediction_id"] == 20
+
+    def test_empty_db_returns_empty(self):
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.return_value = []
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            result = service.find_similar_posts(embedding=[0.1] * 1536)
+
+        assert result == []
+
+    def test_exclude_prediction_id_passed_to_query(self):
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.return_value = []
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            service.find_similar_posts(embedding=[0.1] * 1536, exclude_prediction_id=42)
+
+        call_args = mock_session.execute.call_args
+        params = call_args[0][1]  # Second positional arg is the params dict
+        assert params["exclude_id"] == 42
+
+    def test_min_similarity_converted_to_max_distance(self):
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.return_value = []
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        service = EchoService(embedding_client=_mock_embedding_client())
+        with patch(_SESSION_PATCH, return_value=mock_ctx):
+            service.find_similar_posts(embedding=[0.1] * 1536, min_similarity=0.80)
+
+        call_args = mock_session.execute.call_args
+        params = call_args[0][1]
+        assert abs(params["max_dist"] - 0.20) < 0.001

--- a/shit_tests/shit/llm/test_embeddings.py
+++ b/shit_tests/shit/llm/test_embeddings.py
@@ -1,0 +1,85 @@
+"""
+Tests for shit/llm/embeddings.py — EmbeddingClient.
+
+Covers: single embedding, batch embedding, text truncation.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from shit.llm.embeddings import EmbeddingClient
+
+
+def _make_mock_response(embeddings: list[list[float]]) -> MagicMock:
+    """Create a mock OpenAI embeddings.create() response."""
+    mock_resp = MagicMock()
+    mock_resp.data = [MagicMock(embedding=e) for e in embeddings]
+    return mock_resp
+
+
+class TestEmbedSingle:
+    def test_returns_embedding_vector(self):
+        expected = [0.1] * 1536
+        with patch("shit.llm.embeddings.OpenAI") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.embeddings.create.return_value = _make_mock_response([expected])
+            mock_cls.return_value = mock_client
+
+            client = EmbeddingClient()
+            result = client.embed("Hello world")
+
+        assert result == expected
+        mock_client.embeddings.create.assert_called_once()
+        call_kwargs = mock_client.embeddings.create.call_args
+        assert call_kwargs.kwargs["model"] == "text-embedding-3-small"
+        assert call_kwargs.kwargs["input"] == "Hello world"
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 10000
+        with patch("shit.llm.embeddings.OpenAI") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.embeddings.create.return_value = _make_mock_response(
+                [[0.1] * 1536]
+            )
+            mock_cls.return_value = mock_client
+
+            client = EmbeddingClient()
+            client.embed(long_text)
+
+        call_kwargs = mock_client.embeddings.create.call_args
+        assert len(call_kwargs.kwargs["input"]) == 8000
+
+
+class TestEmbedBatch:
+    def test_returns_multiple_embeddings(self):
+        expected = [[0.1] * 1536, [0.2] * 1536, [0.3] * 1536]
+        with patch("shit.llm.embeddings.OpenAI") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.embeddings.create.return_value = _make_mock_response(expected)
+            mock_cls.return_value = mock_client
+
+            client = EmbeddingClient()
+            result = client.embed_batch(["a", "b", "c"])
+
+        assert len(result) == 3
+        assert result[0] == expected[0]
+
+    def test_empty_input_returns_empty(self):
+        with patch("shit.llm.embeddings.OpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = EmbeddingClient()
+            assert client.embed_batch([]) == []
+
+    def test_truncates_each_text(self):
+        with patch("shit.llm.embeddings.OpenAI") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.embeddings.create.return_value = _make_mock_response(
+                [[0.1] * 1536, [0.2] * 1536]
+            )
+            mock_cls.return_value = mock_client
+
+            client = EmbeddingClient()
+            client.embed_batch(["x" * 10000, "y" * 10000])
+
+        call_kwargs = mock_client.embeddings.create.call_args
+        for text in call_kwargs.kwargs["input"]:
+            assert len(text) == 8000

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -549,6 +549,21 @@ class ShitpostAnalyzer:
                     except Exception as e:
                         logger.warning(f"Failed to emit prediction_created event: {e}")
 
+                    # Generate embedding for Historical Echoes similarity search
+                    try:
+                        post_text = shitpost.get("text", "")
+                        if post_text:
+                            await asyncio.to_thread(
+                                self._embed_prediction,
+                                int(analysis_id),
+                                post_text,
+                                shitpost_id,
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to generate embedding for prediction {analysis_id}: {e}"
+                        )
+
                     # Reactively capture price snapshots + backfill for new tickers
                     if assets:
                         try:
@@ -785,6 +800,20 @@ class ShitpostAnalyzer:
         }
 
         return enhanced_analysis
+
+    @staticmethod
+    def _embed_prediction(
+        prediction_id: int, text: str, shitpost_id: str | None = None
+    ) -> None:
+        """Generate and store embedding for a prediction (sync, for asyncio.to_thread)."""
+        from shit.echoes.echo_service import EchoService
+
+        service = EchoService()
+        service.embed_and_store(
+            prediction_id=prediction_id,
+            text=text,
+            shitpost_id=shitpost_id,
+        )
 
     async def _trigger_reactive_backfill(
         self, prediction_id: int, assets: list, post_published_at=None


### PR DESCRIPTION
## Summary
- **EchoService** (`shit/echoes/`) — embed post text via OpenAI `text-embedding-3-small`, store in `post_embeddings` table (pgvector), find similar past posts by cosine similarity, aggregate their realized market outcomes (returns, win rate, P&L)
- **Analyzer integration** — embeds post text after prediction storage via `asyncio.to_thread` (fail-open: embedding failure doesn't block the pipeline)
- **Telegram alert enrichment** — echo section shows avg return, win rate, P&L from similar past posts; omitted when no echoes found
- **API endpoint** — `GET /api/echoes/for-prediction/{id}?timeframe=t7` with configurable timeframe and limit
- **Backfill CLI** — `python -m shit.echoes.backfill` embeds all existing posts (~$0.001 cost); doubles as retry for failed embeddings

## Production deployment steps
1. Enable pgvector: `CREATE EXTENSION IF NOT EXISTS vector;` on Neon
2. Create `post_embeddings` table (schema in plan doc)
3. Run backfill: `python -m shit.echoes.backfill`
4. Deploy — new predictions will auto-embed

## Verification
- 31 new tests, 1869 total passing
- Lint clean on all changed files
- Challenge round: 5 decisions documented in plan (no IVFFlat index, `shit/echoes/` location, event consumer only, separate API endpoint, backfill-as-retry)

## Test plan
- [x] EmbeddingClient: single/batch embed, truncation (5 tests)
- [x] EchoService: store, dedup, empty text, get embedding (6 tests)
- [x] Similarity search: results ordering, empty DB, exclude self, threshold (4 tests)
- [x] Aggregation: full/no/partial outcomes, match details (5 tests)
- [x] Alert integration: echo section rendering, event consumer enrichment, fail-open (8 tests)
- [x] API endpoint: response, 404, custom timeframe (3 tests)
- [x] Full suite regression: 1869 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)