### PR TITLE
feat: /watchlist command for Telegram bot ticker filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Watchlist Filtering** — Telegram `/watchlist` commands for subscribers to control which tickers generate alerts
+  - Commands: `/watchlist add TSLA NVDA`, `/watchlist remove NVDA`, `/watchlist show`, `/watchlist clear`
+  - Validates tickers against `ticker_registry` (active symbols only), applies alias remapping (FB→META), rejects delisted tickers
+  - Company names displayed via ORM lookup on `TickerRegistry`
+  - 50-ticker cap, case-insensitive input, backward compatible (empty watchlist = all alerts)
+  - Updated `/help` and `/start` welcome messages
+  - 23 new tests in `test_watchlist.py`
 - **Confidence Calibration** — Maps raw LLM confidence to empirical accuracy using historical prediction outcomes
   - `CalibrationService` in `shit/market_data/calibration.py` — bin-based lookup table (10 bins), rolling 6-month window, staleness guard (30-day max age)
   - `CalibrationCurve` model in `shit/market_data/models.py` — JSONB bin_stats and lookup_table, indexed by (timeframe, fitted_at)

--- a/documentation/planning/product-brainstorm_2026-04-09/03_WATCHLIST_FILTERING.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/03_WATCHLIST_FILTERING.md
@@ -2,8 +2,9 @@
 
 **Feature**: Users specify tickers they care about via Telegram bot commands. Only get alerts when the LLM identifies their watchlist tickers.
 
-**Status**: IN PROGRESS
+**Status**: COMPLETE
 **Started**: 2026-04-11
+**Completed**: 2026-04-11
 
 ### Challenge Resolutions (2026-04-11)
 1. **Separation**: `_validate_watchlist_tickers()` and `_get_ticker_names()` stay in `telegram_bot.py` — they query `ticker_registry` (not notification domain), so putting them in `notifications/db.py` would muddle scope.

--- a/documentation/planning/product-brainstorm_2026-04-09/03_WATCHLIST_FILTERING.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/03_WATCHLIST_FILTERING.md
@@ -2,7 +2,14 @@
 
 **Feature**: Users specify tickers they care about via Telegram bot commands. Only get alerts when the LLM identifies their watchlist tickers.
 
-**Status**: Planning
+**Status**: IN PROGRESS
+**Started**: 2026-04-11
+
+### Challenge Resolutions (2026-04-11)
+1. **Separation**: `_validate_watchlist_tickers()` and `_get_ticker_names()` stay in `telegram_bot.py` — they query `ticker_registry` (not notification domain), so putting them in `notifications/db.py` would muddle scope.
+2. **ORM consistency**: `_get_ticker_names()` uses `TickerRegistry` ORM model instead of raw SQL, matching `_validate_watchlist_tickers()`.
+3. **Test scope**: Dropped tests 14-16 (filter_predictions_by_preferences smoke tests) — the filtering logic is unchanged and already covered in `test_alert_engine.py`.
+4. **No implicit add**: `/watchlist TSLA` (no action keyword) returns a usage hint instead of silently adding. Explicit is better than implicit.
 **Date**: 2026-04-09
 **Estimated Effort**: Small (1 session)
 
@@ -350,8 +357,7 @@ def handle_watchlist_command(chat_id: str, args: str = "") -> str:
     elif action == "clear":
         return _handle_watchlist_clear(chat_id, prefs)
     else:
-        # If user typed "/watchlist TSLA", treat as "add TSLA"
-        return _handle_watchlist_add(chat_id, prefs, current_watchlist, parts)
+        return "Unknown action\\. Use `/watchlist add TSLA`, `/watchlist remove TSLA`, or `/watchlist show`\\."
 ```
 
 ### Step 2: Add Helper Functions
@@ -391,26 +397,20 @@ def _get_ticker_names(symbols: list[str]) -> dict[str, str]:
     """Look up company names for a list of symbols."""
     if not symbols:
         return {}
-    from notifications.db import _execute_read, _row_to_dict
-    from sqlalchemy import text
     from shit.db.sync_session import get_session
+    from shit.market_data.models import TickerRegistry
 
     try:
         with get_session() as session:
-            result = session.execute(
-                text("""
-                    SELECT symbol, company_name, sector
-                    FROM ticker_registry
-                    WHERE symbol = ANY(:symbols)
-                """),
-                {"symbols": symbols},
-            )
-            rows = result.fetchall()
-            columns = result.keys()
+            rows = session.query(
+                TickerRegistry.symbol,
+                TickerRegistry.company_name,
+                TickerRegistry.sector,
+            ).filter(TickerRegistry.symbol.in_(symbols)).all()
             return {
-                row[0]: f"{row[1]}" + (f" ({row[2]})" if row[2] else "")
+                row.symbol: f"{row.company_name}" + (f" ({row.sector})" if row.sector else "")
                 for row in rows
-                if row[1]
+                if row.company_name
             }
     except Exception:
         return {}
@@ -476,13 +476,9 @@ Add `_validate_watchlist_tickers()` as shown in the Ticker Validation section ab
 
 13. **`test_watchlist_case_insensitive`**: Add "tsla", verify "TSLA" is stored.
 
-14. **`test_filter_with_watchlist`**: Call `filter_predictions_by_preferences` with `assets_of_interest=["TSLA"]` and prediction with `assets=["AAPL", "TSLA"]`. Verify match.
+14. **`test_process_update_watchlist_command`**: Send `/watchlist add TSLA` through `process_update()`, verify correct handler is called.
 
-15. **`test_filter_with_watchlist_no_match`**: Same but prediction has `assets=["AAPL", "GOOGL"]`. Verify no match.
-
-16. **`test_filter_empty_watchlist`**: `assets_of_interest=[]`, verify all predictions match.
-
-17. **`test_process_update_watchlist_command`**: Send `/watchlist add TSLA` through `process_update()`, verify correct handler is called.
+15. **`test_unknown_action_shows_usage`**: Send `/watchlist TSLA` (no action keyword), verify usage hint response.
 
 ### Existing Test Compatibility
 

--- a/notifications/telegram_bot.py
+++ b/notifications/telegram_bot.py
@@ -1,8 +1,8 @@
 """
 Telegram Bot command handlers for Shitpost Alpha.
 
-Handles /start, /stop, /status, /settings, /stats, /latest, /help commands
-and routes incoming webhook updates to the appropriate handler.
+Handles /start, /stop, /status, /settings, /watchlist, /stats, /latest, /help
+commands and routes incoming webhook updates to the appropriate handler.
 """
 
 import json
@@ -67,6 +67,7 @@ You're now subscribed to receive real\\-time prediction alerts\\.
 \u2022 Sentiment: All
 
 *Commands:*
+/watchlist \\- Set which tickers you want alerts for
 /settings \\- View/change your preferences
 /status \\- Check subscription status
 /stats \\- View prediction accuracy
@@ -352,13 +353,18 @@ def handle_help_command() -> str:
 /stop \\- Unsubscribe from alerts
 /status \\- Check your subscription status
 /settings \\- View/change alert preferences
+/watchlist \\- Manage your ticker watchlist
 /stats \\- View prediction accuracy stats
 /latest \\- Show recent predictions
 /help \\- Show this help message
 
+*Watchlist Examples:*
+`/watchlist add TSLA NVDA`
+`/watchlist remove NVDA`
+`/watchlist clear`
+
 *Settings Examples:*
 `/settings confidence 80`
-`/settings assets AAPL TSLA`
 `/settings sentiment bullish`
 
 *About:*
@@ -366,6 +372,304 @@ This bot sends alerts when our LLM detects high\\-confidence trading signals fro
 
 \u26a0\ufe0f _Not financial advice\\. For entertainment only\\._
 """
+
+
+# ============================================================
+# Watchlist Command Handlers
+# ============================================================
+
+MAX_WATCHLIST_SIZE = 50
+
+
+def _escape_md(text: str) -> str:
+    """Escape special characters for Telegram MarkdownV2."""
+    return "".join(f"\\{c}" if c in r"_*[]()~`>#+-=|{}.!" else c for c in text)
+
+
+def _normalize_ticker(symbol: str) -> tuple:
+    """Normalize a ticker symbol via alias remapping.
+
+    Returns:
+        (normalized_symbol, warning) — warning is set if delisted.
+    """
+    from shit.market_data.ticker_validator import TickerValidator
+
+    symbol = symbol.strip().upper()
+    if symbol in TickerValidator.ALIASES:
+        replacement = TickerValidator.ALIASES[symbol]
+        if replacement is None:
+            return symbol, f"{symbol} is no longer publicly traded"
+        return replacement, None
+    return symbol, None
+
+
+def _validate_watchlist_tickers(symbols: list) -> tuple:
+    """Validate tickers against the ticker_registry.
+
+    Returns:
+        (valid_symbols, invalid_symbols)
+    """
+    from shit.db.sync_session import get_session
+    from shit.market_data.models import TickerRegistry
+
+    if not symbols:
+        return [], []
+
+    try:
+        with get_session() as session:
+            known = (
+                session.query(TickerRegistry.symbol)
+                .filter(
+                    TickerRegistry.symbol.in_(symbols),
+                    TickerRegistry.status == "active",
+                )
+                .all()
+            )
+            known_set = {r.symbol for r in known}
+
+        valid = [s for s in symbols if s in known_set]
+        invalid = [s for s in symbols if s not in known_set]
+        return valid, invalid
+    except Exception:
+        # If DB is unavailable, accept all tickers (fail-open)
+        return symbols, []
+
+
+def _get_ticker_names(symbols: list) -> dict:
+    """Look up company names for a list of symbols from ticker_registry."""
+    if not symbols:
+        return {}
+    from shit.db.sync_session import get_session
+    from shit.market_data.models import TickerRegistry
+
+    try:
+        with get_session() as session:
+            rows = (
+                session.query(
+                    TickerRegistry.symbol,
+                    TickerRegistry.company_name,
+                    TickerRegistry.sector,
+                )
+                .filter(TickerRegistry.symbol.in_(symbols))
+                .all()
+            )
+            return {
+                row.symbol: (
+                    f"{row.company_name}" + (f" ({row.sector})" if row.sector else "")
+                )
+                for row in rows
+                if row.company_name
+            }
+    except Exception:
+        return {}
+
+
+def _format_watchlist_display(watchlist: list) -> str:
+    """Format watchlist for display with company names."""
+    if not watchlist:
+        return (
+            "\U0001f4cb *Your Watchlist*\n\n"
+            "Your watchlist is empty \\- you're receiving alerts for ALL tickers\\.\n\n"
+            "To focus on specific tickers, use:\n"
+            "`/watchlist add TSLA NVDA AAPL`"
+        )
+
+    names = _get_ticker_names(watchlist)
+    lines = ["\U0001f4cb *Your Watchlist*\n"]
+    lines.append(f"You're tracking {len(watchlist)} tickers:")
+    for symbol in sorted(watchlist):
+        name = names.get(symbol, "")
+        if name:
+            lines.append(f"\u2022 {symbol} \\- {_escape_md(name)}")
+        else:
+            lines.append(f"\u2022 {symbol}")
+    lines.append(
+        "\nYou'll only receive alerts when these tickers appear in a prediction\\."
+    )
+    lines.append(
+        "\n_Use /watchlist add TICKER or /watchlist remove TICKER to modify\\._"
+    )
+    return "\n".join(lines)
+
+
+def _format_watchlist_summary(watchlist: list) -> str:
+    """Format a compact watchlist summary for add/remove responses."""
+    if not watchlist:
+        return ""
+    names = _get_ticker_names(watchlist)
+    lines = [f"\nYour watchlist \\({len(watchlist)} tickers\\):"]
+    for symbol in sorted(watchlist):
+        name = names.get(symbol, "")
+        if name:
+            lines.append(f"\u2022 {symbol} \\- {_escape_md(name)}")
+        else:
+            lines.append(f"\u2022 {symbol}")
+    return "\n".join(lines)
+
+
+def _handle_watchlist_add(
+    chat_id: str,
+    prefs: Dict[str, Any],
+    current_watchlist: list,
+    tickers_raw: list,
+) -> str:
+    """Handle /watchlist add <tickers>."""
+    if not tickers_raw:
+        return "Usage: `/watchlist add TSLA NVDA AAPL`"
+
+    # Normalize via alias remapping and check for delisted
+    normalized = []
+    delisted_warnings = []
+    for t in tickers_raw:
+        symbol, warning = _normalize_ticker(t)
+        if warning:
+            delisted_warnings.append(warning)
+        else:
+            normalized.append(symbol)
+
+    # Deduplicate while preserving order
+    seen = set()
+    deduped = []
+    for s in normalized:
+        if s not in seen:
+            seen.add(s)
+            deduped.append(s)
+    normalized = deduped
+
+    # Check max size
+    new_count = len(set(current_watchlist) | set(normalized))
+    if new_count > MAX_WATCHLIST_SIZE:
+        return (
+            f"Watchlist is limited to {MAX_WATCHLIST_SIZE} tickers\\. "
+            f"You have {len(current_watchlist)}\\."
+        )
+
+    # Validate against registry
+    valid, invalid = _validate_watchlist_tickers(normalized)
+
+    # Separate already-present from truly new
+    already_present = [s for s in valid if s in current_watchlist]
+    new_additions = [s for s in valid if s not in current_watchlist]
+
+    # Update watchlist if there are new additions
+    if new_additions:
+        updated = current_watchlist + new_additions
+        prefs["assets_of_interest"] = updated
+        update_subscription(chat_id, alert_preferences=prefs)
+        current_watchlist = updated
+
+    # Build response
+    lines = []
+    if new_additions:
+        lines.append(f"\u2705 Added to watchlist: {', '.join(new_additions)}")
+    if already_present:
+        lines.append(f"\u2139\ufe0f Already on watchlist: {', '.join(already_present)}")
+    if invalid:
+        lines.append(
+            f"\u26a0\ufe0f Unknown tickers \\(not in our registry\\): "
+            f"{', '.join(invalid)}"
+        )
+    if delisted_warnings:
+        for w in delisted_warnings:
+            lines.append(f"\u26a0\ufe0f {_escape_md(w)}")
+
+    if not lines:
+        lines.append("No valid tickers to add\\.")
+
+    # Append watchlist summary
+    summary = _format_watchlist_summary(current_watchlist)
+    if summary:
+        lines.append(summary)
+
+    return "\n".join(lines)
+
+
+def _handle_watchlist_remove(
+    chat_id: str,
+    prefs: Dict[str, Any],
+    current_watchlist: list,
+    tickers_raw: list,
+) -> str:
+    """Handle /watchlist remove <tickers>."""
+    if not tickers_raw:
+        return "Usage: `/watchlist remove TSLA NVDA`"
+
+    symbols = [s.strip().upper() for s in tickers_raw if s.strip()]
+
+    present = [s for s in symbols if s in current_watchlist]
+    absent = [s for s in symbols if s not in current_watchlist]
+
+    lines = []
+    if present:
+        updated = [s for s in current_watchlist if s not in present]
+        prefs["assets_of_interest"] = updated
+        update_subscription(chat_id, alert_preferences=prefs)
+        lines.append(f"\u2705 Removed from watchlist: {', '.join(present)}")
+        current_watchlist = updated
+    if absent:
+        lines.append(f"\u2139\ufe0f Not on your watchlist: {', '.join(absent)}")
+
+    if current_watchlist:
+        summary = _format_watchlist_summary(current_watchlist)
+        if summary:
+            lines.append(summary)
+    else:
+        lines.append(
+            "\nYour watchlist is now empty \\- you'll receive alerts for ALL tickers\\."
+        )
+
+    return "\n".join(lines)
+
+
+def _handle_watchlist_clear(chat_id: str, prefs: Dict[str, Any]) -> str:
+    """Handle /watchlist clear."""
+    prefs["assets_of_interest"] = []
+    update_subscription(chat_id, alert_preferences=prefs)
+    return "\u2705 Watchlist cleared\\. You'll now receive alerts for ALL tickers\\."
+
+
+def handle_watchlist_command(chat_id: str, args: str = "") -> str:
+    """Handle /watchlist command — view/modify ticker watchlist.
+
+    Supports:
+        /watchlist              — Show current watchlist
+        /watchlist show         — Same as above
+        /watchlist add TSLA     — Add tickers
+        /watchlist remove TSLA  — Remove tickers
+        /watchlist clear        — Clear watchlist (receive all alerts)
+    """
+    sub = get_subscription(chat_id)
+    if not sub:
+        return "\u2753 You're not subscribed. Send /start first."
+
+    prefs = sub.get("alert_preferences", {})
+    if isinstance(prefs, str):
+        try:
+            prefs = json.loads(prefs)
+        except json.JSONDecodeError:
+            prefs = {}
+
+    current_watchlist = prefs.get("assets_of_interest", [])
+    args = args.strip()
+
+    if not args or args.lower() == "show":
+        return _format_watchlist_display(current_watchlist)
+
+    parts = args.split()
+    action = parts[0].lower()
+    tickers_raw = parts[1:] if len(parts) > 1 else []
+
+    if action == "add":
+        return _handle_watchlist_add(chat_id, prefs, current_watchlist, tickers_raw)
+    elif action == "remove":
+        return _handle_watchlist_remove(chat_id, prefs, current_watchlist, tickers_raw)
+    elif action == "clear":
+        return _handle_watchlist_clear(chat_id, prefs)
+    else:
+        return (
+            "Unknown action\\. Use `/watchlist add TSLA`, "
+            "`/watchlist remove TSLA`, or `/watchlist show`\\."
+        )
 
 
 # ============================================================
@@ -423,6 +727,8 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
         response = handle_status_command(chat_id)
     elif command == "/settings":
         response = handle_settings_command(chat_id, args)
+    elif command == "/watchlist":
+        response = handle_watchlist_command(chat_id, args)
     elif command == "/stats":
         response = handle_stats_command(chat_id)
     elif command == "/latest":

--- a/shit_tests/notifications/test_watchlist.py
+++ b/shit_tests/notifications/test_watchlist.py
@@ -1,0 +1,320 @@
+"""Tests for /watchlist command handlers in notifications/telegram_bot.py."""
+
+from unittest.mock import patch
+
+from notifications.telegram_bot import (
+    _escape_md,
+    handle_watchlist_command,
+    process_update,
+)
+
+
+class TestEscapeMd:
+    """Test MarkdownV2 escape helper."""
+
+    def test_escapes_dots_and_parens(self):
+        assert _escape_md("Tesla Inc.") == "Tesla Inc\\."
+        assert _escape_md("(Technology)") == "\\(Technology\\)"
+
+    def test_plain_text_unchanged(self):
+        assert _escape_md("TSLA") == "TSLA"
+
+
+class TestWatchlistShow:
+    """Test /watchlist and /watchlist show."""
+
+    @patch("notifications.telegram_bot._get_ticker_names", return_value={})
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_empty_watchlist(self, mock_get_sub, _mock_names):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        result = handle_watchlist_command("123")
+        assert "empty" in result
+        assert "ALL tickers" in result
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_with_tickers(self, mock_get_sub, mock_names):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA", "AAPL"]}
+        }
+        mock_names.return_value = {
+            "TSLA": "Tesla Inc.",
+            "AAPL": "Apple Inc.",
+        }
+        result = handle_watchlist_command("123")
+        assert "TSLA" in result
+        assert "AAPL" in result
+        assert "2 tickers" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_not_subscribed(self, mock_get_sub):
+        mock_get_sub.return_value = None
+        result = handle_watchlist_command("123")
+        assert "not subscribed" in result
+
+    @patch("notifications.telegram_bot._get_ticker_names", return_value={})
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_show_explicit(self, mock_get_sub, _mock_names):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        result = handle_watchlist_command("123", "show")
+        assert "empty" in result
+
+
+class TestWatchlistAdd:
+    """Test /watchlist add."""
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_valid(self, mock_get_sub, mock_update, mock_validate, mock_names):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_validate.return_value = (["TSLA", "NVDA"], [])
+        mock_names.return_value = {
+            "TSLA": "Tesla Inc.",
+            "NVDA": "NVIDIA Corp.",
+        }
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "add TSLA NVDA")
+        assert "Added" in result
+        assert "TSLA" in result
+        assert "NVDA" in result
+        mock_update.assert_called_once()
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_duplicate(self, mock_get_sub, mock_update, mock_validate, mock_names):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA"]}
+        }
+        mock_validate.return_value = (["TSLA"], [])
+        mock_names.return_value = {"TSLA": "Tesla Inc."}
+
+        result = handle_watchlist_command("123", "add TSLA")
+        assert "Already on watchlist" in result
+        mock_update.assert_not_called()
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_invalid(self, mock_get_sub, mock_update, mock_validate, mock_names):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_validate.return_value = ([], ["FAKESYMBOL"])
+        mock_names.return_value = {}
+
+        result = handle_watchlist_command("123", "add FAKESYMBOL")
+        assert "Unknown tickers" in result
+        assert "FAKESYMBOL" in result
+        mock_update.assert_not_called()
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_mixed_valid_and_invalid(
+        self, mock_get_sub, mock_update, mock_validate, mock_names
+    ):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_validate.return_value = (["TSLA", "AAPL"], ["FAKESYMBOL"])
+        mock_names.return_value = {
+            "TSLA": "Tesla Inc.",
+            "AAPL": "Apple Inc.",
+        }
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "add TSLA FAKESYMBOL AAPL")
+        assert "Added" in result
+        assert "TSLA" in result
+        assert "Unknown tickers" in result
+        assert "FAKESYMBOL" in result
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot._normalize_ticker")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_alias_remapping(
+        self, mock_get_sub, mock_update, mock_normalize, mock_validate, mock_names
+    ):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_normalize.return_value = ("META", None)
+        mock_validate.return_value = (["META"], [])
+        mock_names.return_value = {"META": "Meta Platforms Inc."}
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "add FB")
+        assert "META" in result
+        mock_update.assert_called_once()
+
+    @patch("notifications.telegram_bot._normalize_ticker")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_delisted(self, mock_get_sub, mock_update, mock_normalize):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_normalize.return_value = (
+            "TWTR",
+            "TWTR is no longer publicly traded",
+        )
+
+        result = handle_watchlist_command("123", "add TWTR")
+        assert "no longer publicly traded" in result
+        mock_update.assert_not_called()
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_add_no_tickers(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        result = handle_watchlist_command("123", "add")
+        assert "Usage" in result
+
+
+class TestWatchlistRemove:
+    """Test /watchlist remove."""
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_remove_existing(self, mock_get_sub, mock_update, mock_names):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA", "AAPL"]}
+        }
+        mock_names.return_value = {"AAPL": "Apple Inc."}
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "remove TSLA")
+        assert "Removed" in result
+        assert "TSLA" in result
+        call_args = mock_update.call_args
+        prefs = call_args[1]["alert_preferences"]
+        assert prefs["assets_of_interest"] == ["AAPL"]
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_remove_nonexistent(self, mock_get_sub, mock_update, mock_names):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA", "AAPL"]}
+        }
+        mock_names.return_value = {"TSLA": "Tesla Inc.", "AAPL": "Apple Inc."}
+
+        result = handle_watchlist_command("123", "remove NVDA")
+        assert "Not on your watchlist" in result
+        mock_update.assert_not_called()
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_remove_last_ticker(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA"]}
+        }
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "remove TSLA")
+        assert "Removed" in result
+        assert "ALL tickers" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_remove_no_tickers(self, mock_get_sub):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA"]}
+        }
+        result = handle_watchlist_command("123", "remove")
+        assert "Usage" in result
+
+
+class TestWatchlistClear:
+    """Test /watchlist clear."""
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_clear(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": ["TSLA", "AAPL"]}
+        }
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "clear")
+        assert "cleared" in result.lower()
+        assert "ALL tickers" in result
+        call_args = mock_update.call_args
+        prefs = call_args[1]["alert_preferences"]
+        assert prefs["assets_of_interest"] == []
+
+
+class TestWatchlistEdgeCases:
+    """Test edge cases: max size, case sensitivity, unknown action."""
+
+    @patch(
+        "notifications.telegram_bot._normalize_ticker",
+        side_effect=lambda s: (s.strip().upper(), None),
+    )
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_max_size(self, mock_get_sub, mock_update, _mock_normalize):
+        current = [f"T{i:03d}" for i in range(49)]
+        mock_get_sub.return_value = {
+            "alert_preferences": {"assets_of_interest": current}
+        }
+        result = handle_watchlist_command("123", "add NEW1 NEW2")
+        assert "limited to 50" in result
+        mock_update.assert_not_called()
+
+    @patch("notifications.telegram_bot._get_ticker_names")
+    @patch("notifications.telegram_bot._validate_watchlist_tickers")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_case_insensitive(
+        self, mock_get_sub, mock_update, mock_validate, mock_names
+    ):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        mock_validate.return_value = (["TSLA"], [])
+        mock_names.return_value = {"TSLA": "Tesla Inc."}
+        mock_update.return_value = True
+
+        result = handle_watchlist_command("123", "add tsla")
+        assert "TSLA" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_unknown_action_shows_usage(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        result = handle_watchlist_command("123", "TSLA")
+        assert "Unknown action" in result
+        assert "/watchlist add" in result
+
+    @patch("notifications.telegram_bot._get_ticker_names", return_value={})
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_json_string_prefs(self, mock_get_sub, _mock_names):
+        """Handles alert_preferences stored as JSON string."""
+        import json
+
+        mock_get_sub.return_value = {
+            "alert_preferences": json.dumps({"assets_of_interest": ["TSLA"]})
+        }
+        result = handle_watchlist_command("123")
+        assert "1 tickers" in result
+
+
+class TestProcessUpdateWatchlist:
+    """Test /watchlist routing through process_update."""
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    @patch("notifications.telegram_bot._get_ticker_names", return_value={})
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_routes_to_watchlist_handler(
+        self, mock_get_sub, mock_update, _mock_names, mock_send
+    ):
+        mock_get_sub.return_value = {"alert_preferences": {"assets_of_interest": []}}
+        update = {
+            "message": {
+                "chat": {"id": 123, "type": "private"},
+                "from": {"username": "testuser"},
+                "text": "/watchlist",
+            }
+        }
+        result = process_update(update)
+        assert result is not None
+        assert "Watchlist" in result


### PR DESCRIPTION
## Summary
- Add `/watchlist add`, `/watchlist remove`, `/watchlist show`, `/watchlist clear` commands to Telegram bot
- Validates tickers against `ticker_registry` (active only), applies alias remapping (FB→META), rejects delisted tickers
- 50-ticker cap, case-insensitive, backward compatible (empty watchlist = all alerts)
- Updated `/help` and `/start` messages to surface the new command
- No schema changes — uses existing `assets_of_interest` in `alert_preferences` JSON

## Test plan
- [x] 23 new tests in `test_watchlist.py` — all pass
- [x] 186 existing notification tests — zero regressions
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format`)

Implements Feature #03 from product brainstorm roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)