### PR TITLE
feat: confidence calibration — map raw LLM confidence to empirical accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Confidence Calibration** — Maps raw LLM confidence to empirical accuracy using historical prediction outcomes
+  - `CalibrationService` in `shit/market_data/calibration.py` — bin-based lookup table (10 bins), rolling 6-month window, staleness guard (30-day max age)
+  - `CalibrationCurve` model in `shit/market_data/models.py` — JSONB bin_stats and lookup_table, indexed by (timeframe, fitted_at)
+  - `calibrated_confidence` column on `predictions` table — populated at storage time, nullable for uncalibrated
+  - Prediction storage: applies calibration via deferred import in `PredictionOperations._calibrate()`
+  - Event payload: includes `calibrated_confidence` for downstream consumers
+  - Telegram alerts: shows "85% raw / 62% calibrated" format when calibration available
+  - Alert filtering: prefers calibrated confidence over raw, with graceful fallback
+  - API endpoint `GET /api/calibration/curve?timeframe=t7` — returns bin stats and lookup table
+  - Frontend: SVG reliability diagram component, calibrated badge in PredictionPanel
+  - CLI: `python -m shit.market_data.calibration --refit [--timeframe t7]`
+  - 40 new tests across 4 test files
 - **Historical Echoes** — Semantic similarity search over past posts to surface actual market outcomes alongside new predictions
   - `EchoService` in `shit/echoes/` — embed, search (pgvector cosine similarity), and aggregate historical outcomes (returns, win rate, P&L)
   - `EmbeddingClient` in `shit/llm/embeddings.py` — OpenAI `text-embedding-3-small` (1536 dimensions) with batch support

--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from api.routers import echoes, feed, prices, telegram
+from api.routers import calibration, echoes, feed, prices, telegram
 
 
 @asynccontextmanager
@@ -46,6 +46,7 @@ app.add_middleware(
 )
 
 # API routers
+app.include_router(calibration.router, prefix="/api/calibration", tags=["calibration"])
 app.include_router(echoes.router, prefix="/api/echoes", tags=["echoes"])
 app.include_router(feed.router, prefix="/api/feed", tags=["feed"])
 app.include_router(prices.router, prefix="/api/prices", tags=["prices"])

--- a/api/queries/feed_queries.py
+++ b/api/queries/feed_queries.py
@@ -47,6 +47,7 @@ def get_analyzed_post_at_offset(
             p.assets,
             p.market_impact,
             p.confidence,
+            p.calibrated_confidence,
             p.thesis,
             p.analysis_status,
             p.engagement_score,

--- a/api/routers/calibration.py
+++ b/api/routers/calibration.py
@@ -1,0 +1,29 @@
+"""Calibration curve API endpoint."""
+
+from fastapi import APIRouter, HTTPException, Query
+
+from api.schemas.calibration import CalibrationCurveResponse
+
+router = APIRouter()
+
+
+@router.get("/curve", response_model=CalibrationCurveResponse)
+def get_calibration_curve(
+    timeframe: str = Query("t7", pattern="^t(1|3|7|30)$"),
+):
+    """Get the latest calibration curve for a given timeframe."""
+    from shit.market_data.calibration import CalibrationService
+
+    svc = CalibrationService(timeframe=timeframe)
+    curve = svc._load_latest_curve()
+    if not curve:
+        raise HTTPException(404, "No calibration curve available")
+
+    return CalibrationCurveResponse(
+        fitted_at=curve.fitted_at.isoformat(),
+        timeframe=curve.timeframe,
+        n_predictions=curve.n_predictions,
+        n_bins=curve.n_bins,
+        bin_stats=curve.bin_stats,
+        lookup_table=curve.lookup_table,
+    )

--- a/api/schemas/calibration.py
+++ b/api/schemas/calibration.py
@@ -1,0 +1,21 @@
+"""Pydantic response models for the calibration API."""
+
+from pydantic import BaseModel
+from typing import Optional
+
+
+class BinStat(BaseModel):
+    bin_label: str
+    bin_center: float
+    n_total: int
+    n_correct: int
+    accuracy: Optional[float] = None
+
+
+class CalibrationCurveResponse(BaseModel):
+    fitted_at: str
+    timeframe: str
+    n_predictions: int
+    n_bins: int
+    bin_stats: list[BinStat]
+    lookup_table: dict[str, Optional[float]]

--- a/api/schemas/feed.py
+++ b/api/schemas/feed.py
@@ -53,6 +53,7 @@ class Scores(BaseModel):
 class Prediction(BaseModel):
     prediction_id: int
     confidence: Optional[float] = None
+    calibrated_confidence: Optional[float] = None
     thesis: Optional[str] = None
     assets: list[str] = []
     market_impact: dict[str, str] = {}

--- a/api/services/feed_service.py
+++ b/api/services/feed_service.py
@@ -117,6 +117,7 @@ class FeedService:
         return Prediction(
             prediction_id=row["prediction_id"],
             confidence=row.get("confidence"),
+            calibrated_confidence=row.get("calibrated_confidence"),
             thesis=row.get("thesis"),
             assets=assets if isinstance(assets, list) else [],
             market_impact=market_impact if isinstance(market_impact, dict) else {},

--- a/documentation/planning/product-brainstorm_2026-04-09/06_CONFIDENCE_CALIBRATION.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/06_CONFIDENCE_CALIBRATION.md
@@ -2,8 +2,10 @@
 
 **Feature**: Build a calibration curve from 1000+ historical predictions to map raw LLM confidence to actual accuracy rates.
 
-**Status**: IN PROGRESS  
+**Status**: COMPLETE  
 **Started**: 2026-04-10  
+**Completed**: 2026-04-10  
+**PR**: #135  
 **Priority**: High  
 **Estimated Effort**: 2-3 sessions  
 

--- a/documentation/planning/product-brainstorm_2026-04-09/06_CONFIDENCE_CALIBRATION.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/06_CONFIDENCE_CALIBRATION.md
@@ -2,9 +2,24 @@
 
 **Feature**: Build a calibration curve from 1000+ historical predictions to map raw LLM confidence to actual accuracy rates.
 
-**Status**: Design  
+**Status**: IN PROGRESS  
+**Started**: 2026-04-10  
 **Priority**: High  
 **Estimated Effort**: 2-3 sessions  
+
+---
+
+## Challenge Round Resolutions
+
+1. **Calibration method: Lookup table only (no sklearn).** Isotonic regression adds a ~50MB dependency for marginal smoothing between bins. With 10 bins and 100+ samples/bin, lookup table accuracy is sufficient. No pickle, no BYTEA, no sklearn versioning. Add isotonic later if data volume justifies it.
+
+2. **Scope: Global only for v1 (no per-provider/per-asset).** System uses one LLM provider. Feature 05 (ensemble) isn't built. Adding scope later = add column + WHERE clause (~30 min). No `scope` column in table.
+
+3. **Entry point: `python -m shit.market_data.calibration --refit` (not root-level `calibration_cron.py`).** Follows existing CLI patterns (`shit/echoes/backfill.py`, `shit/market_data/cli.py`).
+
+4. **Table simplified.** No `scope` column, no `model_bytes` BYTEA column. Just JSONB for bin_stats and lookup_table.
+
+5. **Staleness guard added.** `max_age_days=30` on curve loading. Returns None if curve is older than threshold — falls back to raw confidence gracefully.
 
 ---
 
@@ -60,56 +75,29 @@ T+7 (7 trading days, ~1.5 calendar weeks) is the sweet spot:
 
 Calibration curves for other timeframes (T+1, T+3, T+30) can be computed too, but T+7 is the default.
 
-### Fitting Method: Isotonic Regression
+### Fitting Method: Bin-Based Lookup Table
 
-**Why isotonic regression over Platt scaling:**
+**Why lookup table over isotonic regression (Challenge Round Resolution #1):**
 
-- Platt scaling (logistic sigmoid fit) assumes a specific functional form. Our confidence-to-accuracy relationship may not be sigmoidal.
-- Isotonic regression is non-parametric -- it produces a monotonically non-decreasing mapping with no functional form assumption.
-- With 1000+ data points across 10 bins, we have enough data for non-parametric fitting.
-- `sklearn.isotonic.IsotonicRegression` is battle-tested and available.
-
-```python
-from sklearn.isotonic import IsotonicRegression
-
-def fit_calibration_curve(
-    raw_confidences: list[float],
-    correct_flags: list[bool],
-) -> IsotonicRegression:
-    """Fit isotonic regression calibration curve.
-
-    Args:
-        raw_confidences: LLM confidence scores for each prediction.
-        correct_flags: Whether each prediction was correct (True/False).
-
-    Returns:
-        Fitted IsotonicRegression model.
-    """
-    import numpy as np
-
-    X = np.array(raw_confidences)
-    y = np.array(correct_flags, dtype=float)
-
-    ir = IsotonicRegression(y_min=0.0, y_max=1.0, out_of_bounds="clip")
-    ir.fit(X, y)
-    return ir
-```
-
-### Alternative: Simple Lookup Table
-
-For environments where sklearn is undesirable, a simple bin-based lookup table works:
+- No new dependency (sklearn ~50MB+ with scipy). Zero new packages.
+- With 10 bins and 100+ samples per bin, accuracy estimates are already stable.
+- JSON-native — debuggable, inspectable, no pickle versioning issues.
+- Isotonic regression on 10 bins converges to ~10 breakpoints — same resolution as lookup table.
+- If data volume grows to 10,000+ predictions, isotonic regression can be added in one PR.
 
 ```python
 def build_lookup_table(
     raw_confidences: list[float],
     correct_flags: list[bool],
     n_bins: int = 10,
-) -> dict[str, float]:
+    min_per_bin: int = 5,
+) -> dict[str, float | None]:
     """Build bin-based calibration lookup table.
 
     Returns:
         Dict mapping bin label to empirical accuracy.
         Example: {"0.7-0.8": 0.62, "0.8-0.9": 0.71, ...}
+        Bins with fewer than min_per_bin samples return None.
     """
     bins = {}
     for conf, correct in zip(raw_confidences, correct_flags):
@@ -122,12 +110,11 @@ def build_lookup_table(
             bins[bin_label]["correct"] += 1
 
     return {
-        label: data["correct"] / data["total"] if data["total"] > 0 else None
+        label: round(data["correct"] / data["total"], 4)
+        if data["total"] >= min_per_bin else None
         for label, data in sorted(bins.items())
     }
 ```
-
-**Recommendation**: Implement both. Use isotonic regression as the primary calibration method, with the lookup table as a human-readable diagnostic.
 
 ---
 
@@ -163,286 +150,12 @@ CALIBRATION_MIN_PER_BIN: int = 5    # Minimum per bin
 
 ### New Module: `shit/market_data/calibration.py`
 
-```python
-"""
-Confidence Calibration Service
+> **Challenge Round**: Simplified — no sklearn, no pickle, no scope, no BYTEA. Lookup table only. Staleness guard added.
 
-Fits calibration curves from historical prediction outcomes and applies
-calibrated confidence to new predictions.
-"""
-
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from typing import Optional
-import json
-import pickle
-
-from sqlalchemy import text
-from shit.db.sync_session import get_session
-from shit.logging import get_service_logger
-
-logger = get_service_logger("calibration")
-
-
-@dataclass
-class CalibrationCurve:
-    """Fitted calibration curve with metadata."""
-    fitted_at: datetime
-    timeframe: str                    # "t7" (primary), "t1", "t3", "t30"
-    window_start: datetime
-    window_end: datetime
-    n_predictions: int
-    n_bins: int
-    bin_stats: list[dict]             # Per-bin: {bin_label, n_total, n_correct, accuracy}
-    model_bytes: Optional[bytes]      # Pickled IsotonicRegression
-    lookup_table: dict[str, float]    # Bin label -> empirical accuracy
-    scope: str                        # "global", "provider:openai", "asset:TSLA"
-
-
-class CalibrationService:
-    """Fits and applies confidence calibration curves."""
-
-    def __init__(
-        self,
-        timeframe: str = "t7",
-        window_days: int = 180,
-        min_samples: int = 100,
-        min_per_bin: int = 5,
-        n_bins: int = 10,
-    ):
-        self.timeframe = timeframe
-        self.window_days = window_days
-        self.min_samples = min_samples
-        self.min_per_bin = min_per_bin
-        self.n_bins = n_bins
-
-    def fit(self, scope: str = "global") -> Optional[CalibrationCurve]:
-        """Fit a calibration curve from historical data.
-
-        Args:
-            scope: "global", "provider:{id}", or "asset:{symbol}"
-
-        Returns:
-            CalibrationCurve if enough data, None otherwise.
-        """
-        # Query historical predictions with outcomes
-        data = self._query_calibration_data(scope)
-        if len(data) < self.min_samples:
-            logger.warning(
-                f"Insufficient data for calibration: {len(data)} < {self.min_samples}"
-            )
-            return None
-
-        raw_confidences = [d["confidence"] for d in data]
-        correct_flags = [d["correct"] for d in data]
-
-        # Build lookup table
-        lookup = self._build_lookup_table(raw_confidences, correct_flags)
-
-        # Fit isotonic regression
-        model_bytes = self._fit_isotonic(raw_confidences, correct_flags)
-
-        # Build per-bin statistics
-        bin_stats = self._compute_bin_stats(raw_confidences, correct_flags)
-
-        window_end = datetime.utcnow()
-        window_start = window_end - timedelta(days=self.window_days)
-
-        curve = CalibrationCurve(
-            fitted_at=datetime.utcnow(),
-            timeframe=self.timeframe,
-            window_start=window_start,
-            window_end=window_end,
-            n_predictions=len(data),
-            n_bins=self.n_bins,
-            bin_stats=bin_stats,
-            model_bytes=model_bytes,
-            lookup_table=lookup,
-            scope=scope,
-        )
-
-        # Persist to database
-        self._store_curve(curve)
-        logger.info(
-            f"Calibration curve fitted: {scope}, {len(data)} predictions, "
-            f"timeframe={self.timeframe}"
-        )
-        return curve
-
-    def calibrate(self, raw_confidence: float) -> Optional[float]:
-        """Apply calibration to a raw confidence score.
-
-        Args:
-            raw_confidence: LLM-reported confidence (0.0-1.0).
-
-        Returns:
-            Calibrated confidence, or None if no calibration curve available.
-        """
-        curve = self._load_latest_curve()
-        if not curve or not curve.model_bytes:
-            return None
-
-        try:
-            import numpy as np
-            model = pickle.loads(curve.model_bytes)
-            calibrated = float(model.predict([raw_confidence])[0])
-            return max(0.0, min(1.0, calibrated))
-        except Exception as e:
-            logger.error(f"Calibration prediction failed: {e}")
-            return None
-
-    def _query_calibration_data(self, scope: str) -> list[dict]:
-        """Query predictions with outcomes for calibration fitting."""
-        correct_col = f"correct_{self.timeframe}"
-        window_start = datetime.utcnow() - timedelta(days=self.window_days)
-
-        base_query = f"""
-            SELECT
-                p.confidence,
-                po.{correct_col} as correct,
-                p.llm_provider,
-                po.symbol
-            FROM predictions p
-            JOIN prediction_outcomes po ON po.prediction_id = p.id
-            WHERE p.analysis_status = 'completed'
-                AND p.confidence IS NOT NULL
-                AND po.{correct_col} IS NOT NULL
-                AND p.created_at >= :window_start
-        """
-
-        params = {"window_start": window_start}
-
-        # Add scope filter
-        if scope.startswith("provider:"):
-            provider = scope.split(":")[1]
-            base_query += " AND p.llm_provider = :provider"
-            params["provider"] = provider
-        elif scope.startswith("asset:"):
-            symbol = scope.split(":")[1]
-            base_query += " AND po.symbol = :symbol"
-            params["symbol"] = symbol
-
-        with get_session() as session:
-            result = session.execute(text(base_query), params)
-            rows = result.fetchall()
-            columns = result.keys()
-            return [dict(zip(columns, row)) for row in rows]
-
-    def _fit_isotonic(self, confidences: list[float], correct: list[bool]) -> Optional[bytes]:
-        """Fit isotonic regression and return pickled model bytes."""
-        try:
-            import numpy as np
-            from sklearn.isotonic import IsotonicRegression
-
-            X = np.array(confidences)
-            y = np.array(correct, dtype=float)
-            ir = IsotonicRegression(y_min=0.0, y_max=1.0, out_of_bounds="clip")
-            ir.fit(X, y)
-            return pickle.dumps(ir)
-        except ImportError:
-            logger.warning("sklearn not available, skipping isotonic regression")
-            return None
-
-    def _build_lookup_table(self, confidences: list[float], correct: list[bool]) -> dict:
-        """Build bin-based lookup table."""
-        bins = {}
-        for conf, c in zip(confidences, correct):
-            bin_idx = min(int(conf * self.n_bins), self.n_bins - 1)
-            label = f"{bin_idx / self.n_bins:.1f}-{(bin_idx + 1) / self.n_bins:.1f}"
-            if label not in bins:
-                bins[label] = {"total": 0, "correct": 0}
-            bins[label]["total"] += 1
-            if c:
-                bins[label]["correct"] += 1
-
-        return {
-            label: round(data["correct"] / data["total"], 4) if data["total"] >= self.min_per_bin else None
-            for label, data in sorted(bins.items())
-        }
-
-    def _compute_bin_stats(self, confidences: list[float], correct: list[bool]) -> list[dict]:
-        """Compute detailed per-bin statistics."""
-        bins = {}
-        for conf, c in zip(confidences, correct):
-            bin_idx = min(int(conf * self.n_bins), self.n_bins - 1)
-            if bin_idx not in bins:
-                bins[bin_idx] = {"total": 0, "correct": 0}
-            bins[bin_idx]["total"] += 1
-            if c:
-                bins[bin_idx]["correct"] += 1
-
-        stats = []
-        for i in range(self.n_bins):
-            data = bins.get(i, {"total": 0, "correct": 0})
-            accuracy = data["correct"] / data["total"] if data["total"] > 0 else None
-            stats.append({
-                "bin_label": f"{i / self.n_bins:.1f}-{(i + 1) / self.n_bins:.1f}",
-                "bin_center": (i + 0.5) / self.n_bins,
-                "n_total": data["total"],
-                "n_correct": data["correct"],
-                "accuracy": accuracy,
-            })
-        return stats
-
-    def _store_curve(self, curve: CalibrationCurve) -> None:
-        """Persist calibration curve to database."""
-        with get_session() as session:
-            session.execute(
-                text("""
-                    INSERT INTO calibration_curves (
-                        fitted_at, timeframe, window_start, window_end,
-                        n_predictions, n_bins, bin_stats, model_bytes,
-                        lookup_table, scope
-                    ) VALUES (
-                        :fitted_at, :timeframe, :window_start, :window_end,
-                        :n_predictions, :n_bins, :bin_stats, :model_bytes,
-                        :lookup_table, :scope
-                    )
-                """),
-                {
-                    "fitted_at": curve.fitted_at,
-                    "timeframe": curve.timeframe,
-                    "window_start": curve.window_start,
-                    "window_end": curve.window_end,
-                    "n_predictions": curve.n_predictions,
-                    "n_bins": curve.n_bins,
-                    "bin_stats": json.dumps(curve.bin_stats),
-                    "model_bytes": curve.model_bytes,
-                    "lookup_table": json.dumps(curve.lookup_table),
-                    "scope": curve.scope,
-                },
-            )
-
-    def _load_latest_curve(self, scope: str = "global") -> Optional[CalibrationCurve]:
-        """Load the most recently fitted calibration curve."""
-        with get_session() as session:
-            result = session.execute(
-                text("""
-                    SELECT * FROM calibration_curves
-                    WHERE scope = :scope AND timeframe = :timeframe
-                    ORDER BY fitted_at DESC
-                    LIMIT 1
-                """),
-                {"scope": scope, "timeframe": self.timeframe},
-            )
-            row = result.fetchone()
-            if not row:
-                return None
-            columns = result.keys()
-            data = dict(zip(columns, row))
-            return CalibrationCurve(
-                fitted_at=data["fitted_at"],
-                timeframe=data["timeframe"],
-                window_start=data["window_start"],
-                window_end=data["window_end"],
-                n_predictions=data["n_predictions"],
-                n_bins=data["n_bins"],
-                bin_stats=json.loads(data["bin_stats"]) if isinstance(data["bin_stats"], str) else data["bin_stats"],
-                model_bytes=data["model_bytes"],
-                lookup_table=json.loads(data["lookup_table"]) if isinstance(data["lookup_table"], str) else data["lookup_table"],
-                scope=data["scope"],
-            )
-```
+See implementation for final code. Key design:
+- `CalibrationCurve` dataclass: fitted_at, timeframe, window dates, n_predictions, n_bins, bin_stats (list[dict]), lookup_table (dict)
+- `CalibrationService`: fit() queries data + builds lookup, calibrate() does bin lookup, _load_latest_curve() has max_age_days=30 staleness guard
+- CLI entry: `python -m shit.market_data.calibration --refit [--timeframe t7]`
 
 ---
 
@@ -457,36 +170,9 @@ calibrated_confidence = Column(Float, nullable=True)  # Calibrated confidence 0.
 
 ### New Table: `calibration_curves`
 
-```sql
-CREATE TABLE calibration_curves (
-    id SERIAL PRIMARY KEY,
-    fitted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    timeframe VARCHAR(10) NOT NULL,          -- 't1', 't3', 't7', 't30'
-    window_start TIMESTAMP NOT NULL,
-    window_end TIMESTAMP NOT NULL,
-    n_predictions INTEGER NOT NULL,
-    n_bins INTEGER NOT NULL DEFAULT 10,
-    bin_stats JSONB NOT NULL,                -- Per-bin statistics
-    model_bytes BYTEA,                       -- Pickled sklearn model
-    lookup_table JSONB NOT NULL,             -- Bin -> accuracy mapping
-    scope VARCHAR(100) NOT NULL DEFAULT 'global',  -- 'global', 'provider:openai', 'asset:TSLA'
-    created_at TIMESTAMP NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX idx_calibration_curves_scope_timeframe
-    ON calibration_curves (scope, timeframe, fitted_at DESC);
-
-COMMENT ON TABLE calibration_curves IS 'Historical calibration curves mapping raw LLM confidence to empirical accuracy';
-```
-
-### Migration SQL
+> **Challenge Round**: Simplified — no `scope` column, no `model_bytes` BYTEA column.
 
 ```sql
--- Add calibrated_confidence to predictions
-ALTER TABLE predictions ADD COLUMN calibrated_confidence FLOAT;
-COMMENT ON COLUMN predictions.calibrated_confidence IS 'Empirically calibrated confidence from calibration curve (null if uncalibrated)';
-
--- Create calibration_curves table
 CREATE TABLE calibration_curves (
     id SERIAL PRIMARY KEY,
     fitted_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -496,14 +182,34 @@ CREATE TABLE calibration_curves (
     n_predictions INTEGER NOT NULL,
     n_bins INTEGER NOT NULL DEFAULT 10,
     bin_stats JSONB NOT NULL,
-    model_bytes BYTEA,
     lookup_table JSONB NOT NULL,
-    scope VARCHAR(100) NOT NULL DEFAULT 'global',
     created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_calibration_curves_scope_timeframe
-    ON calibration_curves (scope, timeframe, fitted_at DESC);
+CREATE INDEX idx_calibration_curves_timeframe
+    ON calibration_curves (timeframe, fitted_at DESC);
+```
+
+### Migration SQL
+
+```sql
+ALTER TABLE predictions ADD COLUMN calibrated_confidence FLOAT;
+
+CREATE TABLE calibration_curves (
+    id SERIAL PRIMARY KEY,
+    fitted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    timeframe VARCHAR(10) NOT NULL,
+    window_start TIMESTAMP NOT NULL,
+    window_end TIMESTAMP NOT NULL,
+    n_predictions INTEGER NOT NULL,
+    n_bins INTEGER NOT NULL DEFAULT 10,
+    bin_stats JSONB NOT NULL,
+    lookup_table JSONB NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_calibration_curves_timeframe
+    ON calibration_curves (timeframe, fitted_at DESC);
 ```
 
 ---
@@ -512,88 +218,36 @@ CREATE INDEX idx_calibration_curves_scope_timeframe
 
 ### Weekly Refit Cron
 
-A Railway cron job runs every Sunday at 02:00 UTC:
-
-```python
-# calibration_cron.py (new entry point)
-"""Weekly calibration curve refit."""
-
-from shit.market_data.calibration import CalibrationService
-from shit.logging import setup_cli_logging
-
-def main():
-    setup_cli_logging(verbose=True)
-
-    for timeframe in ["t1", "t3", "t7", "t30"]:
-        svc = CalibrationService(timeframe=timeframe)
-
-        # Global calibration
-        curve = svc.fit(scope="global")
-        if curve:
-            print(f"Global {timeframe}: {curve.n_predictions} predictions, "
-                  f"lookup={curve.lookup_table}")
-
-        # Per-provider calibration (if ensemble is active)
-        for provider in ["openai", "anthropic", "grok"]:
-            curve = svc.fit(scope=f"provider:{provider}")
-            if curve:
-                print(f"Provider {provider} {timeframe}: {curve.n_predictions} predictions")
-
-if __name__ == "__main__":
-    main()
-```
+> **Challenge Round**: Entry point moved from root-level `calibration_cron.py` to `python -m shit.market_data.calibration --refit`. Per-provider loop removed (global only).
 
 **Railway Service**: `calibration-refit`, cron schedule `0 2 * * 0` (Sunday 2 AM UTC).
+**Command**: `python -m shit.market_data.calibration --refit`
 
 ### On-Demand Refit
 
-The calibration service can also be triggered manually:
-
 ```bash
-python -m shit.market_data.calibration --refit --timeframe t7 --scope global
+python -m shit.market_data.calibration --refit                    # All timeframes
+python -m shit.market_data.calibration --refit --timeframe t7     # Single timeframe
 ```
 
 ---
 
-## Per-Asset vs. Global Calibration
+## Scope: Global Only (v1)
 
-### Tradeoffs
-
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Global** | Most data per bin, stable estimates | Ignores asset-specific LLM bias |
-| **Per-provider** | Captures model-specific calibration | 3x less data per curve |
-| **Per-asset** | Most accurate per ticker | Very sparse (most tickers have < 20 predictions) |
-| **Per-sector** | Good balance of specificity and data | Requires sector tagging |
-
-### Recommendation
-
-1. **Primary**: Global calibration (enough data, most stable).
-2. **Secondary**: Per-provider calibration (useful when ensemble is active; each provider may have different confidence distributions).
-3. **Future**: Per-sector calibration when enough data accumulates (group assets by `ticker_registry.sector`).
-4. **Not recommended now**: Per-asset calibration (insufficient data for most tickers).
+> **Challenge Round**: Per-provider and per-asset scoping deferred until Feature 05 (Multi-LLM Ensemble) lands. Global calibration is sufficient with one provider.
 
 ### Applying Calibration at Prediction Time
 
-In `shitvault/prediction_operations.py`, when storing a prediction:
+In `shitvault/prediction_operations.py`, apply calibration via deferred import + `asyncio.to_thread`:
 
 ```python
-async def store_analysis(self, shitpost_id: str, analysis: dict, shitpost: dict) -> Optional[int]:
-    # ... existing logic ...
-
-    # Apply calibration
-    raw_confidence = analysis.get("confidence")
-    calibrated = None
-    if raw_confidence is not None:
-        from shit.market_data.calibration import CalibrationService
-        cal_svc = CalibrationService(timeframe="t7")
-        calibrated = cal_svc.calibrate(raw_confidence)
-
-    prediction = Prediction(
-        confidence=raw_confidence,
-        calibrated_confidence=calibrated,
-        # ... other fields ...
-    )
+# After creating prediction, apply calibration
+raw_confidence = analysis_data.get("confidence")
+if raw_confidence is not None:
+    from shit.market_data.calibration import CalibrationService
+    cal_svc = CalibrationService(timeframe="t7")
+    calibrated = cal_svc.calibrate(raw_confidence)
+    # Store on prediction object
 ```
 
 ---
@@ -721,15 +375,16 @@ When the system first deploys or after a major model change, there may not be en
 
 | File | Change |
 |------|--------|
-| `shit/market_data/calibration.py` | **NEW** - `CalibrationService`, `CalibrationCurve` |
+| `shit/market_data/calibration.py` | **NEW** - `CalibrationService`, `CalibrationCurve` (with CLI `__main__` block) |
 | `shitvault/shitpost_models.py` | Add `calibrated_confidence` column to Prediction |
 | `shitvault/prediction_operations.py` | Apply calibration when storing predictions |
 | `notifications/telegram_sender.py` | Show calibrated confidence in alerts |
 | `notifications/alert_engine.py` | Filter on calibrated confidence |
+| `notifications/event_consumer.py` | Pass `calibrated_confidence` in alert dict |
 | `api/routers/calibration.py` | **NEW** - Calibration curve API endpoint |
 | `api/schemas/feed.py` | Add `calibrated_confidence` to PredictionResponse |
+| `api/schemas/calibration.py` | **NEW** - Calibration API response models |
 | `frontend/src/components/CalibrationChart.tsx` | **NEW** - Reliability diagram |
-| `calibration_cron.py` | **NEW** - Weekly refit entry point |
 | `shit_tests/shit/market_data/test_calibration.py` | **NEW** - Unit tests |
 
 ---
@@ -792,15 +447,7 @@ def synthetic_calibration_data():
 
 ## Dependencies
 
-### New Python Package
-
-```
-scikit-learn>=1.4.0  # For IsotonicRegression
-```
-
-Add to `requirements.txt`. This is a well-maintained, BSD-licensed package already commonly used in ML applications. The only function we need is `IsotonicRegression`.
-
-If adding sklearn is undesirable (large dependency), the lookup table approach works standalone. The isotonic regression is an enhancement, not a requirement.
+> **Challenge Round**: No new Python packages. sklearn removed — lookup table uses only stdlib + existing numpy/sqlalchemy.
 
 ---
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 /** API client — fetch wrapper with base URL handling. */
 
-import type { FeedResponse, LiveQuote, PriceResponse } from "../types/api";
+import type { CalibrationCurveData, FeedResponse, LiveQuote, PriceResponse } from "../types/api";
 
 const BASE_URL = "";
 
@@ -28,4 +28,12 @@ export function fetchPriceData(
 
 export function fetchLiveQuote(symbol: string): Promise<LiveQuote> {
   return fetchJson<LiveQuote>(`/api/prices/${symbol}/live`);
+}
+
+export function fetchCalibrationCurve(
+  timeframe: string = "t7",
+): Promise<CalibrationCurveData> {
+  return fetchJson<CalibrationCurveData>(
+    `/api/calibration/curve?timeframe=${timeframe}`,
+  );
 }

--- a/frontend/src/components/CalibrationChart.tsx
+++ b/frontend/src/components/CalibrationChart.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import { fetchCalibrationCurve } from "../api/client";
+import type { CalibrationCurveData } from "../types/api";
+import { colors } from "../styles/theme";
+
+const containerStyle: CSSProperties = {
+  marginTop: "12px",
+  borderRadius: "12px",
+  overflow: "hidden",
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.06)",
+  padding: "16px",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "13px",
+  fontWeight: 600,
+  color: colors.navy,
+  marginBottom: "12px",
+};
+
+const metaStyle: CSSProperties = {
+  fontSize: "11px",
+  color: colors.textMuted,
+  marginTop: "8px",
+};
+
+const CHART_W = 300;
+const CHART_H = 220;
+const PAD = { top: 10, right: 20, bottom: 30, left: 40 };
+const PLOT_W = CHART_W - PAD.left - PAD.right;
+const PLOT_H = CHART_H - PAD.top - PAD.bottom;
+
+export default function CalibrationChart() {
+  const [data, setData] = useState<CalibrationCurveData | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetchCalibrationCurve("t7")
+      .then(setData)
+      .catch(() => setError(true));
+  }, []);
+
+  if (error || !data) return null;
+
+  const bins = data.bin_stats.filter((b) => b.accuracy !== null && b.n_total > 0);
+  if (bins.length === 0) return null;
+
+  const x = (v: number) => PAD.left + v * PLOT_W;
+  const y = (v: number) => PAD.top + (1 - v) * PLOT_H;
+
+  return (
+    <div style={containerStyle}>
+      <div style={titleStyle}>Confidence Calibration (T+7)</div>
+      <svg
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        width="100%"
+        style={{ maxWidth: CHART_W }}
+      >
+        {/* Grid lines */}
+        {[0, 0.25, 0.5, 0.75, 1].map((v) => (
+          <line
+            key={`h-${v}`}
+            x1={PAD.left}
+            x2={PAD.left + PLOT_W}
+            y1={y(v)}
+            y2={y(v)}
+            stroke={colors.gridLine}
+            strokeWidth={1}
+          />
+        ))}
+
+        {/* Perfect calibration diagonal */}
+        <line
+          x1={x(0)}
+          y1={y(0)}
+          x2={x(1)}
+          y2={y(1)}
+          stroke={colors.borderLight}
+          strokeWidth={1}
+          strokeDasharray="4 4"
+        />
+
+        {/* Actual calibration points + line */}
+        {bins.length > 1 && (
+          <polyline
+            points={bins
+              .map((b) => `${x(b.bin_center)},${y(b.accuracy!)}`)
+              .join(" ")}
+            fill="none"
+            stroke={colors.blue}
+            strokeWidth={2}
+          />
+        )}
+        {bins.map((b) => (
+          <circle
+            key={b.bin_label}
+            cx={x(b.bin_center)}
+            cy={y(b.accuracy!)}
+            r={Math.min(6, Math.max(3, b.n_total / 20))}
+            fill={colors.blue}
+            opacity={0.85}
+          >
+            <title>
+              {b.bin_label}: {(b.accuracy! * 100).toFixed(0)}% accurate (n=
+              {b.n_total})
+            </title>
+          </circle>
+        ))}
+
+        {/* Y-axis labels */}
+        {[0, 0.25, 0.5, 0.75, 1].map((v) => (
+          <text
+            key={`yl-${v}`}
+            x={PAD.left - 4}
+            y={y(v) + 3}
+            textAnchor="end"
+            fontSize={9}
+            fill={colors.textMuted}
+          >
+            {(v * 100).toFixed(0)}%
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {[0, 0.25, 0.5, 0.75, 1].map((v) => (
+          <text
+            key={`xl-${v}`}
+            x={x(v)}
+            y={PAD.top + PLOT_H + 14}
+            textAnchor="middle"
+            fontSize={9}
+            fill={colors.textMuted}
+          >
+            {(v * 100).toFixed(0)}%
+          </text>
+        ))}
+
+        {/* Axis labels */}
+        <text
+          x={x(0.5)}
+          y={CHART_H - 2}
+          textAnchor="middle"
+          fontSize={10}
+          fill={colors.textSecondary}
+        >
+          Raw Confidence
+        </text>
+        <text
+          x={10}
+          y={y(0.5)}
+          textAnchor="middle"
+          fontSize={10}
+          fill={colors.textSecondary}
+          transform={`rotate(-90, 10, ${y(0.5)})`}
+        >
+          Actual Accuracy
+        </text>
+      </svg>
+      <div style={metaStyle}>
+        {data.n_predictions} predictions &middot; Fitted{" "}
+        {new Date(data.fitted_at).toLocaleDateString()}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PredictionPanel.tsx
+++ b/frontend/src/components/PredictionPanel.tsx
@@ -59,6 +59,18 @@ export function PredictionPanel({ prediction }: Props) {
         <span style={labelStyle}>AI Intelligence Report</span>
         <span style={{ ...convictionStyle, color: confidenceColor }}>
           {formatConfidence(prediction.confidence)} CONVICTION
+          {prediction.calibrated_confidence != null && (
+            <span
+              style={{
+                fontSize: "0.7rem",
+                fontWeight: 400,
+                color: "var(--text-muted)",
+                marginLeft: "6px",
+              }}
+            >
+              ({Math.round(prediction.calibrated_confidence * 100)}% cal)
+            </span>
+          )}
         </span>
       </div>
 

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -14,6 +14,7 @@ import { SkeletonFeed } from "../components/SkeletonFeed";
 import { PriceKPIs } from "../components/PriceKPIs";
 import { TimeframeToggle, timeframeToDays, type Timeframe } from "../components/TimeframeToggle";
 import { PriceChart } from "../components/PriceChart";
+import CalibrationChart from "../components/CalibrationChart";
 import { NavigationArrows } from "../components/NavigationArrows";
 
 const mainStyle: CSSProperties = {
@@ -195,6 +196,8 @@ export function FeedPage() {
                     outcome={activeOutcome}
                   />
                 )}
+
+                <CalibrationChart />
               </>
             )}
           </motion.div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -49,10 +49,28 @@ export interface Scores {
 export interface Prediction {
   prediction_id: number;
   confidence: number | null;
+  calibrated_confidence: number | null;
   thesis: string | null;
   assets: string[];
   market_impact: Record<string, string>;
   scores: Scores;
+}
+
+export interface BinStat {
+  bin_label: string;
+  bin_center: number;
+  n_total: number;
+  n_correct: number;
+  accuracy: number | null;
+}
+
+export interface CalibrationCurveData {
+  fitted_at: string;
+  timeframe: string;
+  n_predictions: number;
+  n_bins: number;
+  bin_stats: BinStat[];
+  lookup_table: Record<string, number | null>;
 }
 
 export interface Returns {

--- a/notifications/alert_engine.py
+++ b/notifications/alert_engine.py
@@ -138,8 +138,8 @@ def filter_predictions_by_preferences(
 
     matched = []
     for pred in predictions:
-        # Check confidence threshold
-        confidence = pred.get("confidence")
+        # Check confidence threshold (prefer calibrated when available)
+        confidence = pred.get("calibrated_confidence") or pred.get("confidence")
         if confidence is None or confidence < min_confidence:
             continue
 

--- a/notifications/event_consumer.py
+++ b/notifications/event_consumer.py
@@ -57,6 +57,7 @@ class NotificationsWorker(EventWorker):
             "prediction_id": prediction_id,
             "shitpost_id": payload.get("shitpost_id"),
             "confidence": payload.get("confidence"),
+            "calibrated_confidence": payload.get("calibrated_confidence"),
             "assets": payload.get("assets", []),
             "sentiment": "neutral",  # Will be enriched if market_impact available
             "thesis": "",

--- a/notifications/telegram_sender.py
+++ b/notifications/telegram_sender.py
@@ -125,7 +125,15 @@ def format_telegram_alert(alert: Dict[str, Any]) -> str:
     """
     sentiment = alert.get("sentiment", "neutral").upper()
     confidence = alert.get("confidence", 0)
-    confidence_pct = escape_markdown(f"{confidence:.0%}") if confidence else "N/A"
+    calibrated = alert.get("calibrated_confidence")
+    if calibrated is not None and confidence:
+        confidence_pct = escape_markdown(
+            f"{confidence:.0%} raw / {calibrated:.0%} calibrated"
+        )
+    elif confidence:
+        confidence_pct = escape_markdown(f"{confidence:.0%}")
+    else:
+        confidence_pct = "N/A"
     assets = alert.get("assets", [])
     assets_str = escape_markdown(", ".join(assets[:5])) if assets else "None specified"
     text = alert.get("text", "")[:300]

--- a/shit/db/sync_session.py
+++ b/shit/db/sync_session.py
@@ -74,7 +74,7 @@ def create_tables():
         Prediction,
         TelegramSubscription,
     )
-    from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry
+    from shit.market_data.models import MarketPrice, PredictionOutcome, TickerRegistry, CalibrationCurve  # noqa: F401
     from shitvault.signal_models import Signal
     from shit.events.models import Event  # noqa: F401
     from shit.echoes.models import PostEmbedding  # noqa: F401

--- a/shit/market_data/calibration.py
+++ b/shit/market_data/calibration.py
@@ -1,0 +1,260 @@
+"""
+Confidence Calibration Service
+
+Fits calibration curves from historical prediction outcomes and applies
+calibrated confidence to new predictions. Uses bin-based lookup tables
+to map raw LLM confidence to empirical accuracy rates.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import text
+
+from shit.db.sync_session import get_session
+from shit.logging import get_service_logger
+from shit.market_data.models import CalibrationCurve
+
+logger = get_service_logger("calibration")
+
+VALID_TIMEFRAMES = ("t1", "t3", "t7", "t30")
+
+
+class CalibrationService:
+    """Fits and applies confidence calibration curves."""
+
+    def __init__(
+        self,
+        timeframe: str = "t7",
+        window_days: int = 180,
+        min_samples: int = 100,
+        min_per_bin: int = 5,
+        n_bins: int = 10,
+        max_age_days: int = 30,
+    ):
+        if timeframe not in VALID_TIMEFRAMES:
+            raise ValueError(f"Invalid timeframe: {timeframe}. Must be one of {VALID_TIMEFRAMES}")
+        self.timeframe = timeframe
+        self.window_days = window_days
+        self.min_samples = min_samples
+        self.min_per_bin = min_per_bin
+        self.n_bins = n_bins
+        self.max_age_days = max_age_days
+
+    def fit(self) -> Optional[CalibrationCurve]:
+        """Fit a calibration curve from historical prediction outcomes.
+
+        Returns:
+            CalibrationCurve ORM instance if enough data, None otherwise.
+        """
+        data = self._query_calibration_data()
+        if len(data) < self.min_samples:
+            logger.warning(
+                f"Insufficient data for calibration: {len(data)} < {self.min_samples}"
+            )
+            return None
+
+        confidences = [d["confidence"] for d in data]
+        correct_flags = [d["correct"] for d in data]
+
+        lookup = self._build_lookup_table(confidences, correct_flags)
+        bin_stats = self._compute_bin_stats(confidences, correct_flags)
+
+        now = datetime.now(timezone.utc)
+        curve = CalibrationCurve(
+            fitted_at=now,
+            timeframe=self.timeframe,
+            window_start=now - timedelta(days=self.window_days),
+            window_end=now,
+            n_predictions=len(data),
+            n_bins=self.n_bins,
+            bin_stats=bin_stats,
+            lookup_table=lookup,
+        )
+
+        self._store_curve(curve)
+        logger.info(
+            f"Calibration curve fitted: {len(data)} predictions, "
+            f"timeframe={self.timeframe}"
+        )
+        return curve
+
+    def calibrate(self, raw_confidence: float) -> Optional[float]:
+        """Apply calibration to a raw confidence score.
+
+        Args:
+            raw_confidence: LLM-reported confidence (0.0-1.0).
+
+        Returns:
+            Calibrated confidence, or None if no curve available or bin has
+            insufficient data.
+        """
+        curve = self._load_latest_curve()
+        if not curve:
+            return None
+
+        bin_idx = min(int(raw_confidence * self.n_bins), self.n_bins - 1)
+        label = f"{bin_idx / self.n_bins:.1f}-{(bin_idx + 1) / self.n_bins:.1f}"
+        return curve.lookup_table.get(label)
+
+    def _query_calibration_data(self) -> list[dict]:
+        """Query predictions with outcomes for calibration fitting."""
+        correct_col = f"correct_{self.timeframe}"
+        window_start = datetime.now(timezone.utc) - timedelta(days=self.window_days)
+
+        query = text(f"""
+            SELECT
+                p.confidence,
+                po.{correct_col} as correct
+            FROM predictions p
+            JOIN prediction_outcomes po ON po.prediction_id = p.id
+            WHERE p.analysis_status = 'completed'
+                AND p.confidence IS NOT NULL
+                AND po.{correct_col} IS NOT NULL
+                AND p.created_at >= :window_start
+        """)
+
+        with get_session() as session:
+            result = session.execute(query, {"window_start": window_start})
+            return [dict(row._mapping) for row in result]
+
+    def _build_lookup_table(
+        self, confidences: list[float], correct_flags: list[bool]
+    ) -> dict[str, float | None]:
+        """Build bin-based calibration lookup table."""
+        bins: dict[str, dict[str, int]] = {}
+        for conf, correct in zip(confidences, correct_flags):
+            bin_idx = min(int(conf * self.n_bins), self.n_bins - 1)
+            label = f"{bin_idx / self.n_bins:.1f}-{(bin_idx + 1) / self.n_bins:.1f}"
+            if label not in bins:
+                bins[label] = {"total": 0, "correct": 0}
+            bins[label]["total"] += 1
+            if correct:
+                bins[label]["correct"] += 1
+
+        return {
+            label: round(data["correct"] / data["total"], 4)
+            if data["total"] >= self.min_per_bin
+            else None
+            for label, data in sorted(bins.items())
+        }
+
+    def _compute_bin_stats(
+        self, confidences: list[float], correct_flags: list[bool]
+    ) -> list[dict]:
+        """Compute detailed per-bin statistics."""
+        bins: dict[int, dict[str, int]] = {}
+        for conf, correct in zip(confidences, correct_flags):
+            bin_idx = min(int(conf * self.n_bins), self.n_bins - 1)
+            if bin_idx not in bins:
+                bins[bin_idx] = {"total": 0, "correct": 0}
+            bins[bin_idx]["total"] += 1
+            if correct:
+                bins[bin_idx]["correct"] += 1
+
+        stats = []
+        for i in range(self.n_bins):
+            data = bins.get(i, {"total": 0, "correct": 0})
+            total = data["total"]
+            n_correct = data["correct"]
+            accuracy = round(n_correct / total, 4) if total > 0 else None
+            stats.append({
+                "bin_label": f"{i / self.n_bins:.1f}-{(i + 1) / self.n_bins:.1f}",
+                "bin_center": round((i + 0.5) / self.n_bins, 2),
+                "n_total": total,
+                "n_correct": n_correct,
+                "accuracy": accuracy,
+            })
+        return stats
+
+    def _store_curve(self, curve: CalibrationCurve) -> None:
+        """Persist calibration curve to database."""
+        with get_session() as session:
+            session.add(curve)
+
+    def _load_latest_curve(self) -> Optional[CalibrationCurve]:
+        """Load the most recently fitted calibration curve.
+
+        Returns None if no curve exists or the latest curve is older
+        than max_age_days (staleness guard).
+        """
+        with get_session() as session:
+            curve = (
+                session.query(CalibrationCurve)
+                .filter(CalibrationCurve.timeframe == self.timeframe)
+                .order_by(CalibrationCurve.fitted_at.desc())
+                .first()
+            )
+            if not curve:
+                return None
+
+            age = datetime.now(timezone.utc) - curve.fitted_at.replace(
+                tzinfo=timezone.utc
+            )
+            if age > timedelta(days=self.max_age_days):
+                logger.warning(
+                    f"Calibration curve is stale ({age.days} days old > "
+                    f"{self.max_age_days} max). Falling back to raw confidence."
+                )
+                return None
+
+            # Detach from session so it can be used after session closes
+            session.expunge(curve)
+            return curve
+
+
+def refit_all(timeframes: list[str] | None = None) -> dict[str, int]:
+    """Refit calibration curves for all (or specified) timeframes.
+
+    Returns:
+        Dict mapping timeframe to n_predictions fitted, or 0 if insufficient data.
+    """
+    if timeframes is None:
+        timeframes = list(VALID_TIMEFRAMES)
+
+    results = {}
+    for tf in timeframes:
+        svc = CalibrationService(timeframe=tf)
+        curve = svc.fit()
+        results[tf] = curve.n_predictions if curve else 0
+
+    return results
+
+
+def main() -> None:
+    """CLI entry point for calibration refit."""
+    import argparse
+    from shit.logging import setup_cli_logging
+
+    parser = argparse.ArgumentParser(
+        prog="python -m shit.market_data.calibration",
+        description="Fit confidence calibration curves from historical outcomes",
+    )
+    parser.add_argument(
+        "--refit",
+        action="store_true",
+        required=True,
+        help="Refit calibration curves",
+    )
+    parser.add_argument(
+        "--timeframe",
+        choices=VALID_TIMEFRAMES,
+        default=None,
+        help="Single timeframe to refit (default: all)",
+    )
+    args = parser.parse_args()
+
+    setup_cli_logging(verbose=True)
+
+    timeframes = [args.timeframe] if args.timeframe else None
+    results = refit_all(timeframes)
+
+    for tf, n in results.items():
+        if n > 0:
+            logger.info(f"  {tf}: fitted from {n} predictions")
+        else:
+            logger.warning(f"  {tf}: insufficient data")
+
+
+if __name__ == "__main__":
+    main()

--- a/shit/market_data/models.py
+++ b/shit/market_data/models.py
@@ -14,10 +14,13 @@ from sqlalchemy import (
     Float,
     BigInteger,
     ForeignKey,
+    Index,
     Integer,
     Boolean,
+    JSON,
     Text,
     UniqueConstraint,
+    func,
 )
 from sqlalchemy.orm import relationship
 
@@ -314,10 +317,34 @@ class TickerRegistry(Base, IDMixin, TimestampMixin):
         return f"<TickerRegistry(symbol='{self.symbol}'{name_part}, status='{self.status}')>"
 
 
-# Indexes for efficient querying
-from sqlalchemy import Index
+class CalibrationCurve(Base):
+    """Fitted calibration curve mapping raw LLM confidence to empirical accuracy.
 
-# Create composite indexes for common queries
+    Each row is an immutable snapshot: one timeframe, one fit.
+    The latest row per timeframe is the active curve.
+    """
+
+    __tablename__ = "calibration_curves"
+
+    id = Column(Integer, primary_key=True)
+    fitted_at = Column(DateTime, nullable=False)
+    timeframe = Column(String(10), nullable=False)
+    window_start = Column(DateTime, nullable=False)
+    window_end = Column(DateTime, nullable=False)
+    n_predictions = Column(Integer, nullable=False)
+    n_bins = Column(Integer, nullable=False, default=10)
+    bin_stats = Column(JSON, nullable=False)
+    lookup_table = Column(JSON, nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    def __repr__(self):
+        return (
+            f"<CalibrationCurve(timeframe='{self.timeframe}', "
+            f"n={self.n_predictions}, fitted={self.fitted_at})>"
+        )
+
+
+# Composite indexes for common queries
 Index("idx_market_price_symbol_date", MarketPrice.symbol, MarketPrice.date, unique=True)
 Index(
     "idx_prediction_outcome_symbol_date",
@@ -332,4 +359,9 @@ Index(
     "idx_price_snapshot_symbol_captured",
     PriceSnapshot.symbol,
     PriceSnapshot.captured_at,
+)
+Index(
+    "idx_calibration_curves_timeframe",
+    CalibrationCurve.timeframe,
+    CalibrationCurve.fitted_at.desc(),
 )

--- a/shit_tests/api/test_calibration_api.py
+++ b/shit_tests/api/test_calibration_api.py
@@ -1,7 +1,6 @@
 """Tests for the calibration API endpoint."""
 
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient

--- a/shit_tests/api/test_calibration_api.py
+++ b/shit_tests/api/test_calibration_api.py
@@ -1,0 +1,86 @@
+"""Tests for the calibration API endpoint."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from shit.market_data.models import CalibrationCurve
+
+client = TestClient(app)
+
+
+class TestCalibrationCurveEndpoint:
+    """Tests for GET /api/calibration/curve."""
+
+    def _make_curve(self):
+        curve = CalibrationCurve(
+            id=1,
+            fitted_at=datetime(2026, 4, 10, 2, 0, 0, tzinfo=timezone.utc),
+            timeframe="t7",
+            window_start=datetime(2025, 10, 10, tzinfo=timezone.utc),
+            window_end=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            n_predictions=500,
+            n_bins=10,
+            bin_stats=[
+                {
+                    "bin_label": "0.7-0.8",
+                    "bin_center": 0.75,
+                    "n_total": 120,
+                    "n_correct": 74,
+                    "accuracy": 0.6167,
+                }
+            ],
+            lookup_table={"0.7-0.8": 0.6167, "0.8-0.9": 0.55},
+        )
+        return curve
+
+    def test_returns_curve(self):
+        """Returns calibration curve data when available."""
+        curve = self._make_curve()
+
+        with patch(
+            "shit.market_data.calibration.CalibrationService._load_latest_curve",
+            return_value=curve,
+        ):
+            resp = client.get("/api/calibration/curve?timeframe=t7")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["timeframe"] == "t7"
+        assert body["n_predictions"] == 500
+        assert len(body["bin_stats"]) == 1
+        assert body["lookup_table"]["0.7-0.8"] == 0.6167
+
+    def test_returns_404_when_no_curve(self):
+        """Returns 404 when no calibration curve is available."""
+        with patch(
+            "shit.market_data.calibration.CalibrationService._load_latest_curve",
+            return_value=None,
+        ):
+            resp = client.get("/api/calibration/curve?timeframe=t7")
+
+        assert resp.status_code == 404
+
+    def test_validates_timeframe_parameter(self):
+        """Rejects invalid timeframe values."""
+        resp = client.get("/api/calibration/curve?timeframe=t99")
+        assert resp.status_code == 422
+
+    def test_default_timeframe_is_t7(self):
+        """Default timeframe is t7 when not specified."""
+        curve = self._make_curve()
+
+        with patch(
+            "shit.market_data.calibration.CalibrationService.__init__",
+            return_value=None,
+        ) as mock_init, patch(
+            "shit.market_data.calibration.CalibrationService._load_latest_curve",
+            return_value=curve,
+        ):
+            resp = client.get("/api/calibration/curve")
+
+        assert resp.status_code == 200
+        mock_init.assert_called_once_with(timeframe="t7")

--- a/shit_tests/notifications/test_alert_engine.py
+++ b/shit_tests/notifications/test_alert_engine.py
@@ -287,3 +287,49 @@ class TestCheckAndDispatch:
         result = check_and_dispatch()
         assert result["predictions_found"] == 1
         assert result["alerts_sent"] == 0
+
+
+class TestCalibratedConfidenceFiltering:
+    """Test that filtering prefers calibrated_confidence when available."""
+
+    def _make_alert(self, confidence=0.8, calibrated=None, assets=None):
+        return {
+            "prediction_id": 1,
+            "text": "Test",
+            "confidence": confidence,
+            "calibrated_confidence": calibrated,
+            "assets": assets or ["AAPL"],
+            "sentiment": "bullish",
+        }
+
+    def _prefs(self, min_confidence=0.7):
+        return {
+            "min_confidence": min_confidence,
+            "assets_of_interest": [],
+            "sentiment_filter": "all",
+        }
+
+    def test_uses_calibrated_when_available(self):
+        """Calibrated confidence takes precedence over raw."""
+        # Raw 0.85 passes 0.7 threshold, but calibrated 0.55 does not
+        alerts = [self._make_alert(confidence=0.85, calibrated=0.55)]
+        result = filter_predictions_by_preferences(alerts, self._prefs(0.7))
+        assert len(result) == 0
+
+    def test_calibrated_passes_threshold(self):
+        """Alert passes when calibrated confidence meets threshold."""
+        alerts = [self._make_alert(confidence=0.85, calibrated=0.75)]
+        result = filter_predictions_by_preferences(alerts, self._prefs(0.7))
+        assert len(result) == 1
+
+    def test_falls_back_to_raw_when_calibrated_is_none(self):
+        """Raw confidence used when calibrated is None (no curve)."""
+        alerts = [self._make_alert(confidence=0.85, calibrated=None)]
+        result = filter_predictions_by_preferences(alerts, self._prefs(0.7))
+        assert len(result) == 1
+
+    def test_falls_back_to_raw_when_calibrated_missing(self):
+        """Raw confidence used when calibrated_confidence key is absent."""
+        alert = {"prediction_id": 1, "confidence": 0.85, "assets": ["AAPL"], "sentiment": "bullish"}
+        result = filter_predictions_by_preferences([alert], self._prefs(0.7))
+        assert len(result) == 1

--- a/shit_tests/notifications/test_telegram_sender.py
+++ b/shit_tests/notifications/test_telegram_sender.py
@@ -222,6 +222,37 @@ class TestFormatAlertMarkdownV2:
         assert "BTC\\-USD" in message
 
 
+class TestCalibratedConfidenceDisplay:
+    """Test calibrated confidence rendering in Telegram alerts."""
+
+    def _make_alert(self, confidence=0.85, calibrated=None):
+        return {
+            "sentiment": "bullish",
+            "confidence": confidence,
+            "calibrated_confidence": calibrated,
+            "assets": ["TSLA"],
+            "text": "Test post.",
+            "thesis": "Test thesis.",
+        }
+
+    def test_shows_both_when_calibrated_available(self):
+        """Shows 'raw / calibrated' format when calibrated confidence exists."""
+        message = format_telegram_alert(self._make_alert(confidence=0.85, calibrated=0.62))
+        assert "85% raw" in message or "85\\% raw" in message
+        assert "62% calibrated" in message or "62\\% calibrated" in message
+
+    def test_shows_only_raw_when_no_calibration(self):
+        """Shows only raw confidence when calibrated is None."""
+        message = format_telegram_alert(self._make_alert(confidence=0.85, calibrated=None))
+        assert "85%" in message
+        assert "calibrated" not in message
+
+    def test_shows_na_when_no_confidence(self):
+        """Shows N/A when confidence is 0 or None."""
+        message = format_telegram_alert(self._make_alert(confidence=None))
+        assert "N/A" in message
+
+
 class TestEscapeMarkdown:
     """Test Markdown escaping."""
 

--- a/shit_tests/shit/market_data/test_calibration.py
+++ b/shit_tests/shit/market_data/test_calibration.py
@@ -1,0 +1,339 @@
+"""Tests for confidence calibration service."""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+from shit.market_data.calibration import CalibrationService, VALID_TIMEFRAMES, refit_all
+from shit.market_data.models import CalibrationCurve
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service():
+    """Default calibration service with T+7 timeframe."""
+    return CalibrationService(timeframe="t7", min_samples=10, min_per_bin=3)
+
+
+@pytest.fixture
+def overconfident_data():
+    """500 predictions simulating an overconfident LLM.
+
+    Raw confidence is uniformly 0.3-0.95. Actual accuracy = raw * 0.7,
+    so 0.9 confidence -> ~63% correct, not 90%.
+    """
+    import random
+
+    random.seed(42)
+    data = []
+    for _ in range(500):
+        conf = random.uniform(0.3, 0.95)
+        correct = random.random() < (conf * 0.7)
+        data.append({"confidence": conf, "correct": correct})
+    return data
+
+
+@pytest.fixture
+def uniform_data():
+    """200 predictions spread uniformly across 10 bins, 50% accuracy each."""
+    data = []
+    for bin_idx in range(10):
+        conf_center = bin_idx / 10 + 0.05
+        for j in range(20):
+            data.append({"confidence": conf_center, "correct": j % 2 == 0})
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_valid_timeframes(self):
+        for tf in VALID_TIMEFRAMES:
+            svc = CalibrationService(timeframe=tf)
+            assert svc.timeframe == tf
+
+    def test_invalid_timeframe_raises(self):
+        with pytest.raises(ValueError, match="Invalid timeframe"):
+            CalibrationService(timeframe="t99")
+
+    def test_defaults(self):
+        svc = CalibrationService()
+        assert svc.timeframe == "t7"
+        assert svc.window_days == 180
+        assert svc.min_samples == 100
+        assert svc.min_per_bin == 5
+        assert svc.n_bins == 10
+        assert svc.max_age_days == 30
+
+
+# ---------------------------------------------------------------------------
+# Lookup Table
+# ---------------------------------------------------------------------------
+
+
+class TestLookupTable:
+    def test_uniform_accuracy(self, service, uniform_data):
+        confidences = [d["confidence"] for d in uniform_data]
+        correct_flags = [d["correct"] for d in uniform_data]
+        lookup = service._build_lookup_table(confidences, correct_flags)
+
+        # Each bin has 20 samples (200 / 10), alternating -> 50% accuracy
+        for label, accuracy in lookup.items():
+            assert accuracy == 0.5
+
+    def test_sparse_bins_return_none(self):
+        svc = CalibrationService(min_per_bin=5)
+        confidences = [0.85, 0.86]  # Only 2 samples in the 0.8-0.9 bin
+        correct_flags = [True, False]
+        lookup = svc._build_lookup_table(confidences, correct_flags)
+
+        assert lookup["0.8-0.9"] is None  # Below min_per_bin
+
+    def test_empty_data(self, service):
+        lookup = service._build_lookup_table([], [])
+        assert lookup == {}
+
+    def test_overconfident_model(self, service, overconfident_data):
+        confidences = [d["confidence"] for d in overconfident_data]
+        correct_flags = [d["correct"] for d in overconfident_data]
+        lookup = service._build_lookup_table(confidences, correct_flags)
+
+        # High-confidence bin (0.8-0.9) should be well below 0.85 midpoint
+        high_bin = lookup.get("0.8-0.9")
+        assert high_bin is not None
+        assert high_bin < 0.80  # Overconfident: actual < raw
+
+    def test_single_bin(self, service):
+        """All predictions in one bin."""
+        confidences = [0.75, 0.76, 0.77, 0.78, 0.79]
+        correct_flags = [True, True, False, True, False]
+        lookup = service._build_lookup_table(confidences, correct_flags)
+
+        assert "0.7-0.8" in lookup
+        assert lookup["0.7-0.8"] == 0.6  # 3/5
+
+    def test_boundary_confidence_1_0(self, service):
+        """Confidence of exactly 1.0 goes into the last bin."""
+        confidences = [1.0, 1.0, 1.0, 1.0, 1.0]
+        correct_flags = [True, True, True, True, False]
+        lookup = service._build_lookup_table(confidences, correct_flags)
+
+        assert "0.9-1.0" in lookup
+        assert lookup["0.9-1.0"] == 0.8  # 4/5
+
+    def test_boundary_confidence_0_0(self, service):
+        """Confidence of exactly 0.0 goes into the first bin."""
+        confidences = [0.0, 0.0, 0.0]
+        correct_flags = [False, False, True]
+        lookup = service._build_lookup_table(confidences, correct_flags)
+
+        assert "0.0-0.1" in lookup
+        assert lookup["0.0-0.1"] == 0.3333  # 1/3 rounded to 4 decimal places
+
+
+# ---------------------------------------------------------------------------
+# Bin Stats
+# ---------------------------------------------------------------------------
+
+
+class TestBinStats:
+    def test_all_bins_present(self, service, uniform_data):
+        confidences = [d["confidence"] for d in uniform_data]
+        correct_flags = [d["correct"] for d in uniform_data]
+        stats = service._compute_bin_stats(confidences, correct_flags)
+
+        assert len(stats) == 10
+        for i, s in enumerate(stats):
+            assert s["bin_label"] == f"{i / 10:.1f}-{(i + 1) / 10:.1f}"
+            assert "bin_center" in s
+            assert "n_total" in s
+            assert "n_correct" in s
+            assert "accuracy" in s
+
+    def test_empty_bins_have_zero_total(self, service):
+        confidences = [0.55]  # Only bin 5
+        correct_flags = [True]
+        stats = service._compute_bin_stats(confidences, correct_flags)
+
+        assert stats[0]["n_total"] == 0
+        assert stats[0]["accuracy"] is None
+        assert stats[5]["n_total"] == 1
+        assert stats[5]["accuracy"] == 1.0
+
+    def test_bin_centers(self, service):
+        stats = service._compute_bin_stats([], [])
+        assert stats[0]["bin_center"] == 0.05
+        assert stats[5]["bin_center"] == 0.55
+        assert stats[9]["bin_center"] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# Calibrate (lookup application)
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrate:
+    def test_returns_none_when_no_curve(self, service):
+        with patch.object(service, "_load_latest_curve", return_value=None):
+            result = service.calibrate(0.8)
+            assert result is None
+
+    def test_returns_accuracy_for_bin(self, service):
+        mock_curve = MagicMock()
+        mock_curve.lookup_table = {"0.7-0.8": 0.62, "0.8-0.9": 0.55}
+
+        with patch.object(service, "_load_latest_curve", return_value=mock_curve):
+            assert service.calibrate(0.75) == 0.62
+            assert service.calibrate(0.85) == 0.55
+
+    def test_returns_none_for_sparse_bin(self, service):
+        mock_curve = MagicMock()
+        mock_curve.lookup_table = {"0.7-0.8": 0.62, "0.8-0.9": None}
+
+        with patch.object(service, "_load_latest_curve", return_value=mock_curve):
+            assert service.calibrate(0.85) is None
+
+    def test_boundary_1_0_uses_last_bin(self, service):
+        mock_curve = MagicMock()
+        mock_curve.lookup_table = {"0.9-1.0": 0.71}
+
+        with patch.object(service, "_load_latest_curve", return_value=mock_curve):
+            assert service.calibrate(1.0) == 0.71
+
+    def test_boundary_0_0_uses_first_bin(self, service):
+        mock_curve = MagicMock()
+        mock_curve.lookup_table = {"0.0-0.1": 0.12}
+
+        with patch.object(service, "_load_latest_curve", return_value=mock_curve):
+            assert service.calibrate(0.0) == 0.12
+
+
+# ---------------------------------------------------------------------------
+# Fit (end-to-end with mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestFit:
+    def test_insufficient_data_returns_none(self, service):
+        with patch.object(service, "_query_calibration_data", return_value=[]):
+            result = service.fit()
+            assert result is None
+
+    def test_fit_stores_curve(self, service, overconfident_data):
+        with patch.object(service, "_query_calibration_data", return_value=overconfident_data):
+            with patch.object(service, "_store_curve") as mock_store:
+                curve = service.fit()
+
+                assert curve is not None
+                assert curve.timeframe == "t7"
+                assert curve.n_predictions == 500
+                assert curve.n_bins == 10
+                assert isinstance(curve.lookup_table, dict)
+                assert isinstance(curve.bin_stats, list)
+                assert len(curve.bin_stats) == 10
+                mock_store.assert_called_once_with(curve)
+
+
+# ---------------------------------------------------------------------------
+# Staleness Guard
+# ---------------------------------------------------------------------------
+
+
+class TestStaleness:
+    def test_fresh_curve_returned(self, service):
+        curve = CalibrationCurve(
+            fitted_at=datetime.now(timezone.utc) - timedelta(days=5),
+            timeframe="t7",
+            window_start=datetime.now(timezone.utc) - timedelta(days=185),
+            window_end=datetime.now(timezone.utc) - timedelta(days=5),
+            n_predictions=200,
+            n_bins=10,
+            bin_stats=[],
+            lookup_table={"0.7-0.8": 0.62},
+        )
+
+        mock_session = MagicMock()
+        mock_query = mock_session.query.return_value.filter.return_value.order_by.return_value
+        mock_query.first.return_value = curve
+
+        with patch("shit.market_data.calibration.get_session") as mock_get:
+            mock_get.return_value.__enter__ = MagicMock(return_value=mock_session)
+            mock_get.return_value.__exit__ = MagicMock(return_value=False)
+            result = service._load_latest_curve()
+
+        assert result is not None
+
+    def test_stale_curve_returns_none(self):
+        svc = CalibrationService(max_age_days=7)
+        curve = CalibrationCurve(
+            fitted_at=datetime.now(timezone.utc) - timedelta(days=10),
+            timeframe="t7",
+            window_start=datetime.now(timezone.utc) - timedelta(days=190),
+            window_end=datetime.now(timezone.utc) - timedelta(days=10),
+            n_predictions=200,
+            n_bins=10,
+            bin_stats=[],
+            lookup_table={"0.7-0.8": 0.62},
+        )
+
+        mock_session = MagicMock()
+        mock_query = mock_session.query.return_value.filter.return_value.order_by.return_value
+        mock_query.first.return_value = curve
+
+        with patch("shit.market_data.calibration.get_session") as mock_get:
+            mock_get.return_value.__enter__ = MagicMock(return_value=mock_session)
+            mock_get.return_value.__exit__ = MagicMock(return_value=False)
+            result = svc._load_latest_curve()
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Refit All
+# ---------------------------------------------------------------------------
+
+
+class TestRefitAll:
+    def test_refits_all_timeframes(self):
+        with patch("shit.market_data.calibration.CalibrationService") as MockSvc:
+            mock_instance = MagicMock()
+            mock_curve = MagicMock()
+            mock_curve.n_predictions = 300
+            mock_instance.fit.return_value = mock_curve
+            MockSvc.return_value = mock_instance
+
+            results = refit_all()
+
+            assert len(results) == 4
+            for tf in VALID_TIMEFRAMES:
+                assert results[tf] == 300
+
+    def test_refits_single_timeframe(self):
+        with patch("shit.market_data.calibration.CalibrationService") as MockSvc:
+            mock_instance = MagicMock()
+            mock_curve = MagicMock()
+            mock_curve.n_predictions = 150
+            mock_instance.fit.return_value = mock_curve
+            MockSvc.return_value = mock_instance
+
+            results = refit_all(timeframes=["t7"])
+
+            assert results == {"t7": 150}
+            MockSvc.assert_called_once_with(timeframe="t7")
+
+    def test_insufficient_data_returns_zero(self):
+        with patch("shit.market_data.calibration.CalibrationService") as MockSvc:
+            mock_instance = MagicMock()
+            mock_instance.fit.return_value = None
+            MockSvc.return_value = mock_instance
+
+            results = refit_all(timeframes=["t7"])
+
+            assert results == {"t7": 0}

--- a/shit_tests/shitvault/test_prediction_operations.py
+++ b/shit_tests/shitvault/test_prediction_operations.py
@@ -446,3 +446,85 @@ class TestPredictionOperationsIntegration:
         assert hasattr(pred_ops, 'handle_no_text_prediction')
         assert hasattr(pred_ops, 'check_prediction_exists')
 
+
+class TestCalibrationIntegration:
+    """Tests for calibrated_confidence integration in prediction storage."""
+
+    @pytest.fixture(autouse=True)
+    def _register_models(self):
+        """Ensure Signal model is registered for Prediction relationship."""
+        from shitvault.signal_models import Signal  # noqa: F401
+
+    @pytest.fixture
+    def prediction_ops(self):
+        mock_ops = MagicMock(spec=DatabaseOperations)
+        mock_ops.session = AsyncMock()
+        mock_ops.session.add = MagicMock()
+        mock_ops.session.commit = AsyncMock()
+        mock_ops.session.refresh = AsyncMock()
+        return PredictionOperations(mock_ops)
+
+    @pytest.mark.asyncio
+    async def test_stores_calibrated_confidence(self, prediction_ops):
+        """When calibration curve exists, stores calibrated value."""
+        captured = None
+
+        def capture(pred):
+            nonlocal captured
+            captured = pred
+            pred.id = 1
+
+        prediction_ops.db_ops.session.add.side_effect = capture
+
+        with patch.object(
+            PredictionOperations,
+            "_calibrate",
+            return_value=0.62,
+        ):
+            await prediction_ops.store_analysis(
+                content_id="test_123",
+                analysis_data={"confidence": 0.85, "assets": ["TSLA"]},
+            )
+
+        assert captured.confidence == 0.85
+        assert captured.calibrated_confidence == 0.62
+
+    @pytest.mark.asyncio
+    async def test_stores_none_when_no_curve(self, prediction_ops):
+        """When no calibration curve exists, calibrated_confidence is None."""
+        captured = None
+
+        def capture(pred):
+            nonlocal captured
+            captured = pred
+            pred.id = 1
+
+        prediction_ops.db_ops.session.add.side_effect = capture
+
+        with patch.object(
+            PredictionOperations,
+            "_calibrate",
+            return_value=None,
+        ):
+            await prediction_ops.store_analysis(
+                content_id="test_123",
+                analysis_data={"confidence": 0.85, "assets": ["TSLA"]},
+            )
+
+        assert captured.confidence == 0.85
+        assert captured.calibrated_confidence is None
+
+    def test_calibrate_returns_none_on_exception(self):
+        """_calibrate catches all exceptions and returns None."""
+        with patch(
+            "shit.market_data.calibration.CalibrationService",
+            side_effect=Exception("DB error"),
+        ):
+            result = PredictionOperations._calibrate(0.85)
+            assert result is None
+
+    def test_calibrate_returns_none_for_none_input(self):
+        """_calibrate short-circuits on None confidence."""
+        result = PredictionOperations._calibrate(None)
+        assert result is None
+

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -533,6 +533,15 @@ class ShitpostAnalyzer:
                             if post_ts
                             else None
                         )
+
+                        # Include calibrated confidence in event payload
+                        calibrated = None
+                        try:
+                            from shit.market_data.calibration import CalibrationService
+                            calibrated = CalibrationService(timeframe="t7").calibrate(confidence)
+                        except Exception:
+                            pass
+
                         emit_event(
                             event_type=EventType.PREDICTION_CREATED,
                             payload={
@@ -541,6 +550,7 @@ class ShitpostAnalyzer:
                                 "signal_id": None,
                                 "assets": assets,
                                 "confidence": confidence,
+                                "calibrated_confidence": calibrated,
                                 "analysis_status": analysis_status,
                                 "post_published_at": post_published,
                             },

--- a/shitvault/prediction_operations.py
+++ b/shitvault/prediction_operations.py
@@ -27,6 +27,17 @@ class PredictionOperations:
     def __init__(self, db_ops: DatabaseOperations):
         self.db_ops = db_ops
         self.bypass_service = BypassService()
+
+    @staticmethod
+    def _calibrate(raw_confidence: Optional[float]) -> Optional[float]:
+        """Apply calibration curve to raw confidence. Returns None if unavailable."""
+        if raw_confidence is None:
+            return None
+        try:
+            from shit.market_data.calibration import CalibrationService
+            return CalibrationService(timeframe="t7").calibrate(raw_confidence)
+        except Exception:
+            return None
     
     async def store_analysis(self, content_id: str, analysis_data: Dict[str, Any], content_data: Dict[str, Any] = None, *, use_signal: bool = False) -> Optional[str]:
         """Store LLM analysis results in the database with enhanced content data.
@@ -71,6 +82,7 @@ class PredictionOperations:
                 assets=analysis_data.get('assets', []),
                 market_impact=analysis_data.get('market_impact', {}),
                 confidence=analysis_data.get('confidence', 0.0),
+                calibrated_confidence=self._calibrate(analysis_data.get('confidence')),
                 thesis=analysis_data.get('thesis', ''),
 
                 # Set analysis status for successful analyses

--- a/shitvault/shitpost_models.py
+++ b/shitvault/shitpost_models.py
@@ -140,6 +140,9 @@ class Prediction(Base, IDMixin, TimestampMixin):
     confidence = Column(
         Float, nullable=True
     )  # Confidence score 0.0-1.0 (nullable for bypassed posts)
+    calibrated_confidence = Column(
+        Float, nullable=True
+    )  # Empirically calibrated confidence from calibration curve
     thesis = Column(Text, nullable=True)  # Investment thesis
 
     # Analysis metadata


### PR DESCRIPTION
## Summary

- **CalibrationService** (`shit/market_data/calibration.py`) — bin-based lookup table mapping raw LLM confidence to historical accuracy rates. 10 bins, rolling 6-month window, staleness guard (30-day max age), CLI refit.
- **CalibrationCurve model** — JSONB storage for bin stats and lookup table, indexed by (timeframe, fitted_at). No sklearn, no pickle, no scope — simplified per challenge round.
- **Prediction integration** — `calibrated_confidence` stored alongside raw confidence at prediction time. Included in event payload for downstream consumers.
- **Alert integration** — Telegram shows "85% raw / 62% calibrated" when available. Alert filtering prefers calibrated over raw with graceful fallback.
- **API + Frontend** — `GET /api/calibration/curve?timeframe=t7` endpoint. SVG reliability diagram component. Calibrated badge in PredictionPanel.

### Challenge Round Decisions
1. Lookup table only (no sklearn) — zero new dependencies
2. Global scope only (no per-provider) — add when ensemble feature lands
3. CLI in package (`python -m shit.market_data.calibration --refit`)
4. Table simplified — no `scope`, no `model_bytes` BYTEA
5. Staleness guard — `max_age_days=30` on curve loading

## Test plan
- [x] 25 unit tests for CalibrationService (lookup table, bin stats, calibrate, fit, staleness, refit)
- [x] 4 integration tests for prediction storage with calibration
- [x] 7 alert tests (filtering with calibrated confidence, Telegram display)
- [x] 4 API tests (endpoint, 404, validation, default timeframe)
- [x] Full suite: 1909 passed
- [x] Lint: all new files pass ruff
- [x] Frontend builds clean
- [ ] Production: `ALTER TABLE predictions ADD COLUMN calibrated_confidence FLOAT`
- [ ] Production: `CREATE TABLE calibration_curves` (see migration SQL in plan doc)
- [ ] Production: `python -m shit.market_data.calibration --refit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)