### PR TITLE
feat: Alert Experience batch — briefing, follow-ups, scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Pre-Market Briefing** — Daily morning digest sent at 8:30 AM ET on trading days
+  - `notifications/briefing.py`: overnight prediction query, per-asset aggregation, MarkdownV2 formatting
+  - Telegram `/briefing` command (on/off/status) for subscriber opt-in/out (default: enabled)
+  - CLI: `python -m notifications briefing [--dry-run] [--force]` with DST-aware scheduling
+  - Quiet night message when no overnight activity; compact format for high-activity nights
+  - 38 new tests in `test_briefing.py`
 - **Watchlist Filtering** — Telegram `/watchlist` commands for subscribers to control which tickers generate alerts
   - Commands: `/watchlist add TSLA NVDA`, `/watchlist remove NVDA`, `/watchlist show`, `/watchlist clear`
   - Validates tickers against `ticker_registry` (active symbols only), applies alias remapping (FB→META), rejects delisted tickers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Weekly Scorecard** — Sunday evening performance digest with accuracy, P&L, top wins/misses, asset breakdown
+  - 4 new files: `scorecard_queries.py`, `scorecard_formatter.py`, `scorecard_service.py`
+  - Telegram `/scorecard` command (on/off/now preview) for subscriber opt-in/out
+  - CLI: `python -m notifications scorecard [--dry-run]`
+  - Streak tracking (consecutive winning/losing weeks), optional Feature 11 leaderboard integration
+  - 28 new tests in `test_scorecard.py`
+- **"What Happened" Follow-Ups** — Automatic T+1h, T+1d, T+7d follow-up messages showing actual market moves vs predictions
+  - `notifications/followups.py`: tracking creation, due detection, outcome lookup, message formatting
+  - `AlertFollowup` model in `notifications/models.py` with `alert_followups` table
+  - Fail-open integration in `alert_engine.py` and `event_consumer.py` (never breaks alert delivery)
+  - Telegram `/followups` command (on/off/selective horizons like `1h,7d`)
+  - CLI: `python -m notifications followup-check`
+  - Daily limit (15/subscriber), 48h deferral timeout, per-subscriber batching
+  - 33 new tests in `test_followups.py`
 - **Pre-Market Briefing** — Daily morning digest sent at 8:30 AM ET on trading days
   - `notifications/briefing.py`: overnight prediction query, per-asset aggregation, MarkdownV2 formatting
   - Telegram `/briefing` command (on/off/status) for subscriber opt-in/out (default: enabled)

--- a/documentation/planning/product-brainstorm_2026-04-09/07_PRE_MARKET_BRIEFING.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/07_PRE_MARKET_BRIEFING.md
@@ -2,7 +2,8 @@
 
 **Feature**: Every trading day at 8:30 AM ET, send a Telegram digest summarizing overnight Trump activity, sentiment, and historical context.
 
-**Status**: Design  
+**Status**: IN PROGRESS  
+**Started**: 2026-04-11  
 **Priority**: Medium  
 **Estimated Effort**: 2 sessions  
 

--- a/documentation/planning/product-brainstorm_2026-04-09/07_PRE_MARKET_BRIEFING.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/07_PRE_MARKET_BRIEFING.md
@@ -2,8 +2,10 @@
 
 **Feature**: Every trading day at 8:30 AM ET, send a Telegram digest summarizing overnight Trump activity, sentiment, and historical context.
 
-**Status**: IN PROGRESS  
+**Status**: COMPLETE  
 **Started**: 2026-04-11  
+**Completed**: 2026-04-11  
+**PR**: #137  
 **Priority**: Medium  
 **Estimated Effort**: 2 sessions  
 

--- a/documentation/planning/product-brainstorm_2026-04-09/08_WHAT_HAPPENED_FOLLOWUPS.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/08_WHAT_HAPPENED_FOLLOWUPS.md
@@ -2,8 +2,10 @@
 
 **Feature**: After sending an alert, automatically send follow-up messages at T+1h, T+1d, and T+7d showing actual market moves vs the prediction.
 
-**Status**: IN PROGRESS  
+**Status**: COMPLETE  
 **Started**: 2026-04-11  
+**Completed**: 2026-04-11  
+**PR**: #137  
 **Priority**: Medium-High  
 **Estimated Effort**: 2-3 sessions  
 

--- a/documentation/planning/product-brainstorm_2026-04-09/08_WHAT_HAPPENED_FOLLOWUPS.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/08_WHAT_HAPPENED_FOLLOWUPS.md
@@ -2,7 +2,8 @@
 
 **Feature**: After sending an alert, automatically send follow-up messages at T+1h, T+1d, and T+7d showing actual market moves vs the prediction.
 
-**Status**: Design  
+**Status**: IN PROGRESS  
+**Started**: 2026-04-11  
 **Priority**: Medium-High  
 **Estimated Effort**: 2-3 sessions  
 

--- a/documentation/planning/product-brainstorm_2026-04-09/12_WEEKLY_SCORECARD.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/12_WEEKLY_SCORECARD.md
@@ -1,6 +1,7 @@
 # Feature 12: Weekly Scorecard
 
-**Status:** Planning
+**Status:** IN PROGRESS  
+**Started:** 2026-04-11
 **Date:** 2026-04-09
 **Priority:** Medium -- builds trust through transparency, showcases system performance
 

--- a/documentation/planning/product-brainstorm_2026-04-09/12_WEEKLY_SCORECARD.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/12_WEEKLY_SCORECARD.md
@@ -1,7 +1,9 @@
 # Feature 12: Weekly Scorecard
 
-**Status:** IN PROGRESS  
-**Started:** 2026-04-11
+**Status:** COMPLETE  
+**Started:** 2026-04-11  
+**Completed:** 2026-04-11  
+**PR:** #137
 **Date:** 2026-04-09
 **Priority:** Medium -- builds trust through transparency, showcases system performance
 

--- a/notifications/__main__.py
+++ b/notifications/__main__.py
@@ -3,6 +3,7 @@ CLI entry point for the notifications module.
 
 Usage:
     python -m notifications check-alerts          # Run alert check (Railway cron)
+    python -m notifications briefing              # Send morning briefing (Railway cron)
     python -m notifications set-webhook <url>     # Register webhook URL with Telegram
     python -m notifications test-alert --chat-id 123  # Send test alert
     python -m notifications list-subscribers      # Show active subscribers
@@ -30,6 +31,56 @@ def cmd_check_alerts(args: argparse.Namespace) -> int:
     print(f"Alerts failed:     {results['alerts_failed']}")
     print(f"Filtered out:      {results['filtered']}")
 
+    return 0
+
+
+def cmd_briefing(args: argparse.Namespace) -> int:
+    """Send the pre-market morning briefing."""
+    from notifications.briefing import (
+        is_briefing_day,
+        is_briefing_time,
+        send_morning_briefing,
+    )
+
+    if args.dry_run:
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        from notifications.briefing import (
+            aggregate_by_asset,
+            format_briefing_message,
+            get_overnight_predictions,
+        )
+
+        now_et = datetime.now(ZoneInfo("America/New_York"))
+        predictions = get_overnight_predictions(now_et)
+        asset_summary = aggregate_by_asset(predictions) if predictions else {}
+        date_str = now_et.strftime("%A, %B %-d, %Y")
+        message = format_briefing_message(date_str, predictions, asset_summary)
+        print(message)
+        return 0
+
+    if not args.force:
+        if not is_briefing_time():
+            from datetime import datetime
+            from zoneinfo import ZoneInfo
+
+            now_et = datetime.now(ZoneInfo("America/New_York"))
+            print(
+                f"Not briefing time (current ET: {now_et.strftime('%H:%M')}), "
+                "exiting. Use --force to override."
+            )
+            return 0
+
+        if not is_briefing_day():
+            print("Not a trading day, skipping briefing. Use --force to override.")
+            return 0
+
+    results = send_morning_briefing()
+    print(
+        f"Briefing: {results['sent']} sent, {results['failed']} failed, "
+        f"{results['skipped']} skipped, {results['predictions_count']} predictions"
+    )
     return 0
 
 
@@ -143,6 +194,22 @@ def main() -> int:
         help="Check for new predictions and dispatch alerts",
     )
 
+    # briefing
+    briefing_parser = subparsers.add_parser(
+        "briefing",
+        help="Send pre-market morning briefing (8:30 AM ET on trading days)",
+    )
+    briefing_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate the briefing and print to stdout (don't send)",
+    )
+    briefing_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Send regardless of time or trading day checks",
+    )
+
     # set-webhook
     webhook_parser = subparsers.add_parser(
         "set-webhook",
@@ -179,6 +246,7 @@ def main() -> int:
 
     commands = {
         "check-alerts": cmd_check_alerts,
+        "briefing": cmd_briefing,
         "set-webhook": cmd_set_webhook,
         "test-alert": cmd_test_alert,
         "list-subscribers": cmd_list_subscribers,

--- a/notifications/__main__.py
+++ b/notifications/__main__.py
@@ -4,6 +4,7 @@ CLI entry point for the notifications module.
 Usage:
     python -m notifications check-alerts          # Run alert check (Railway cron)
     python -m notifications briefing              # Send morning briefing (Railway cron)
+    python -m notifications followup-check        # Process due follow-up messages (Railway cron)
     python -m notifications set-webhook <url>     # Register webhook URL with Telegram
     python -m notifications test-alert --chat-id 123  # Send test alert
     python -m notifications list-subscribers      # Show active subscribers
@@ -80,6 +81,19 @@ def cmd_briefing(args: argparse.Namespace) -> int:
     print(
         f"Briefing: {results['sent']} sent, {results['failed']} failed, "
         f"{results['skipped']} skipped, {results['predictions_count']} predictions"
+    )
+    return 0
+
+
+def cmd_followup_check(args: argparse.Namespace) -> int:
+    """Process due follow-up messages."""
+    from notifications.followups import process_due_followups
+
+    results = process_due_followups()
+    print(
+        f"Follow-ups: {results['checked']} checked, {results['sent']} sent, "
+        f"{results['deferred']} deferred, {results['abandoned']} abandoned, "
+        f"{results['skipped']} skipped"
     )
     return 0
 
@@ -210,6 +224,12 @@ def main() -> int:
         help="Send regardless of time or trading day checks",
     )
 
+    # followup-check
+    subparsers.add_parser(
+        "followup-check",
+        help="Process due follow-up messages (T+1h, T+1d, T+7d)",
+    )
+
     # set-webhook
     webhook_parser = subparsers.add_parser(
         "set-webhook",
@@ -247,6 +267,7 @@ def main() -> int:
     commands = {
         "check-alerts": cmd_check_alerts,
         "briefing": cmd_briefing,
+        "followup-check": cmd_followup_check,
         "set-webhook": cmd_set_webhook,
         "test-alert": cmd_test_alert,
         "list-subscribers": cmd_list_subscribers,

--- a/notifications/__main__.py
+++ b/notifications/__main__.py
@@ -5,6 +5,7 @@ Usage:
     python -m notifications check-alerts          # Run alert check (Railway cron)
     python -m notifications briefing              # Send morning briefing (Railway cron)
     python -m notifications followup-check        # Process due follow-up messages (Railway cron)
+    python -m notifications scorecard             # Send weekly scorecard (Railway cron)
     python -m notifications set-webhook <url>     # Register webhook URL with Telegram
     python -m notifications test-alert --chat-id 123  # Send test alert
     python -m notifications list-subscribers      # Show active subscribers
@@ -94,6 +95,26 @@ def cmd_followup_check(args: argparse.Namespace) -> int:
         f"Follow-ups: {results['checked']} checked, {results['sent']} sent, "
         f"{results['deferred']} deferred, {results['abandoned']} abandoned, "
         f"{results['skipped']} skipped"
+    )
+    return 0
+
+
+def cmd_scorecard(args: argparse.Namespace) -> int:
+    """Send the weekly scorecard."""
+    from notifications.scorecard_service import (
+        generate_scorecard,
+        send_weekly_scorecard,
+    )
+
+    if args.dry_run:
+        message = generate_scorecard()
+        print(message)
+        return 0
+
+    stats = send_weekly_scorecard()
+    print(
+        f"Scorecard: {stats['sent']} sent, {stats['failed']} failed, "
+        f"{stats['skipped']} opted out"
     )
     return 0
 
@@ -230,6 +251,17 @@ def main() -> int:
         help="Process due follow-up messages (T+1h, T+1d, T+7d)",
     )
 
+    # scorecard
+    scorecard_parser = subparsers.add_parser(
+        "scorecard",
+        help="Send weekly performance scorecard (Sunday 7 PM ET)",
+    )
+    scorecard_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate the scorecard and print to stdout (don't send)",
+    )
+
     # set-webhook
     webhook_parser = subparsers.add_parser(
         "set-webhook",
@@ -268,6 +300,7 @@ def main() -> int:
         "check-alerts": cmd_check_alerts,
         "briefing": cmd_briefing,
         "followup-check": cmd_followup_check,
+        "scorecard": cmd_scorecard,
         "set-webhook": cmd_set_webhook,
         "test-alert": cmd_test_alert,
         "list-subscribers": cmd_list_subscribers,

--- a/notifications/alert_engine.py
+++ b/notifications/alert_engine.py
@@ -107,6 +107,22 @@ def check_and_dispatch() -> Dict[str, Any]:
             if success:
                 record_alert_sent(chat_id)
                 results["alerts_sent"] += 1
+
+                # Create follow-up tracking (fail-open)
+                prediction_id = alert.get("prediction_id")
+                if prediction_id:
+                    try:
+                        from notifications.followups import create_followup_tracking
+
+                        create_followup_tracking(
+                            prediction_id=prediction_id,
+                            chat_id=chat_id,
+                            alert_sent_at=datetime.utcnow(),
+                        )
+                    except Exception:
+                        logger.debug(
+                            f"Follow-up tracking failed for prediction {prediction_id}"
+                        )
             else:
                 record_error(chat_id, error or "Unknown error")
                 results["alerts_failed"] += 1

--- a/notifications/briefing.py
+++ b/notifications/briefing.py
@@ -1,0 +1,340 @@
+"""
+Pre-market morning briefing for Telegram subscribers.
+
+Sends a daily digest at 8:30 AM ET on trading days summarizing overnight
+Trump activity, aggregated sentiment, and per-asset breakdown.
+"""
+
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, time
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+from notifications.db import (
+    _execute_read,
+    get_active_subscriptions,
+)
+from notifications.telegram_sender import escape_markdown, send_telegram_message
+from shit.logging import get_service_logger
+from shit.market_data.market_calendar import MarketCalendar
+
+logger = get_service_logger("briefing")
+
+ET = ZoneInfo("America/New_York")
+MAX_TELEGRAM_LENGTH = 4096
+BRIEFING_HOUR = 8
+BRIEFING_MINUTE = 30
+
+
+def get_overnight_predictions(briefing_time: datetime) -> List[Dict[str, Any]]:
+    """Get predictions created since last market close.
+
+    Args:
+        briefing_time: Current briefing datetime (timezone-aware, ET).
+
+    Returns:
+        List of prediction dicts with post text and outcome data.
+    """
+    calendar = MarketCalendar()
+    prev_trading_day = calendar.previous_trading_day(briefing_time.date())
+    window_start = datetime.combine(prev_trading_day, time(16, 0), tzinfo=ET)
+
+    return _execute_read(
+        """
+        SELECT
+            p.id as prediction_id,
+            p.shitpost_id,
+            p.assets,
+            p.market_impact,
+            p.confidence,
+            p.calibrated_confidence,
+            p.thesis,
+            p.post_timestamp,
+            p.created_at,
+            COALESCE(s.text, ts.text) as post_text
+        FROM predictions p
+        LEFT JOIN signals s ON s.signal_id = p.signal_id
+        LEFT JOIN truth_social_shitposts ts ON ts.shitpost_id = p.shitpost_id
+        WHERE p.analysis_status = 'completed'
+            AND p.confidence IS NOT NULL
+            AND p.assets IS NOT NULL
+            AND p.assets::jsonb <> '[]'::jsonb
+            AND p.created_at >= :window_start
+            AND p.created_at < :window_end
+        ORDER BY p.created_at DESC
+        """,
+        params={
+            "window_start": window_start,
+            "window_end": briefing_time,
+        },
+        default=[],
+        context="get_overnight_predictions",
+    )
+
+
+def aggregate_by_asset(predictions: List[Dict[str, Any]]) -> Dict[str, Dict]:
+    """Aggregate predictions by asset symbol.
+
+    Returns:
+        Dict mapping symbol to sentiment, count, avg_confidence, predictions.
+        Sorted by count descending.
+    """
+    assets: Dict[str, Dict[str, list]] = defaultdict(
+        lambda: {"sentiments": [], "confidences": [], "predictions": []}
+    )
+
+    for pred in predictions:
+        impact = pred.get("market_impact", {})
+        if isinstance(impact, str):
+            impact = json.loads(impact)
+        if not isinstance(impact, dict):
+            continue
+
+        for symbol, sentiment in impact.items():
+            assets[symbol]["sentiments"].append(sentiment)
+            assets[symbol]["confidences"].append(pred.get("confidence", 0))
+            text = pred.get("post_text", "") or ""
+            assets[symbol]["predictions"].append(
+                {
+                    "text": text[:80] if text else "",
+                    "confidence": pred.get("confidence", 0),
+                    "calibrated_confidence": pred.get("calibrated_confidence"),
+                    "sentiment": sentiment,
+                }
+            )
+
+    result = {}
+    for symbol, data in assets.items():
+        counts = Counter(data["sentiments"])
+        majority_sentiment = counts.most_common(1)[0][0]
+        confidences = data["confidences"]
+        result[symbol] = {
+            "sentiment": majority_sentiment,
+            "count": len(data["sentiments"]),
+            "avg_confidence": sum(confidences) / len(confidences),
+            "min_confidence": min(confidences),
+            "max_confidence": max(confidences),
+            "predictions": data["predictions"],
+        }
+
+    return dict(sorted(result.items(), key=lambda x: x[1]["count"], reverse=True))
+
+
+def format_briefing_message(
+    date_str: str,
+    predictions: List[Dict[str, Any]],
+    asset_summary: Dict[str, Dict],
+) -> str:
+    """Format the morning briefing as a Telegram MarkdownV2 message.
+
+    Args:
+        date_str: Formatted date string (e.g., "Wednesday, April 9, 2026").
+        predictions: List of overnight prediction dicts.
+        asset_summary: Aggregated per-asset data from aggregate_by_asset().
+
+    Returns:
+        MarkdownV2 formatted string.
+    """
+    lines = []
+
+    # Header
+    lines.append("*SHITPOST ALPHA \\| MORNING BRIEFING*")
+    lines.append(escape_markdown(date_str))
+    lines.append("")
+
+    if not predictions:
+        lines.append("*QUIET NIGHT* \\- No market\\-relevant posts detected\\.")
+        lines.append("")
+        lines.append(escape_markdown("Have a good trading day!"))
+    else:
+        n = len(predictions)
+        post_word = "post" if n == 1 else "posts"
+        lines.append(escape_markdown(f"OVERNIGHT ACTIVITY: {n} {post_word} analyzed"))
+        lines.append("")
+
+        # Net sentiment
+        all_sentiments = []
+        all_confidences = []
+        for data in asset_summary.values():
+            for p in data["predictions"]:
+                all_sentiments.append(p["sentiment"])
+                all_confidences.append(p["confidence"])
+
+        sentiment_counts = Counter(all_sentiments)
+        dominant = sentiment_counts.most_common(1)[0][0].upper()
+        counts_str = ", ".join(f"{c} {s}" for s, c in sentiment_counts.most_common())
+
+        avg_conf = sum(all_confidences) / len(all_confidences) if all_confidences else 0
+        min_conf = min(all_confidences) if all_confidences else 0
+        max_conf = max(all_confidences) if all_confidences else 0
+
+        lines.append(escape_markdown(f"NET SENTIMENT: {dominant} ({counts_str})"))
+        lines.append(
+            escape_markdown(
+                f"AVG CONFIDENCE: {avg_conf:.0%} (range: {min_conf:.0%}-{max_conf:.0%})"
+            )
+        )
+        lines.append("")
+
+        # Per-asset breakdown
+        lines.append("*ASSET BREAKDOWN:*")
+        for symbol, data in asset_summary.items():
+            sentiment = data["sentiment"].upper()
+            count = data["count"]
+            avg = data["avg_confidence"]
+            post_word = "post" if count == 1 else "posts"
+            lines.append(
+                escape_markdown(
+                    f"  {symbol} - {sentiment} ({count} {post_word}, avg conf {avg:.0%})"
+                )
+            )
+            # Show up to 3 posts per asset
+            for p in data["predictions"][:3]:
+                text_preview = p["text"]
+                if len(text_preview) > 60:
+                    text_preview = text_preview[:60] + "..."
+                conf_pct = f"{p['confidence']:.0%}"
+                lines.append(escape_markdown(f'    "{text_preview}" ({conf_pct})'))
+        lines.append("")
+
+    # Footer
+    lines.append(
+        escape_markdown("This is NOT financial advice. For entertainment only.")
+    )
+    lines.append(escape_markdown("Reply /briefing off to disable morning briefings."))
+
+    message = "\n".join(lines)
+
+    # Truncate if over Telegram limit
+    if len(message) > MAX_TELEGRAM_LENGTH:
+        message = _format_compact(date_str, predictions, asset_summary)
+
+    return message
+
+
+def _format_compact(
+    date_str: str,
+    predictions: List[Dict[str, Any]],
+    asset_summary: Dict[str, Dict],
+) -> str:
+    """Format a compact briefing when the full version exceeds Telegram limits."""
+    lines = []
+    lines.append("*SHITPOST ALPHA \\| MORNING BRIEFING*")
+    lines.append(escape_markdown(date_str))
+    lines.append("")
+
+    n = len(predictions)
+    lines.append(escape_markdown(f"OVERNIGHT ACTIVITY: {n} posts analyzed"))
+    lines.append("")
+
+    # Top 5 assets, 1 line each, no post previews
+    lines.append("*ASSET BREAKDOWN:*")
+    for symbol, data in list(asset_summary.items())[:5]:
+        sentiment = data["sentiment"].upper()
+        count = data["count"]
+        avg = data["avg_confidence"]
+        lines.append(
+            escape_markdown(
+                f"  {symbol} - {sentiment} ({count} posts, avg conf {avg:.0%})"
+            )
+        )
+
+    remaining = len(asset_summary) - 5
+    if remaining > 0:
+        lines.append(escape_markdown(f"  ... and {remaining} more assets"))
+
+    lines.append("")
+    lines.append(
+        escape_markdown("This is NOT financial advice. For entertainment only.")
+    )
+    lines.append(escape_markdown("Reply /briefing off to disable morning briefings."))
+
+    return "\n".join(lines)
+
+
+def send_morning_briefing() -> Dict[str, Any]:
+    """Send morning briefing to all opted-in subscribers.
+
+    Returns:
+        Summary dict: {sent, failed, skipped, total_subscribers, predictions_count}
+    """
+    results = {
+        "sent": 0,
+        "failed": 0,
+        "skipped": 0,
+        "total_subscribers": 0,
+        "predictions_count": 0,
+    }
+
+    now_et = datetime.now(ET)
+
+    # Query overnight predictions
+    predictions = get_overnight_predictions(now_et)
+    results["predictions_count"] = len(predictions)
+    asset_summary = aggregate_by_asset(predictions) if predictions else {}
+
+    # Format briefing message
+    date_str = now_et.strftime("%A, %B %-d, %Y")
+    message = format_briefing_message(date_str, predictions, asset_summary)
+
+    # Get subscribers who have briefings enabled
+    subscriptions = get_active_subscriptions()
+    results["total_subscribers"] = len(subscriptions)
+
+    for sub in subscriptions:
+        prefs = sub.get("alert_preferences", {})
+        if isinstance(prefs, str):
+            try:
+                prefs = json.loads(prefs)
+            except json.JSONDecodeError:
+                prefs = {}
+
+        if not prefs.get("briefing_enabled", True):
+            results["skipped"] += 1
+            continue
+
+        chat_id = sub["chat_id"]
+        success, error = send_telegram_message(chat_id, message)
+
+        if success:
+            results["sent"] += 1
+        else:
+            results["failed"] += 1
+            logger.error(f"Failed to send briefing to {chat_id}: {error}")
+
+    logger.info(
+        f"Briefing complete: {results['sent']} sent, "
+        f"{results['failed']} failed, {results['skipped']} skipped, "
+        f"{results['predictions_count']} predictions"
+    )
+    return results
+
+
+def is_briefing_time(now_et: Optional[datetime] = None) -> bool:
+    """Check if now is within the briefing send window (8:25-8:35 AM ET).
+
+    Args:
+        now_et: Current time in ET. Defaults to now.
+
+    Returns:
+        True if within the 10-minute send window.
+    """
+    if now_et is None:
+        now_et = datetime.now(ET)
+    return now_et.hour == BRIEFING_HOUR and 25 <= now_et.minute <= 35
+
+
+def is_briefing_day(now_et: Optional[datetime] = None) -> bool:
+    """Check if today is a trading day.
+
+    Args:
+        now_et: Current time in ET. Defaults to now.
+
+    Returns:
+        True if today is a NYSE trading day.
+    """
+    if now_et is None:
+        now_et = datetime.now(ET)
+    calendar = MarketCalendar()
+    return calendar.is_trading_day(now_et.date())

--- a/notifications/event_consumer.py
+++ b/notifications/event_consumer.py
@@ -108,6 +108,24 @@ class NotificationsWorker(EventWorker):
                 if success:
                     record_alert_sent(chat_id)
                     results["alerts_sent"] += 1
+
+                    # Create follow-up tracking (fail-open)
+                    if prediction_id:
+                        try:
+                            from notifications.followups import (
+                                create_followup_tracking,
+                            )
+                            from datetime import datetime
+
+                            create_followup_tracking(
+                                prediction_id=prediction_id,
+                                chat_id=chat_id,
+                                alert_sent_at=datetime.utcnow(),
+                            )
+                        except Exception:
+                            logger.debug(
+                                f"Follow-up tracking failed for prediction {prediction_id}"
+                            )
                 else:
                     record_error(chat_id, error or "Unknown error")
                     results["alerts_failed"] += 1

--- a/notifications/followups.py
+++ b/notifications/followups.py
@@ -1,0 +1,540 @@
+"""
+"What Happened" follow-up messages for Telegram subscribers.
+
+After an alert is sent, tracks the prediction and sends follow-up messages
+at T+1h, T+1d, and T+7d showing actual market moves vs the prediction.
+"""
+
+import json
+import time as time_module
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from notifications.db import (
+    _execute_read,
+    _execute_write,
+    _extract_scalar,
+)
+from notifications.telegram_sender import escape_markdown, send_telegram_message
+from shit.logging import get_service_logger
+
+logger = get_service_logger("followups")
+
+MAX_FOLLOWUPS_PER_DAY = 15
+MAX_DEFERRAL_HOURS = 48
+HORIZONS = ("1h", "1d", "7d")
+
+# Expected time offsets (hours) from alert time for each horizon
+EXPECTED_OFFSETS = {"1h": 2, "1d": 48, "7d": 336}
+
+# DB column mappings per horizon
+RETURN_COL = {"1h": "return_1h", "1d": "return_t1", "7d": "return_t7"}
+CORRECT_COL = {"1h": "correct_1h", "1d": "correct_t1", "7d": "correct_t7"}
+PNL_COL = {"1h": "pnl_1h", "1d": "pnl_t1", "7d": "pnl_t7"}
+PRICE_COL = {"1h": "price_1h_after", "1d": "price_t1", "7d": "price_t7"}
+SENT_COL = {"1h": "sent_1h", "1d": "sent_1d", "7d": "sent_7d"}
+SENT_AT_COL = {"1h": "sent_1h_at", "1d": "sent_1d_at", "7d": "sent_7d_at"}
+
+
+# ============================================================
+# Follow-up Tracking Creation
+# ============================================================
+
+
+def create_followup_tracking(
+    prediction_id: int,
+    chat_id: str,
+    alert_sent_at: datetime,
+) -> bool:
+    """Create a follow-up tracking row for a sent alert.
+
+    Args:
+        prediction_id: ID of the prediction that triggered the alert.
+        chat_id: Telegram chat ID of the subscriber.
+        alert_sent_at: When the original alert was sent.
+
+    Returns:
+        True if created (or already exists), False on error.
+    """
+    first_check = alert_sent_at + timedelta(minutes=65)  # 1h + 5min buffer
+
+    return _execute_write(
+        """
+        INSERT INTO alert_followups (
+            prediction_id, chat_id, original_alert_sent_at, next_check_at,
+            created_at, updated_at
+        ) VALUES (
+            :prediction_id, :chat_id, :alert_sent_at, :next_check_at,
+            NOW(), NOW()
+        )
+        ON CONFLICT (prediction_id, chat_id) DO NOTHING
+        """,
+        params={
+            "prediction_id": prediction_id,
+            "chat_id": chat_id,
+            "alert_sent_at": alert_sent_at,
+            "next_check_at": first_check,
+        },
+        context="create_followup_tracking",
+    )
+
+
+# ============================================================
+# Due Follow-up Detection
+# ============================================================
+
+
+def get_due_followups() -> List[Dict[str, Any]]:
+    """Get follow-up rows that are due for processing.
+
+    Returns rows where next_check_at <= now and at least one horizon
+    is not yet sent (True).
+    """
+    return _execute_read(
+        """
+        SELECT
+            af.id,
+            af.prediction_id,
+            af.chat_id,
+            af.sent_1h, af.sent_1d, af.sent_7d,
+            af.sent_1h_at, af.sent_1d_at, af.sent_7d_at,
+            af.original_alert_sent_at,
+            af.next_check_at,
+            p.assets,
+            p.market_impact,
+            p.confidence,
+            p.calibrated_confidence,
+            COALESCE(s.text, ts.text) as post_text
+        FROM alert_followups af
+        JOIN predictions p ON p.id = af.prediction_id
+        LEFT JOIN signals s ON s.signal_id = p.signal_id
+        LEFT JOIN truth_social_shitposts ts ON ts.shitpost_id = p.shitpost_id
+        JOIN telegram_subscriptions tsub ON tsub.chat_id = af.chat_id
+            AND tsub.is_active = true
+        WHERE af.next_check_at <= NOW()
+            AND (af.sent_1h IS NOT TRUE OR af.sent_1d IS NOT TRUE OR af.sent_7d IS NOT TRUE)
+        ORDER BY af.original_alert_sent_at ASC
+        """,
+        default=[],
+        context="get_due_followups",
+    )
+
+
+def get_followup_outcomes(prediction_id: int) -> List[Dict[str, Any]]:
+    """Get outcome data for all assets in a prediction.
+
+    Args:
+        prediction_id: The prediction ID.
+
+    Returns:
+        List of outcome dicts, one per asset.
+    """
+    return _execute_read(
+        """
+        SELECT
+            po.symbol,
+            po.prediction_sentiment,
+            po.prediction_confidence,
+            po.price_at_prediction,
+            po.price_at_post,
+            po.price_1h_after,
+            po.return_1h,
+            po.correct_1h,
+            po.pnl_1h,
+            po.price_t1,
+            po.return_t1,
+            po.correct_t1,
+            po.pnl_t1,
+            po.price_t7,
+            po.return_t7,
+            po.correct_t7,
+            po.pnl_t7,
+            po.is_complete
+        FROM prediction_outcomes po
+        WHERE po.prediction_id = :prediction_id
+        """,
+        params={"prediction_id": prediction_id},
+        default=[],
+        context="get_followup_outcomes",
+    )
+
+
+# ============================================================
+# Data Availability Checks
+# ============================================================
+
+
+def _is_data_available(outcome: Dict, horizon: str) -> bool:
+    """Check if outcome data is available for a given horizon."""
+    return outcome.get(RETURN_COL[horizon]) is not None
+
+
+def _should_abandon(followup: Dict, horizon: str) -> bool:
+    """Check if we've been deferring too long for this horizon."""
+    alert_time = followup["original_alert_sent_at"]
+    if isinstance(alert_time, str):
+        alert_time = datetime.fromisoformat(alert_time)
+
+    max_wait_hours = EXPECTED_OFFSETS[horizon] + MAX_DEFERRAL_HOURS
+    elapsed = (
+        datetime.now(timezone.utc) - alert_time.replace(tzinfo=timezone.utc)
+    ).total_seconds()
+    return elapsed > max_wait_hours * 3600
+
+
+# ============================================================
+# Message Formatting
+# ============================================================
+
+
+def format_followup_message(
+    horizon: str,
+    outcomes: List[Dict[str, Any]],
+) -> str:
+    """Format a follow-up message for Telegram.
+
+    Args:
+        horizon: "1h", "1d", or "7d".
+        outcomes: List of outcome dicts (one per asset).
+
+    Returns:
+        MarkdownV2 formatted message.
+    """
+    lines = []
+
+    horizon_labels = {
+        "1h": "1 hour later",
+        "1d": "after 1 trading day",
+        "7d": "after 7 trading days",
+    }
+    header_prefix = {"1h": "UPDATE", "1d": "VERDICT", "7d": "FINAL RESULT"}
+
+    return_key = RETURN_COL[horizon]
+    correct_key = CORRECT_COL[horizon]
+    pnl_key = PNL_COL[horizon]
+    price_key = PRICE_COL[horizon]
+
+    # Header
+    if len(outcomes) == 1:
+        symbol = outcomes[0]["symbol"]
+        lines.append(
+            escape_markdown(
+                f"{header_prefix[horizon]}: {symbol} {horizon_labels[horizon]}"
+            )
+        )
+    else:
+        lines.append(
+            escape_markdown(
+                f"{header_prefix[horizon]}: {len(outcomes)} assets {horizon_labels[horizon]}"
+            )
+        )
+    lines.append("")
+
+    total_correct = 0
+    total_pnl = 0.0
+
+    for outcome in outcomes:
+        symbol = outcome["symbol"]
+        base_price = outcome.get("price_at_post") or outcome.get("price_at_prediction")
+        end_price = outcome.get(price_key)
+        ret = outcome.get(return_key)
+        correct = outcome.get(correct_key)
+        pnl = outcome.get(pnl_key, 0) or 0
+
+        ret_str = f"{ret:+.1f}%" if ret is not None else "N/A"
+
+        if correct is True:
+            result_str = "CORRECT"
+            total_correct += 1
+        elif correct is False:
+            result_str = "INCORRECT"
+        else:
+            result_str = "FLAT"
+
+        price_str = ""
+        if base_price and end_price:
+            price_str = f"${base_price:.2f} -> ${end_price:.2f} "
+
+        sentiment = (outcome.get("prediction_sentiment") or "neutral").upper()
+        conf = outcome.get("prediction_confidence", 0) or 0
+
+        if len(outcomes) == 1:
+            lines.append(escape_markdown(f"Price: {price_str}({ret_str})"))
+            lines.append(
+                escape_markdown(f"Prediction: {sentiment} @ {conf:.0%} confidence")
+            )
+            lines.append(escape_markdown(f"Result: {result_str}"))
+        else:
+            lines.append(
+                escape_markdown(f"  {symbol}: {price_str}({ret_str}) {result_str}")
+            )
+
+        total_pnl += pnl
+
+    lines.append("")
+
+    # P&L summary for 1d and 7d
+    if horizon in ("1d", "7d"):
+        if len(outcomes) == 1:
+            verb = "gained" if total_pnl >= 0 else "lost"
+            lines.append(
+                escape_markdown(
+                    f"P&L: $1,000 position would have {verb} ${abs(total_pnl):.2f}"
+                )
+            )
+        else:
+            lines.append(
+                escape_markdown(f"Overall: {total_correct}/{len(outcomes)} correct")
+            )
+            total_position = len(outcomes) * 1000
+            lines.append(
+                escape_markdown(
+                    f"Net P&L: ${total_pnl:+,.2f} on ${total_position:,} across {len(outcomes)} positions"
+                )
+            )
+
+    # Footer
+    lines.append("")
+    lines.append(escape_markdown("Reply /followups off to disable follow-up messages."))
+
+    return "\n".join(lines)
+
+
+# ============================================================
+# Follow-up Processing
+# ============================================================
+
+
+def _check_daily_limit(chat_id: str) -> bool:
+    """Check if subscriber has hit daily follow-up limit.
+
+    Returns True if under the limit (can send more).
+    """
+    count = _execute_read(
+        """
+        SELECT COUNT(*) as sent_today
+        FROM alert_followups
+        WHERE chat_id = :chat_id
+            AND (
+                (sent_1h = true AND sent_1h_at >= CURRENT_DATE)
+                OR (sent_1d = true AND sent_1d_at >= CURRENT_DATE)
+                OR (sent_7d = true AND sent_7d_at >= CURRENT_DATE)
+            )
+        """,
+        params={"chat_id": chat_id},
+        processor=_extract_scalar,
+        default=0,
+        context="check_daily_followup_limit",
+    )
+    return (count or 0) < MAX_FOLLOWUPS_PER_DAY
+
+
+def _get_subscriber_prefs(chat_id: str) -> Optional[Dict]:
+    """Get subscriber preferences for follow-up filtering."""
+    row = _execute_read(
+        """
+        SELECT alert_preferences
+        FROM telegram_subscriptions
+        WHERE chat_id = :chat_id AND is_active = true
+        """,
+        params={"chat_id": chat_id},
+        processor=_extract_scalar,
+        default=None,
+        context="get_subscriber_prefs_for_followup",
+    )
+    if row is None:
+        return None
+    if isinstance(row, str):
+        try:
+            return json.loads(row)
+        except json.JSONDecodeError:
+            return {}
+    return row if isinstance(row, dict) else {}
+
+
+def _update_followup_sent(followup_id: int, horizon: str) -> bool:
+    """Mark a horizon as sent."""
+    sent_col = SENT_COL[horizon]
+    sent_at_col = SENT_AT_COL[horizon]
+    return _execute_write(
+        f"""
+        UPDATE alert_followups
+        SET {sent_col} = true, {sent_at_col} = NOW(), updated_at = NOW()
+        WHERE id = :id
+        """,
+        params={"id": followup_id},
+        context=f"update_followup_sent_{horizon}",
+    )
+
+
+def _update_followup_abandoned(followup_id: int, horizon: str) -> bool:
+    """Mark a horizon as abandoned (data never became available)."""
+    sent_col = SENT_COL[horizon]
+    return _execute_write(
+        f"""
+        UPDATE alert_followups
+        SET {sent_col} = false, updated_at = NOW()
+        WHERE id = :id
+        """,
+        params={"id": followup_id},
+        context=f"update_followup_abandoned_{horizon}",
+    )
+
+
+def _defer_followup(followup_id: int) -> bool:
+    """Push next_check_at forward by 30 minutes."""
+    return _execute_write(
+        """
+        UPDATE alert_followups
+        SET next_check_at = next_check_at + INTERVAL '30 minutes', updated_at = NOW()
+        WHERE id = :id
+        """,
+        params={"id": followup_id},
+        context="defer_followup",
+    )
+
+
+def _is_horizon_due(followup: Dict, horizon: str) -> bool:
+    """Check if a specific horizon is due for processing.
+
+    A horizon is due if:
+    - It hasn't been sent yet (not True)
+    - Enough time has elapsed since the alert
+    """
+    sent_val = followup.get(SENT_COL[horizon])
+    if sent_val is True:
+        return False  # Already sent
+    if sent_val is False:
+        return False  # Abandoned
+
+    alert_time = followup["original_alert_sent_at"]
+    if isinstance(alert_time, str):
+        alert_time = datetime.fromisoformat(alert_time)
+
+    # Minimum elapsed times
+    min_elapsed = {
+        "1h": timedelta(hours=1),
+        "1d": timedelta(hours=20),
+        "7d": timedelta(days=9),
+    }
+    now = datetime.now(timezone.utc)
+    elapsed = now - alert_time.replace(tzinfo=timezone.utc)
+
+    return elapsed >= min_elapsed[horizon]
+
+
+def _process_single_followup(followup: Dict) -> str:
+    """Process a single follow-up row.
+
+    Returns one of: "sent", "deferred", "abandoned", "skipped".
+    """
+    followup_id = followup["id"]
+    prediction_id = followup["prediction_id"]
+    chat_id = followup["chat_id"]
+
+    # Check subscriber preferences
+    prefs = _get_subscriber_prefs(chat_id)
+    if prefs is None:
+        return "skipped"
+
+    if not prefs.get("followups_enabled", True):
+        return "skipped"
+
+    enabled_horizons = set(prefs.get("followup_horizons", ["1h", "1d", "7d"]))
+
+    # Get outcomes for this prediction
+    outcomes = get_followup_outcomes(prediction_id)
+    if not outcomes:
+        # No outcomes yet — check if we should abandon
+        for horizon in HORIZONS:
+            if followup.get(SENT_COL[horizon]) is None and _should_abandon(
+                followup, horizon
+            ):
+                _update_followup_abandoned(followup_id, horizon)
+        _defer_followup(followup_id)
+        return "deferred"
+
+    sent_any = False
+    deferred_any = False
+
+    for horizon in HORIZONS:
+        if horizon not in enabled_horizons:
+            continue
+        if not _is_horizon_due(followup, horizon):
+            continue
+
+        # Check if data is available for ALL outcomes at this horizon
+        all_available = all(_is_data_available(o, horizon) for o in outcomes)
+
+        if all_available:
+            # Format and send
+            message = format_followup_message(horizon, outcomes)
+            success, error = send_telegram_message(chat_id, message)
+            if success:
+                _update_followup_sent(followup_id, horizon)
+                sent_any = True
+            else:
+                logger.warning(
+                    f"Failed to send {horizon} follow-up to {chat_id}: {error}"
+                )
+                deferred_any = True
+        elif _should_abandon(followup, horizon):
+            _update_followup_abandoned(followup_id, horizon)
+        else:
+            deferred_any = True
+
+    if deferred_any:
+        _defer_followup(followup_id)
+
+    if sent_any:
+        return "sent"
+    elif deferred_any:
+        return "deferred"
+    return "skipped"
+
+
+def process_due_followups() -> Dict[str, int]:
+    """Process all due follow-up messages.
+
+    Groups by subscriber, processes chronologically, respects daily limits.
+
+    Returns:
+        Summary dict: {checked, sent, deferred, abandoned, skipped}
+    """
+    results = {"checked": 0, "sent": 0, "deferred": 0, "abandoned": 0, "skipped": 0}
+
+    due_followups = get_due_followups()
+    results["checked"] = len(due_followups)
+
+    if not due_followups:
+        return results
+
+    # Group by chat_id for batching
+    by_chat: Dict[str, List[Dict]] = defaultdict(list)
+    for fu in due_followups:
+        by_chat[fu["chat_id"]].append(fu)
+
+    for chat_id, followups in by_chat.items():
+        # Check daily limit
+        if not _check_daily_limit(chat_id):
+            results["skipped"] += len(followups)
+            continue
+
+        # Sort by original alert time (oldest first)
+        followups.sort(key=lambda f: f["original_alert_sent_at"])
+
+        for fu in followups:
+            result = _process_single_followup(fu)
+            results[result] += 1
+
+            # Rate limiting between messages to same chat
+            if result == "sent":
+                time_module.sleep(0.1)
+
+    logger.info(
+        f"Follow-ups: {results['checked']} checked, {results['sent']} sent, "
+        f"{results['deferred']} deferred, {results['abandoned']} abandoned, "
+        f"{results['skipped']} skipped"
+    )
+    return results

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -4,7 +4,17 @@ SQLAlchemy models for the notifications subsystem.
 """
 
 from datetime import datetime
-from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+)
 
 from shit.db.data_models import Base, TimestampMixin, IDMixin
 
@@ -75,3 +85,40 @@ class TelegramSubscription(Base, IDMixin, TimestampMixin):
                 return f"@{self.username}"
             return self.first_name or f"User {self.chat_id}"
         return self.title or f"Chat {self.chat_id}"
+
+
+class AlertFollowup(Base, IDMixin, TimestampMixin):
+    """Tracks follow-up messages for sent alerts at T+1h, T+1d, T+7d.
+
+    Each row tracks one (prediction, subscriber) pair. The follow-up
+    checker runs every 5 minutes and processes rows where next_check_at <= now.
+    """
+
+    __tablename__ = "alert_followups"
+    __table_args__ = (
+        UniqueConstraint(
+            "prediction_id", "chat_id", name="uq_alert_followup_pred_chat"
+        ),
+    )
+
+    prediction_id = Column(Integer, ForeignKey("predictions.id"), nullable=False)
+    chat_id = Column(String(50), nullable=False, index=True)
+
+    # Follow-up state: None = not yet due, False = abandoned, True = sent
+    sent_1h = Column(Boolean, nullable=True, default=None)
+    sent_1h_at = Column(DateTime, nullable=True)
+    sent_1d = Column(Boolean, nullable=True, default=None)
+    sent_1d_at = Column(DateTime, nullable=True)
+    sent_7d = Column(Boolean, nullable=True, default=None)
+    sent_7d_at = Column(DateTime, nullable=True)
+
+    # Timing
+    original_alert_sent_at = Column(DateTime, nullable=False)
+    next_check_at = Column(DateTime, nullable=False, index=True)
+
+    def __repr__(self):
+        return (
+            f"<AlertFollowup(prediction_id={self.prediction_id}, "
+            f"chat_id={self.chat_id}, "
+            f"1h={self.sent_1h}, 1d={self.sent_1d}, 7d={self.sent_7d})>"
+        )

--- a/notifications/scorecard_formatter.py
+++ b/notifications/scorecard_formatter.py
@@ -1,0 +1,223 @@
+"""Formats the weekly scorecard as a Telegram MarkdownV2 message."""
+
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from notifications.telegram_sender import escape_markdown
+from shit.logging import get_service_logger
+
+logger = get_service_logger("scorecard_formatter")
+
+
+def format_weekly_scorecard(
+    week_start: date,
+    week_end: date,
+    prediction_stats: Dict[str, Any],
+    accuracy: Dict[str, Any],
+    pnl: Dict[str, Any],
+    top_wins: List[Dict[str, Any]],
+    worst_misses: List[Dict[str, Any]],
+    asset_breakdown: List[Dict[str, Any]],
+    leaderboard: Optional[List[Dict[str, Any]]] = None,
+    llm_vs_crowd: Optional[Dict[str, Any]] = None,
+    streak_info: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the complete weekly scorecard message.
+
+    Args:
+        week_start: Monday of the report week.
+        week_end: Sunday of the report week.
+        prediction_stats: From get_weekly_prediction_stats().
+        accuracy: From get_weekly_accuracy().
+        pnl: From get_weekly_pnl().
+        top_wins: From get_top_wins().
+        worst_misses: From get_worst_misses().
+        asset_breakdown: From get_asset_breakdown().
+        leaderboard: Optional, from Feature 11 voting data.
+        llm_vs_crowd: Optional, from Feature 11 LLM vs crowd comparison.
+        streak_info: Optional, consecutive winning/losing weeks.
+
+    Returns:
+        Formatted MarkdownV2 string.
+    """
+    lines = []
+
+    # === HEADER ===
+    start_str = week_start.strftime("%b %-d")
+    end_str = week_end.strftime("%b %-d, %Y")
+    lines.append("*SHITPOST ALPHA \\- WEEKLY SCORECARD*")
+    lines.append(
+        f"_Week of {escape_markdown(start_str)} \\- {escape_markdown(end_str)}_"
+    )
+    lines.append("")
+
+    # === SIGNALS ===
+    total = prediction_stats.get("total_predictions", 0) or 0
+    completed = prediction_stats.get("completed", 0) or 0
+    bypassed = prediction_stats.get("bypassed", 0) or 0
+    avg_conf = prediction_stats.get("avg_confidence") or 0
+    avg_conf_pct = f"{avg_conf:.0%}" if avg_conf else "N/A"
+
+    lines.append("*\\-\\-\\- SIGNALS \\-\\-\\-*")
+    lines.append(escape_markdown(f"Total Predictions: {total}"))
+    lines.append(escape_markdown(f"Bypassed: {bypassed} | Completed: {completed}"))
+    lines.append(escape_markdown(f"Average Confidence: {avg_conf_pct}"))
+    lines.append("")
+
+    # === ACCURACY ===
+    correct = accuracy.get("correct", 0) or 0
+    incorrect = accuracy.get("incorrect", 0) or 0
+    pending = accuracy.get("pending", 0) or 0
+    evaluated = correct + incorrect
+    acc_pct = f"{(correct / evaluated * 100):.0f}%" if evaluated > 0 else "N/A"
+
+    bullish_correct = accuracy.get("bullish_correct", 0) or 0
+    bullish_total = accuracy.get("bullish_total", 0) or 0
+    bearish_correct = accuracy.get("bearish_correct", 0) or 0
+    bearish_total = accuracy.get("bearish_total", 0) or 0
+
+    bull_pct = (
+        f"{(bullish_correct / bullish_total * 100):.0f}%"
+        if bullish_total > 0
+        else "N/A"
+    )
+    bear_pct = (
+        f"{(bearish_correct / bearish_total * 100):.0f}%"
+        if bearish_total > 0
+        else "N/A"
+    )
+
+    lines.append(escape_markdown("--- ACCURACY (T+7 Trading Days) ---"))
+    lines.append(
+        escape_markdown(f"Correct: {correct} / {evaluated} evaluated ({acc_pct})")
+    )
+    if pending > 0:
+        lines.append(escape_markdown(f"Pending: {pending} (too recent)"))
+    lines.append(
+        escape_markdown(f"Bullish: {bullish_correct}/{bullish_total} ({bull_pct})")
+    )
+    lines.append(
+        escape_markdown(f"Bearish: {bearish_correct}/{bearish_total} ({bear_pct})")
+    )
+    lines.append("")
+
+    # === P&L ===
+    total_pnl = pnl.get("total_pnl", 0) or 0
+    best_pnl = pnl.get("best_pnl", 0) or 0
+    worst_pnl = pnl.get("worst_pnl", 0) or 0
+    trade_count = pnl.get("trade_count", 0) or 0
+
+    lines.append(escape_markdown("--- SIMULATED P&L ($1,000/trade) ---"))
+    lines.append(escape_markdown(f"Weekly P&L: ${total_pnl:+,.2f}"))
+    lines.append(escape_markdown(f"Best trade: ${best_pnl:+,.2f}"))
+    lines.append(escape_markdown(f"Worst trade: ${worst_pnl:+,.2f}"))
+    lines.append(escape_markdown(f"Trades evaluated: {trade_count}"))
+    lines.append("")
+
+    # === TOP WINS ===
+    if top_wins:
+        lines.append("*\\-\\-\\- TOP WINS \\-\\-\\-*")
+        for i, win in enumerate(top_wins, 1):
+            sym = win.get("symbol", "?")
+            sent = win.get("sentiment") or "neutral"
+            conf = win.get("confidence", 0) or 0
+            ret = win.get("return_pct", 0) or 0
+            win_pnl = win.get("pnl", 0) or 0
+            lines.append(
+                escape_markdown(
+                    f"{i}. {sym} {sent} ({conf:.0%}) -> {ret:+.1f}% (${win_pnl:+,.2f})"
+                )
+            )
+        lines.append("")
+
+    # === WORST MISSES ===
+    if worst_misses:
+        losses = [m for m in worst_misses if (m.get("pnl") or 0) < 0]
+        if losses:
+            lines.append("*\\-\\-\\- BIGGEST MISSES \\-\\-\\-*")
+            for i, miss in enumerate(losses, 1):
+                sym = miss.get("symbol", "?")
+                sent = miss.get("sentiment") or "neutral"
+                conf = miss.get("confidence", 0) or 0
+                ret = miss.get("return_pct", 0) or 0
+                miss_pnl = miss.get("pnl", 0) or 0
+                lines.append(
+                    escape_markdown(
+                        f"{i}. {sym} {sent} ({conf:.0%}) -> {ret:+.1f}% (${miss_pnl:+,.2f})"
+                    )
+                )
+            lines.append("")
+
+    # === ASSET BREAKDOWN ===
+    if asset_breakdown:
+        lines.append("*\\-\\-\\- TOP ASSETS \\-\\-\\-*")
+        for asset in asset_breakdown[:5]:
+            sym = asset.get("symbol", "?")
+            count = asset.get("signal_count", 0)
+            acc = asset.get("accuracy_pct") or 0
+            asset_pnl = asset.get("total_pnl", 0) or 0
+            lines.append(
+                escape_markdown(
+                    f"{sym}: {count} signals, {acc:.0f}% accuracy, ${asset_pnl:+,.2f} P&L"
+                )
+            )
+        lines.append("")
+
+    # === CONVICTION LEADERBOARD (Feature 11) ===
+    if leaderboard:
+        lines.append("*\\-\\-\\- CROWD LEADERBOARD \\-\\-\\-*")
+        for i, leader in enumerate(leaderboard[:5], 1):
+            name = escape_markdown((leader.get("display_name") or "Anon")[:15])
+            acc = leader.get("accuracy_pct", 0)
+            correct_l = leader.get("correct", 0)
+            total_l = leader.get("evaluated", 0)
+            lines.append(
+                escape_markdown(f"{i}. {name} - {acc:.0f}% ({correct_l}/{total_l})")
+            )
+
+        if llm_vs_crowd and llm_vs_crowd.get("total_evaluated", 0) >= 3:
+            llm_acc = llm_vs_crowd.get("llm_accuracy", 0)
+            crowd_acc = llm_vs_crowd.get("crowd_accuracy", 0)
+            lines.append(
+                escape_markdown(f"LLM: {llm_acc:.0f}% | Crowd: {crowd_acc:.0f}%")
+            )
+        lines.append("")
+
+    # === STREAK ===
+    if streak_info and streak_info.get("streak_length", 0) > 0:
+        streak_len = streak_info["streak_length"]
+        streak_type = streak_info.get("streak_type", "")
+        week_word = "week" if streak_len == 1 else "weeks"
+        if streak_type == "winning":
+            lines.append(
+                escape_markdown(f"Streak: {streak_len} winning {week_word} in a row")
+            )
+        elif streak_type == "losing":
+            lines.append(
+                escape_markdown(f"Streak: {streak_len} losing {week_word} in a row")
+            )
+        lines.append("")
+
+    # === FOOTER ===
+    lines.append(
+        escape_markdown(
+            "This is NOT financial advice. Simulated results do not reflect actual trading."
+        )
+    )
+    lines.append(escape_markdown("/scorecard off to opt out"))
+
+    return "\n".join(lines)
+
+
+def truncate_to_telegram_limit(message: str, limit: int = 4096) -> str:
+    """Truncate message to Telegram's character limit."""
+    if len(message) <= limit:
+        return message
+
+    truncated = message[: limit - 50]
+    last_newline = truncated.rfind("\n")
+    if last_newline > 0:
+        truncated = truncated[:last_newline]
+
+    truncated += "\n\n" + escape_markdown("(truncated)")
+    return truncated

--- a/notifications/scorecard_queries.py
+++ b/notifications/scorecard_queries.py
@@ -1,0 +1,268 @@
+"""Queries for generating the weekly scorecard."""
+
+from datetime import date
+from typing import Any, Dict, List
+
+from notifications.db import _execute_read, _row_to_dict
+from shit.logging import get_service_logger
+
+logger = get_service_logger("scorecard_queries")
+
+
+def get_weekly_prediction_stats(
+    week_start: date,
+    week_end: date,
+) -> Dict[str, Any]:
+    """Get aggregate prediction stats for a date range.
+
+    Args:
+        week_start: Start date (inclusive, Monday).
+        week_end: End date (inclusive, Sunday).
+
+    Returns:
+        Dict with total_predictions, completed, bypassed, errors, avg_confidence.
+    """
+    return _execute_read(
+        """
+        SELECT
+            COUNT(*) as total_predictions,
+            COUNT(CASE WHEN p.analysis_status = 'completed' THEN 1 END) as completed,
+            COUNT(CASE WHEN p.analysis_status = 'bypassed' THEN 1 END) as bypassed,
+            COUNT(CASE WHEN p.analysis_status = 'error' THEN 1 END) as errors,
+            AVG(CASE WHEN p.analysis_status = 'completed' THEN p.confidence END) as avg_confidence
+        FROM predictions p
+        WHERE p.post_timestamp::date >= :week_start
+            AND p.post_timestamp::date <= :week_end
+        """,
+        params={"week_start": week_start, "week_end": week_end},
+        processor=_row_to_dict,
+        default={"total_predictions": 0},
+        context="get_weekly_prediction_stats",
+    )
+
+
+def get_weekly_accuracy(
+    week_start: date,
+    week_end: date,
+    timeframe: str = "t7",
+) -> Dict[str, Any]:
+    """Get accuracy stats for predictions made during the week.
+
+    Args:
+        week_start: Start date.
+        week_end: End date.
+        timeframe: Which timeframe to evaluate (t1, t3, t7, t30).
+
+    Returns:
+        Dict with correct, incorrect, pending, bullish/bearish splits.
+    """
+    correct_col = f"correct_{timeframe}"
+
+    return _execute_read(
+        f"""
+        SELECT
+            COUNT(*) as total_outcomes,
+            COUNT(CASE WHEN po.{correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN po.{correct_col} = false THEN 1 END) as incorrect,
+            COUNT(CASE WHEN po.{correct_col} IS NULL THEN 1 END) as pending,
+            COUNT(CASE WHEN po.prediction_sentiment = 'bullish'
+                AND po.{correct_col} = true THEN 1 END) as bullish_correct,
+            COUNT(CASE WHEN po.prediction_sentiment = 'bullish'
+                AND po.{correct_col} IS NOT NULL THEN 1 END) as bullish_total,
+            COUNT(CASE WHEN po.prediction_sentiment = 'bearish'
+                AND po.{correct_col} = true THEN 1 END) as bearish_correct,
+            COUNT(CASE WHEN po.prediction_sentiment = 'bearish'
+                AND po.{correct_col} IS NOT NULL THEN 1 END) as bearish_total
+        FROM prediction_outcomes po
+        WHERE po.prediction_date >= :week_start
+            AND po.prediction_date <= :week_end
+        """,
+        params={"week_start": week_start, "week_end": week_end},
+        processor=_row_to_dict,
+        default={"total_outcomes": 0},
+        context="get_weekly_accuracy",
+    )
+
+
+def get_weekly_pnl(
+    week_start: date,
+    week_end: date,
+    timeframe: str = "t7",
+) -> Dict[str, Any]:
+    """Get simulated P&L for predictions made during the week.
+
+    Returns:
+        Dict with total_pnl, avg_pnl, best_pnl, worst_pnl, trade_count.
+    """
+    pnl_col = f"pnl_{timeframe}"
+
+    return _execute_read(
+        f"""
+        SELECT
+            COUNT(*) as trade_count,
+            COALESCE(SUM(po.{pnl_col}), 0) as total_pnl,
+            COALESCE(AVG(po.{pnl_col}), 0) as avg_pnl,
+            MAX(po.{pnl_col}) as best_pnl,
+            MIN(po.{pnl_col}) as worst_pnl
+        FROM prediction_outcomes po
+        WHERE po.prediction_date >= :week_start
+            AND po.prediction_date <= :week_end
+            AND po.{pnl_col} IS NOT NULL
+        """,
+        params={"week_start": week_start, "week_end": week_end},
+        processor=_row_to_dict,
+        default={"trade_count": 0, "total_pnl": 0},
+        context="get_weekly_pnl",
+    )
+
+
+def get_top_wins(
+    week_start: date,
+    week_end: date,
+    limit: int = 3,
+    timeframe: str = "t7",
+) -> List[Dict[str, Any]]:
+    """Get the best-performing predictions of the week."""
+    pnl_col = f"pnl_{timeframe}"
+    return_col = f"return_{timeframe}"
+
+    return _execute_read(
+        f"""
+        SELECT
+            po.symbol,
+            po.prediction_sentiment as sentiment,
+            po.prediction_confidence as confidence,
+            po.{return_col} as return_pct,
+            po.{pnl_col} as pnl
+        FROM prediction_outcomes po
+        WHERE po.prediction_date >= :week_start
+            AND po.prediction_date <= :week_end
+            AND po.{pnl_col} IS NOT NULL
+        ORDER BY po.{pnl_col} DESC
+        LIMIT :limit
+        """,
+        params={"week_start": week_start, "week_end": week_end, "limit": limit},
+        default=[],
+        context="get_top_wins",
+    )
+
+
+def get_worst_misses(
+    week_start: date,
+    week_end: date,
+    limit: int = 3,
+    timeframe: str = "t7",
+) -> List[Dict[str, Any]]:
+    """Get the worst-performing predictions of the week."""
+    pnl_col = f"pnl_{timeframe}"
+    return_col = f"return_{timeframe}"
+
+    return _execute_read(
+        f"""
+        SELECT
+            po.symbol,
+            po.prediction_sentiment as sentiment,
+            po.prediction_confidence as confidence,
+            po.{return_col} as return_pct,
+            po.{pnl_col} as pnl
+        FROM prediction_outcomes po
+        WHERE po.prediction_date >= :week_start
+            AND po.prediction_date <= :week_end
+            AND po.{pnl_col} IS NOT NULL
+        ORDER BY po.{pnl_col} ASC
+        LIMIT :limit
+        """,
+        params={"week_start": week_start, "week_end": week_end, "limit": limit},
+        default=[],
+        context="get_worst_misses",
+    )
+
+
+def get_asset_breakdown(
+    week_start: date,
+    week_end: date,
+    timeframe: str = "t7",
+) -> List[Dict[str, Any]]:
+    """Get per-asset performance summary."""
+    correct_col = f"correct_{timeframe}"
+    pnl_col = f"pnl_{timeframe}"
+
+    return _execute_read(
+        f"""
+        SELECT
+            po.symbol,
+            COUNT(*) as signal_count,
+            COUNT(CASE WHEN po.{correct_col} = true THEN 1 END) as correct,
+            COUNT(CASE WHEN po.{correct_col} IS NOT NULL THEN 1 END) as evaluated,
+            ROUND(
+                COUNT(CASE WHEN po.{correct_col} = true THEN 1 END)::numeric
+                / NULLIF(COUNT(CASE WHEN po.{correct_col} IS NOT NULL THEN 1 END), 0)
+                * 100, 1
+            ) as accuracy_pct,
+            COALESCE(SUM(po.{pnl_col}), 0) as total_pnl
+        FROM prediction_outcomes po
+        WHERE po.prediction_date >= :week_start
+            AND po.prediction_date <= :week_end
+        GROUP BY po.symbol
+        ORDER BY COUNT(*) DESC
+        LIMIT 5
+        """,
+        params={"week_start": week_start, "week_end": week_end},
+        default=[],
+        context="get_asset_breakdown",
+    )
+
+
+def get_weekly_streak() -> Dict[str, Any]:
+    """Calculate the current streak of winning/losing weeks.
+
+    Returns:
+        Dict with streak_type ('winning' or 'losing') and streak_length.
+    """
+    rows = _execute_read(
+        """
+        WITH weekly_performance AS (
+            SELECT
+                DATE_TRUNC('week', po.prediction_date)::date as week_start,
+                COUNT(CASE WHEN po.correct_t7 = true THEN 1 END) as correct,
+                COUNT(CASE WHEN po.correct_t7 IS NOT NULL THEN 1 END) as evaluated,
+                COALESCE(SUM(po.pnl_t7), 0) as total_pnl
+            FROM prediction_outcomes po
+            WHERE po.prediction_date >= CURRENT_DATE - INTERVAL '12 weeks'
+            GROUP BY DATE_TRUNC('week', po.prediction_date)
+            HAVING COUNT(CASE WHEN po.correct_t7 IS NOT NULL THEN 1 END) >= 3
+            ORDER BY week_start DESC
+        )
+        SELECT
+            week_start,
+            correct,
+            evaluated,
+            total_pnl,
+            CASE
+                WHEN evaluated > 0 AND (correct::float / evaluated) >= 0.5
+                    AND total_pnl >= 0 THEN true
+                ELSE false
+            END as is_winning_week
+        FROM weekly_performance
+        ORDER BY week_start DESC
+        """,
+        default=[],
+        context="get_weekly_streak",
+    )
+
+    if not rows:
+        return {"streak_type": None, "streak_length": 0}
+
+    current_is_winning = rows[0].get("is_winning_week", False)
+    streak = 0
+
+    for row in rows:
+        if row.get("is_winning_week") == current_is_winning:
+            streak += 1
+        else:
+            break
+
+    return {
+        "streak_type": "winning" if current_is_winning else "losing",
+        "streak_length": streak,
+    }

--- a/notifications/scorecard_service.py
+++ b/notifications/scorecard_service.py
@@ -1,0 +1,157 @@
+"""
+Weekly Scorecard Service
+
+Orchestrates data collection, formatting, and delivery of the weekly scorecard.
+Called by Railway cron every Sunday at 7 PM ET.
+"""
+
+import json
+from datetime import date, timedelta
+from typing import Optional
+
+from notifications.db import get_active_subscriptions
+from notifications.scorecard_formatter import (
+    format_weekly_scorecard,
+    truncate_to_telegram_limit,
+)
+from notifications.scorecard_queries import (
+    get_asset_breakdown,
+    get_top_wins,
+    get_weekly_accuracy,
+    get_weekly_pnl,
+    get_weekly_prediction_stats,
+    get_weekly_streak,
+    get_worst_misses,
+)
+from notifications.telegram_sender import send_telegram_message
+from shit.logging import get_service_logger
+
+logger = get_service_logger("scorecard_service")
+
+
+def get_current_week_range() -> tuple[date, date]:
+    """Get the Monday-Sunday range for the current week.
+
+    Returns:
+        Tuple of (monday, sunday) as date objects.
+    """
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def generate_scorecard(
+    week_start: Optional[date] = None,
+    week_end: Optional[date] = None,
+) -> str:
+    """Generate the scorecard message for a given week.
+
+    Args:
+        week_start: Monday of the week. Defaults to current week.
+        week_end: Sunday of the week. Defaults to current week.
+
+    Returns:
+        Formatted MarkdownV2 message string.
+    """
+    if week_start is None or week_end is None:
+        week_start, week_end = get_current_week_range()
+
+    logger.info(f"Generating scorecard for {week_start} to {week_end}")
+
+    prediction_stats = get_weekly_prediction_stats(week_start, week_end)
+    accuracy = get_weekly_accuracy(week_start, week_end, timeframe="t7")
+    pnl = get_weekly_pnl(week_start, week_end, timeframe="t7")
+    top_wins = get_top_wins(week_start, week_end, limit=3)
+    worst_misses = get_worst_misses(week_start, week_end, limit=3)
+    asset_breakdown = get_asset_breakdown(week_start, week_end)
+    streak = get_weekly_streak()
+
+    # Optional: conviction voting leaderboard (Feature 11)
+    leaderboard = None
+    llm_vs_crowd = None
+    try:
+        from notifications.vote_db import get_leaderboard, get_llm_vs_crowd_stats
+
+        leaderboard = get_leaderboard(limit=5)
+        llm_vs_crowd = get_llm_vs_crowd_stats()
+    except ImportError:
+        pass  # Feature 11 not yet implemented
+
+    message = format_weekly_scorecard(
+        week_start=week_start,
+        week_end=week_end,
+        prediction_stats=prediction_stats,
+        accuracy=accuracy,
+        pnl=pnl,
+        top_wins=top_wins,
+        worst_misses=worst_misses,
+        asset_breakdown=asset_breakdown,
+        leaderboard=leaderboard,
+        llm_vs_crowd=llm_vs_crowd,
+        streak_info=streak,
+    )
+
+    return truncate_to_telegram_limit(message)
+
+
+def send_weekly_scorecard() -> dict:
+    """Generate and send the weekly scorecard to all active subscribers.
+
+    Returns:
+        Stats dict with sent, failed, skipped counts.
+    """
+    stats = {"sent": 0, "failed": 0, "skipped": 0}
+
+    message = generate_scorecard()
+
+    # Check if there's enough data
+    total = message.count("Total Predictions: 0")
+    if total > 0:
+        logger.info("No predictions this week, skipping scorecard")
+        return stats
+
+    subscriptions = get_active_subscriptions()
+    for sub in subscriptions:
+        chat_id = sub["chat_id"]
+
+        prefs = sub.get("alert_preferences", {})
+        if isinstance(prefs, str):
+            try:
+                prefs = json.loads(prefs)
+            except json.JSONDecodeError:
+                prefs = {}
+
+        if not prefs.get("scorecard_enabled", True):
+            stats["skipped"] += 1
+            continue
+
+        success, error = send_telegram_message(chat_id, message)
+        if success:
+            stats["sent"] += 1
+        else:
+            stats["failed"] += 1
+            logger.warning(f"Failed to send scorecard to {chat_id}: {error}")
+
+    logger.info(
+        f"Weekly scorecard: {stats['sent']} sent, "
+        f"{stats['failed']} failed, {stats['skipped']} skipped"
+    )
+    return stats
+
+
+def generate_and_send_scorecard(
+    chat_id: str,
+    preview: bool = False,
+) -> None:
+    """Generate and send a scorecard to a single chat (for /scorecard now).
+
+    Args:
+        chat_id: Telegram chat ID.
+        preview: If True, add a "PREVIEW" header.
+    """
+    message = generate_scorecard()
+    if preview:
+        message = "*PREVIEW \\- Not final*\n\n" + message
+
+    send_telegram_message(chat_id, message)

--- a/notifications/telegram_bot.py
+++ b/notifications/telegram_bot.py
@@ -1,7 +1,8 @@
 """
 Telegram Bot command handlers for Shitpost Alpha.
 
-Handles /start, /stop, /status, /settings, /watchlist, /briefing, /followups, /stats, /latest, /help
+Handles /start, /stop, /status, /settings, /watchlist, /briefing, /followups,
+/scorecard, /stats, /latest, /help
 commands and routes incoming webhook updates to the appropriate handler.
 """
 
@@ -70,6 +71,7 @@ You're now subscribed to receive real\\-time prediction alerts\\.
 /watchlist \\- Set which tickers you want alerts for
 /briefing \\- Morning briefing settings
 /followups \\- Follow\\-up message settings
+/scorecard \\- Weekly performance digest
 /settings \\- View/change your preferences
 /status \\- Check subscription status
 /stats \\- View prediction accuracy
@@ -358,6 +360,7 @@ def handle_help_command() -> str:
 /watchlist \\- Manage your ticker watchlist
 /briefing \\- Toggle morning briefing \\(8:30 AM ET\\)
 /followups \\- Toggle prediction follow\\-up messages
+/scorecard \\- Weekly performance scorecard
 /stats \\- View prediction accuracy stats
 /latest \\- Show recent predictions
 /help \\- Show this help message
@@ -485,6 +488,59 @@ def handle_followups_command(chat_id: str, args: str = "") -> str:
         "/followups off \\- Disable follow\\-ups\n"
         "`/followups 1h,7d` \\- Only get 1h and 7d follow\\-ups"
     )
+
+
+# ============================================================
+# Scorecard Command Handler
+# ============================================================
+
+
+def handle_scorecard_command(chat_id: str, args: str = "") -> str:
+    """Handle /scorecard command.
+
+    /scorecard       -- Show status and next delivery time
+    /scorecard on    -- Enable weekly scorecard (default)
+    /scorecard off   -- Disable weekly scorecard
+    /scorecard now   -- Send this week's scorecard immediately (preview)
+    """
+    arg = args.strip().lower()
+
+    if arg == "now":
+        from notifications.scorecard_service import generate_and_send_scorecard
+
+        generate_and_send_scorecard(chat_id=chat_id, preview=True)
+        return None  # Message sent directly by the service
+
+    sub = get_subscription(chat_id)
+    if not sub:
+        return "You're not subscribed\\. Send /start first\\."
+
+    prefs = sub.get("alert_preferences", {})
+    if isinstance(prefs, str):
+        try:
+            prefs = json.loads(prefs)
+        except json.JSONDecodeError:
+            prefs = {}
+
+    if arg == "off":
+        prefs["scorecard_enabled"] = False
+        update_subscription(chat_id, alert_preferences=prefs)
+        return "Weekly scorecard disabled\\. Send /scorecard on to re\\-enable\\."
+    elif arg == "on":
+        prefs["scorecard_enabled"] = True
+        update_subscription(chat_id, alert_preferences=prefs)
+        return "Weekly scorecard enabled\\. Delivery: Sunday 7 PM ET\\."
+    else:
+        current = prefs.get("scorecard_enabled", True)
+        status = "enabled" if current else "disabled"
+        return (
+            f"Weekly scorecard is currently *{status}*\\.\n"
+            "Delivery: Sunday 7 PM ET\n\n"
+            "*Commands:*\n"
+            "/scorecard off \\- Disable\n"
+            "/scorecard on \\- Enable\n"
+            "`/scorecard now` \\- Preview this week's scorecard"
+        )
 
 
 # ============================================================
@@ -846,6 +902,8 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
         response = handle_briefing_command(chat_id, args)
     elif command == "/followups":
         response = handle_followups_command(chat_id, args)
+    elif command == "/scorecard":
+        response = handle_scorecard_command(chat_id, args)
     elif command == "/stats":
         response = handle_stats_command(chat_id)
     elif command == "/latest":

--- a/notifications/telegram_bot.py
+++ b/notifications/telegram_bot.py
@@ -1,7 +1,7 @@
 """
 Telegram Bot command handlers for Shitpost Alpha.
 
-Handles /start, /stop, /status, /settings, /watchlist, /briefing, /stats, /latest, /help
+Handles /start, /stop, /status, /settings, /watchlist, /briefing, /followups, /stats, /latest, /help
 commands and routes incoming webhook updates to the appropriate handler.
 """
 
@@ -17,7 +17,7 @@ from notifications.db import (
     get_subscription,
     update_subscription,
 )
-from notifications.telegram_sender import send_telegram_message
+from notifications.telegram_sender import escape_markdown, send_telegram_message
 from shit.logging import get_service_logger
 
 logger = get_service_logger("telegram_bot")
@@ -69,6 +69,7 @@ You're now subscribed to receive real\\-time prediction alerts\\.
 *Commands:*
 /watchlist \\- Set which tickers you want alerts for
 /briefing \\- Morning briefing settings
+/followups \\- Follow\\-up message settings
 /settings \\- View/change your preferences
 /status \\- Check subscription status
 /stats \\- View prediction accuracy
@@ -356,6 +357,7 @@ def handle_help_command() -> str:
 /settings \\- View/change alert preferences
 /watchlist \\- Manage your ticker watchlist
 /briefing \\- Toggle morning briefing \\(8:30 AM ET\\)
+/followups \\- Toggle prediction follow\\-up messages
 /stats \\- View prediction accuracy stats
 /latest \\- Show recent predictions
 /help \\- Show this help message
@@ -422,6 +424,67 @@ def handle_briefing_command(chat_id: str, args: str = "") -> str:
             f"Morning briefings are currently *{status}*\\.\n\n"
             "Send /briefing on or /briefing off to change\\."
         )
+
+
+# ============================================================
+# Follow-ups Command Handler
+# ============================================================
+
+
+def handle_followups_command(chat_id: str, args: str = "") -> str:
+    """Handle /followups command — toggle follow-up messages.
+
+    Args:
+        chat_id: Telegram chat ID.
+        args: "on", "off", or empty for status. Also "1h,1d" for selective.
+
+    Returns:
+        Response message.
+    """
+    sub = get_subscription(chat_id)
+    if not sub:
+        return "You're not subscribed\\. Send /start first\\."
+
+    prefs = sub.get("alert_preferences", {})
+    if isinstance(prefs, str):
+        try:
+            prefs = json.loads(prefs)
+        except json.JSONDecodeError:
+            prefs = {}
+
+    current = prefs.get("followups_enabled", True)
+    current_horizons = prefs.get("followup_horizons", ["1h", "1d", "7d"])
+    arg = args.strip().lower()
+
+    if arg == "off":
+        prefs["followups_enabled"] = False
+        update_subscription(chat_id, alert_preferences=prefs)
+        return "Follow\\-up messages disabled\\. Send /followups on to re\\-enable\\."
+    elif arg == "on":
+        prefs["followups_enabled"] = True
+        update_subscription(chat_id, alert_preferences=prefs)
+        h_str = ", ".join(current_horizons)
+        return escape_markdown(f"Follow-up messages enabled for: {h_str}")
+    elif all(h in ("1h", "1d", "7d") for h in arg.replace(" ", "").split(",")):
+        horizons = [
+            h.strip() for h in arg.split(",") if h.strip() in ("1h", "1d", "7d")
+        ]
+        if horizons:
+            prefs["followup_horizons"] = horizons
+            prefs["followups_enabled"] = True
+            update_subscription(chat_id, alert_preferences=prefs)
+            return escape_markdown(f"Follow-ups set to: {', '.join(horizons)}")
+    # Default: show status
+    status = "enabled" if current else "disabled"
+    h_str = ", ".join(current_horizons)
+    return (
+        f"Follow\\-ups are currently *{status}*\\.\n"
+        f"Active horizons: {escape_markdown(h_str)}\n\n"
+        "*Commands:*\n"
+        "/followups on \\- Enable all follow\\-ups\n"
+        "/followups off \\- Disable follow\\-ups\n"
+        "`/followups 1h,7d` \\- Only get 1h and 7d follow\\-ups"
+    )
 
 
 # ============================================================
@@ -781,6 +844,8 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
         response = handle_watchlist_command(chat_id, args)
     elif command == "/briefing":
         response = handle_briefing_command(chat_id, args)
+    elif command == "/followups":
+        response = handle_followups_command(chat_id, args)
     elif command == "/stats":
         response = handle_stats_command(chat_id)
     elif command == "/latest":

--- a/notifications/telegram_bot.py
+++ b/notifications/telegram_bot.py
@@ -1,7 +1,7 @@
 """
 Telegram Bot command handlers for Shitpost Alpha.
 
-Handles /start, /stop, /status, /settings, /watchlist, /stats, /latest, /help
+Handles /start, /stop, /status, /settings, /watchlist, /briefing, /stats, /latest, /help
 commands and routes incoming webhook updates to the appropriate handler.
 """
 
@@ -68,6 +68,7 @@ You're now subscribed to receive real\\-time prediction alerts\\.
 
 *Commands:*
 /watchlist \\- Set which tickers you want alerts for
+/briefing \\- Morning briefing settings
 /settings \\- View/change your preferences
 /status \\- Check subscription status
 /stats \\- View prediction accuracy
@@ -354,6 +355,7 @@ def handle_help_command() -> str:
 /status \\- Check your subscription status
 /settings \\- View/change alert preferences
 /watchlist \\- Manage your ticker watchlist
+/briefing \\- Toggle morning briefing \\(8:30 AM ET\\)
 /stats \\- View prediction accuracy stats
 /latest \\- Show recent predictions
 /help \\- Show this help message
@@ -372,6 +374,54 @@ This bot sends alerts when our LLM detects high\\-confidence trading signals fro
 
 \u26a0\ufe0f _Not financial advice\\. For entertainment only\\._
 """
+
+
+# ============================================================
+# Briefing Command Handler
+# ============================================================
+
+
+def handle_briefing_command(chat_id: str, args: str = "") -> str:
+    """Handle /briefing command — toggle morning briefing.
+
+    Args:
+        chat_id: Telegram chat ID.
+        args: Command arguments ("on", "off", or empty for status).
+
+    Returns:
+        Response message.
+    """
+    sub = get_subscription(chat_id)
+    if not sub:
+        return "You're not subscribed\\. Send /start first\\."
+
+    prefs = sub.get("alert_preferences", {})
+    if isinstance(prefs, str):
+        try:
+            prefs = json.loads(prefs)
+        except json.JSONDecodeError:
+            prefs = {}
+
+    current = prefs.get("briefing_enabled", True)
+    arg = args.strip().lower()
+
+    if arg == "off":
+        prefs["briefing_enabled"] = False
+        update_subscription(chat_id, alert_preferences=prefs)
+        return "Morning briefings disabled\\. Send /briefing on to re\\-enable\\."
+    elif arg == "on":
+        prefs["briefing_enabled"] = True
+        update_subscription(chat_id, alert_preferences=prefs)
+        return (
+            "Morning briefings enabled\\! "
+            "You'll receive a digest at 8:30 AM ET on trading days\\."
+        )
+    else:
+        status = "enabled" if current else "disabled"
+        return (
+            f"Morning briefings are currently *{status}*\\.\n\n"
+            "Send /briefing on or /briefing off to change\\."
+        )
 
 
 # ============================================================
@@ -729,6 +779,8 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
         response = handle_settings_command(chat_id, args)
     elif command == "/watchlist":
         response = handle_watchlist_command(chat_id, args)
+    elif command == "/briefing":
+        response = handle_briefing_command(chat_id, args)
     elif command == "/stats":
         response = handle_stats_command(chat_id)
     elif command == "/latest":

--- a/shit_tests/notifications/test_briefing.py
+++ b/shit_tests/notifications/test_briefing.py
@@ -1,0 +1,484 @@
+"""Tests for pre-market morning briefing (Feature 07)."""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notifications.briefing import (
+    ET,
+    aggregate_by_asset,
+    format_briefing_message,
+    is_briefing_day,
+    is_briefing_time,
+    send_morning_briefing,
+)
+from notifications.telegram_bot import handle_briefing_command, process_update
+
+
+# ============================================================
+# Aggregation Tests
+# ============================================================
+
+
+class TestAggregateByAsset:
+    """Test aggregate_by_asset()."""
+
+    def test_single_asset(self):
+        predictions = [
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.85,
+                "post_text": "Tesla is failing",
+            },
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.78,
+                "post_text": "EV market crashing",
+            },
+        ]
+        result = aggregate_by_asset(predictions)
+        assert "TSLA" in result
+        assert result["TSLA"]["count"] == 2
+        assert result["TSLA"]["sentiment"] == "bearish"
+        assert result["TSLA"]["avg_confidence"] == pytest.approx(0.815)
+
+    def test_multiple_assets_sorted_by_count(self):
+        predictions = [
+            {
+                "market_impact": {"TSLA": "bearish", "F": "neutral"},
+                "confidence": 0.85,
+                "post_text": "Auto sector in trouble",
+            },
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.90,
+                "post_text": "Tesla bad",
+            },
+        ]
+        result = aggregate_by_asset(predictions)
+        symbols = list(result.keys())
+        assert symbols[0] == "TSLA"
+        assert result["TSLA"]["count"] == 2
+        assert result["F"]["count"] == 1
+
+    def test_empty_predictions(self):
+        result = aggregate_by_asset([])
+        assert result == {}
+
+    def test_mixed_sentiments_majority_wins(self):
+        predictions = [
+            {"market_impact": {"TSLA": "bearish"}, "confidence": 0.85, "post_text": ""},
+            {"market_impact": {"TSLA": "bearish"}, "confidence": 0.80, "post_text": ""},
+            {"market_impact": {"TSLA": "bullish"}, "confidence": 0.70, "post_text": ""},
+        ]
+        result = aggregate_by_asset(predictions)
+        assert result["TSLA"]["sentiment"] == "bearish"
+
+    def test_json_string_market_impact(self):
+        predictions = [
+            {
+                "market_impact": json.dumps({"AAPL": "bullish"}),
+                "confidence": 0.75,
+                "post_text": "Apple strong",
+            },
+        ]
+        result = aggregate_by_asset(predictions)
+        assert "AAPL" in result
+        assert result["AAPL"]["sentiment"] == "bullish"
+
+    def test_none_post_text(self):
+        predictions = [
+            {
+                "market_impact": {"SPY": "bearish"},
+                "confidence": 0.80,
+                "post_text": None,
+            },
+        ]
+        result = aggregate_by_asset(predictions)
+        assert result["SPY"]["predictions"][0]["text"] == ""
+
+    def test_confidence_range(self):
+        predictions = [
+            {"market_impact": {"TSLA": "bearish"}, "confidence": 0.90, "post_text": ""},
+            {"market_impact": {"TSLA": "bearish"}, "confidence": 0.70, "post_text": ""},
+        ]
+        result = aggregate_by_asset(predictions)
+        assert result["TSLA"]["min_confidence"] == 0.70
+        assert result["TSLA"]["max_confidence"] == 0.90
+
+
+# ============================================================
+# Formatting Tests
+# ============================================================
+
+
+class TestFormatBriefingMessage:
+    """Test format_briefing_message()."""
+
+    def test_quiet_night(self):
+        message = format_briefing_message("Wednesday, April 9, 2026", [], {})
+        assert "QUIET NIGHT" in message
+        assert "MORNING BRIEFING" in message
+        assert "April 9" in message
+
+    def test_active_night(self):
+        predictions = [
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.85,
+                "post_text": "Bad",
+            },
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.78,
+                "post_text": "Worse",
+            },
+            {"market_impact": {"F": "neutral"}, "confidence": 0.72, "post_text": "Ok"},
+        ]
+        asset_summary = aggregate_by_asset(predictions)
+        message = format_briefing_message(
+            "Wednesday, April 9, 2026", predictions, asset_summary
+        )
+        assert "3 posts analyzed" in message
+        assert "TSLA" in message
+        assert "ASSET BREAKDOWN" in message
+        assert "BEARISH" in message
+
+    def test_single_prediction(self):
+        predictions = [
+            {
+                "market_impact": {"NVDA": "bullish"},
+                "confidence": 0.90,
+                "post_text": "Chips",
+            },
+        ]
+        asset_summary = aggregate_by_asset(predictions)
+        message = format_briefing_message(
+            "Thursday, April 10, 2026", predictions, asset_summary
+        )
+        assert "1 post analyzed" in message
+        assert "NVDA" in message
+
+    def test_escapes_markdown(self):
+        predictions = [
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.85,
+                "post_text": "Tesla Inc. (TSLA) is failing!",
+            },
+        ]
+        asset_summary = aggregate_by_asset(predictions)
+        message = format_briefing_message("April 9, 2026", predictions, asset_summary)
+        # Dots and parens should be escaped
+        assert "Inc\\." in message
+        assert "\\(TSLA\\)" in message
+
+    def test_under_telegram_limit(self):
+        # Generate a large but reasonable briefing
+        predictions = []
+        for i in range(10):
+            predictions.append(
+                {
+                    "market_impact": {f"T{i:02d}": "bearish"},
+                    "confidence": 0.80,
+                    "post_text": f"Post about ticker T{i:02d} with some content",
+                }
+            )
+        asset_summary = aggregate_by_asset(predictions)
+        message = format_briefing_message("April 9, 2026", predictions, asset_summary)
+        assert len(message) <= 4096
+
+    def test_footer_present(self):
+        message = format_briefing_message("April 9, 2026", [], {})
+        assert "NOT financial advice" in message
+        assert "/briefing off" in message
+
+    def test_truncation_for_many_assets(self):
+        """Very large briefing triggers compact format."""
+        predictions = []
+        for i in range(50):
+            predictions.append(
+                {
+                    "market_impact": {f"TICK{i:03d}": "bearish"},
+                    "confidence": 0.80,
+                    "post_text": "A" * 80,
+                }
+            )
+        asset_summary = aggregate_by_asset(predictions)
+        message = format_briefing_message("April 9, 2026", predictions, asset_summary)
+        assert len(message) <= 4096
+
+
+# ============================================================
+# Scheduling Tests
+# ============================================================
+
+
+class TestScheduling:
+    """Test briefing time and day checks."""
+
+    def test_is_briefing_time_correct(self):
+        t = datetime(2026, 4, 9, 8, 30, tzinfo=ET)
+        assert is_briefing_time(t) is True
+
+    def test_is_briefing_time_early(self):
+        t = datetime(2026, 4, 9, 8, 20, tzinfo=ET)
+        assert is_briefing_time(t) is False
+
+    def test_is_briefing_time_late(self):
+        t = datetime(2026, 4, 9, 8, 40, tzinfo=ET)
+        assert is_briefing_time(t) is False
+
+    def test_is_briefing_time_wrong_hour(self):
+        t = datetime(2026, 4, 9, 15, 30, tzinfo=ET)
+        assert is_briefing_time(t) is False
+
+    def test_is_briefing_time_edge_25(self):
+        t = datetime(2026, 4, 9, 8, 25, tzinfo=ET)
+        assert is_briefing_time(t) is True
+
+    def test_is_briefing_time_edge_35(self):
+        t = datetime(2026, 4, 9, 8, 35, tzinfo=ET)
+        assert is_briefing_time(t) is True
+
+    @patch("notifications.briefing.MarketCalendar")
+    def test_is_briefing_day_trading_day(self, mock_cal_cls):
+        mock_cal = MagicMock()
+        mock_cal.is_trading_day.return_value = True
+        mock_cal_cls.return_value = mock_cal
+
+        t = datetime(2026, 4, 9, 8, 30, tzinfo=ET)  # Wednesday
+        assert is_briefing_day(t) is True
+
+    @patch("notifications.briefing.MarketCalendar")
+    def test_is_briefing_day_weekend(self, mock_cal_cls):
+        mock_cal = MagicMock()
+        mock_cal.is_trading_day.return_value = False
+        mock_cal_cls.return_value = mock_cal
+
+        t = datetime(2026, 4, 12, 8, 30, tzinfo=ET)  # Saturday
+        assert is_briefing_day(t) is False
+
+
+# ============================================================
+# Subscriber Preference Tests
+# ============================================================
+
+
+class TestBriefingCommand:
+    """Test /briefing command handler."""
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_not_subscribed(self, mock_get_sub):
+        mock_get_sub.return_value = None
+        result = handle_briefing_command("123")
+        assert "not subscribed" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_briefing_off(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": True}}
+        mock_update.return_value = True
+        result = handle_briefing_command("123", "off")
+        assert "disabled" in result
+        call_args = mock_update.call_args
+        prefs = call_args[1]["alert_preferences"]
+        assert prefs["briefing_enabled"] is False
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_briefing_on(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": False}}
+        mock_update.return_value = True
+        result = handle_briefing_command("123", "on")
+        assert "enabled" in result
+        assert "8:30 AM ET" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_briefing_status_enabled(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": True}}
+        result = handle_briefing_command("123")
+        assert "enabled" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_briefing_status_disabled(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": False}}
+        result = handle_briefing_command("123")
+        assert "disabled" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_briefing_default_enabled(self, mock_get_sub):
+        """New subscribers default to briefing enabled."""
+        mock_get_sub.return_value = {"alert_preferences": {}}
+        result = handle_briefing_command("123")
+        assert "enabled" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_json_string_prefs(self, mock_get_sub):
+        mock_get_sub.return_value = {
+            "alert_preferences": json.dumps({"briefing_enabled": True})
+        }
+        result = handle_briefing_command("123")
+        assert "enabled" in result
+
+
+# ============================================================
+# Send Morning Briefing Tests
+# ============================================================
+
+
+class TestSendMorningBriefing:
+    """Test send_morning_briefing() orchestrator."""
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_sends_to_opted_in(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = []
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {"briefing_enabled": True}},
+            {"chat_id": "222", "alert_preferences": {"briefing_enabled": True}},
+        ]
+        mock_send.return_value = (True, None)
+
+        results = send_morning_briefing()
+        assert results["sent"] == 2
+        assert results["skipped"] == 0
+        assert mock_send.call_count == 2
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_skips_opted_out(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = []
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {"briefing_enabled": True}},
+            {"chat_id": "222", "alert_preferences": {"briefing_enabled": False}},
+        ]
+        mock_send.return_value = (True, None)
+
+        results = send_morning_briefing()
+        assert results["sent"] == 1
+        assert results["skipped"] == 1
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_default_enabled(self, mock_preds, mock_subs, mock_send):
+        """Subscribers without explicit pref default to enabled."""
+        mock_preds.return_value = []
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {}},
+        ]
+        mock_send.return_value = (True, None)
+
+        results = send_morning_briefing()
+        assert results["sent"] == 1
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_handles_send_failure(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = []
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {}},
+        ]
+        mock_send.return_value = (False, "Bot blocked")
+
+        results = send_morning_briefing()
+        assert results["sent"] == 0
+        assert results["failed"] == 1
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_no_subscribers(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = []
+        mock_subs.return_value = []
+
+        results = send_morning_briefing()
+        assert results["sent"] == 0
+        assert results["total_subscribers"] == 0
+        mock_send.assert_not_called()
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_json_string_prefs(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = []
+        mock_subs.return_value = [
+            {
+                "chat_id": "111",
+                "alert_preferences": json.dumps({"briefing_enabled": True}),
+            },
+        ]
+        mock_send.return_value = (True, None)
+
+        results = send_morning_briefing()
+        assert results["sent"] == 1
+
+    @patch("notifications.briefing.send_telegram_message")
+    @patch("notifications.briefing.get_active_subscriptions")
+    @patch("notifications.briefing.get_overnight_predictions")
+    def test_predictions_count_tracked(self, mock_preds, mock_subs, mock_send):
+        mock_preds.return_value = [
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.85,
+                "post_text": "Bad",
+            },
+            {
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.80,
+                "post_text": "Worse",
+            },
+        ]
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {}},
+        ]
+        mock_send.return_value = (True, None)
+
+        results = send_morning_briefing()
+        assert results["predictions_count"] == 2
+
+
+# ============================================================
+# Process Update Routing Tests
+# ============================================================
+
+
+class TestProcessUpdateBriefing:
+    """Test /briefing routing through process_update."""
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_routes_to_briefing_handler(self, mock_get_sub, mock_send):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": True}}
+        update = {
+            "message": {
+                "chat": {"id": 123, "type": "private"},
+                "from": {"username": "testuser"},
+                "text": "/briefing",
+            }
+        }
+        result = process_update(update)
+        assert result is not None
+        assert "enabled" in result
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_routes_briefing_off(self, mock_get_sub, mock_update, mock_send):
+        mock_get_sub.return_value = {"alert_preferences": {"briefing_enabled": True}}
+        mock_update.return_value = True
+        update = {
+            "message": {
+                "chat": {"id": 123, "type": "private"},
+                "from": {"username": "testuser"},
+                "text": "/briefing off",
+            }
+        }
+        result = process_update(update)
+        assert "disabled" in result

--- a/shit_tests/notifications/test_followups.py
+++ b/shit_tests/notifications/test_followups.py
@@ -1,0 +1,480 @@
+"""Tests for 'What Happened' follow-up messages (Feature 08)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from notifications.followups import (
+    _is_data_available,
+    _is_horizon_due,
+    _should_abandon,
+    create_followup_tracking,
+    format_followup_message,
+    process_due_followups,
+)
+from notifications.telegram_bot import handle_followups_command, process_update
+
+
+# ============================================================
+# Follow-up Creation Tests
+# ============================================================
+
+
+class TestCreateFollowupTracking:
+    """Test follow-up row creation."""
+
+    @patch("notifications.followups._execute_write")
+    def test_creates_with_correct_params(self, mock_write):
+        mock_write.return_value = True
+        now = datetime(2026, 4, 9, 14, 0, tzinfo=timezone.utc)
+        result = create_followup_tracking(
+            prediction_id=42, chat_id="123", alert_sent_at=now
+        )
+        assert result is True
+        call_args = mock_write.call_args
+        params = call_args[1]["params"] if "params" in call_args[1] else call_args[0][1]
+        assert params["prediction_id"] == 42
+        assert params["chat_id"] == "123"
+        # First check should be alert_time + 65 minutes
+        expected_check = now + timedelta(minutes=65)
+        assert params["next_check_at"] == expected_check
+
+    @patch("notifications.followups._execute_write")
+    def test_idempotent_on_conflict(self, mock_write):
+        """ON CONFLICT DO NOTHING means duplicates are safe."""
+        mock_write.return_value = True
+        now = datetime(2026, 4, 9, 14, 0, tzinfo=timezone.utc)
+        create_followup_tracking(42, "123", now)
+        create_followup_tracking(42, "123", now)
+        assert mock_write.call_count == 2  # Both calls execute, DB handles dedup
+
+
+# ============================================================
+# Data Availability Tests
+# ============================================================
+
+
+class TestDataAvailability:
+    """Test data availability checks."""
+
+    def test_1h_available(self):
+        outcome = {"return_1h": -0.8}
+        assert _is_data_available(outcome, "1h") is True
+
+    def test_1h_not_available(self):
+        outcome = {"return_1h": None}
+        assert _is_data_available(outcome, "1h") is False
+
+    def test_1d_available(self):
+        outcome = {"return_t1": -1.2}
+        assert _is_data_available(outcome, "1d") is True
+
+    def test_7d_not_available(self):
+        outcome = {"return_t7": None}
+        assert _is_data_available(outcome, "7d") is False
+
+    def test_abandon_after_max_deferral(self):
+        """After expected time + 48h, abandon the horizon."""
+        alert_time = datetime.now(timezone.utc) - timedelta(
+            hours=100
+        )  # Well past 1h + 48h
+        followup = {"original_alert_sent_at": alert_time}
+        assert _should_abandon(followup, "1h") is True
+
+    def test_no_abandon_within_window(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        followup = {"original_alert_sent_at": alert_time}
+        assert _should_abandon(followup, "1h") is False
+
+
+# ============================================================
+# Horizon Due Tests
+# ============================================================
+
+
+class TestIsHorizonDue:
+    """Test horizon due logic."""
+
+    def test_1h_due_after_1_hour(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(hours=1, minutes=5)
+        followup = {"original_alert_sent_at": alert_time, "sent_1h": None}
+        assert _is_horizon_due(followup, "1h") is True
+
+    def test_1h_not_due_too_early(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(minutes=30)
+        followup = {"original_alert_sent_at": alert_time, "sent_1h": None}
+        assert _is_horizon_due(followup, "1h") is False
+
+    def test_already_sent_not_due(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(hours=2)
+        followup = {"original_alert_sent_at": alert_time, "sent_1h": True}
+        assert _is_horizon_due(followup, "1h") is False
+
+    def test_abandoned_not_due(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(hours=2)
+        followup = {"original_alert_sent_at": alert_time, "sent_1h": False}
+        assert _is_horizon_due(followup, "1h") is False
+
+    def test_1d_due_after_20_hours(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(hours=21)
+        followup = {"original_alert_sent_at": alert_time, "sent_1d": None}
+        assert _is_horizon_due(followup, "1d") is True
+
+    def test_7d_due_after_9_days(self):
+        alert_time = datetime.now(timezone.utc) - timedelta(days=10)
+        followup = {"original_alert_sent_at": alert_time, "sent_7d": None}
+        assert _is_horizon_due(followup, "7d") is True
+
+
+# ============================================================
+# Message Formatting Tests
+# ============================================================
+
+
+class TestFormatFollowupMessage:
+    """Test follow-up message formatting."""
+
+    def test_1h_single_asset_correct(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_1h_after": 243.20,
+                "return_1h": -0.9,
+                "correct_1h": True,
+                "pnl_1h": 9.0,
+            }
+        ]
+        message = format_followup_message("1h", outcomes)
+        assert "UPDATE" in message
+        assert "TSLA" in message
+        assert "CORRECT" in message
+        assert "1 hour later" in message
+
+    def test_1h_single_asset_incorrect(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_1h_after": 247.10,
+                "return_1h": 0.7,
+                "correct_1h": False,
+                "pnl_1h": -7.0,
+            }
+        ]
+        message = format_followup_message("1h", outcomes)
+        assert "INCORRECT" in message
+
+    def test_1d_with_pnl(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_t1": 241.30,
+                "return_t1": -1.7,
+                "correct_t1": True,
+                "pnl_t1": 17.10,
+            }
+        ]
+        message = format_followup_message("1d", outcomes)
+        assert "VERDICT" in message
+        assert "P&L" in message
+        assert "gained" in message
+        assert "17" in message
+
+    def test_7d_final_result(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_t7": 237.20,
+                "return_t7": -3.4,
+                "correct_t7": True,
+                "pnl_t7": 33.80,
+            }
+        ]
+        message = format_followup_message("7d", outcomes)
+        assert "FINAL RESULT" in message
+        assert "7 trading days" in message
+
+    def test_multi_asset(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_t1": 241.30,
+                "return_t1": -1.7,
+                "correct_t1": True,
+                "pnl_t1": 17.10,
+            },
+            {
+                "symbol": "F",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.78,
+                "price_at_post": 12.80,
+                "price_t1": 12.65,
+                "return_t1": -1.2,
+                "correct_t1": True,
+                "pnl_t1": 11.70,
+            },
+        ]
+        message = format_followup_message("1d", outcomes)
+        assert "2 assets" in message
+        assert "TSLA" in message
+        assert "F:" in message  # Note: "F" with colon
+        assert "Overall" in message
+
+    def test_escapes_markdown(self):
+        outcomes = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_1h_after": 243.20,
+                "return_1h": -0.9,
+                "correct_1h": True,
+                "pnl_1h": 9.0,
+            }
+        ]
+        message = format_followup_message("1h", outcomes)
+        # Dots and parens should be escaped in MarkdownV2
+        assert "\\." in message
+        assert "\\(" in message
+
+    def test_1d_loss_pnl(self):
+        outcomes = [
+            {
+                "symbol": "META",
+                "prediction_sentiment": "bullish",
+                "prediction_confidence": 0.73,
+                "price_at_post": 500.00,
+                "price_t1": 496.00,
+                "return_t1": -0.8,
+                "correct_t1": False,
+                "pnl_t1": -8.00,
+            }
+        ]
+        message = format_followup_message("1d", outcomes)
+        assert "lost" in message
+
+    def test_footer_present(self):
+        outcomes = [
+            {
+                "symbol": "SPY",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.80,
+                "price_at_post": 500.00,
+                "price_1h_after": 499.00,
+                "return_1h": -0.2,
+                "correct_1h": True,
+                "pnl_1h": 2.0,
+            }
+        ]
+        message = format_followup_message("1h", outcomes)
+        assert "/followups off" in message
+
+
+# ============================================================
+# /followups Command Tests
+# ============================================================
+
+
+class TestFollowupsCommand:
+    """Test /followups bot command."""
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_not_subscribed(self, mock_get_sub):
+        mock_get_sub.return_value = None
+        result = handle_followups_command("123")
+        assert "not subscribed" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_followups_off(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"followups_enabled": True}}
+        mock_update.return_value = True
+        result = handle_followups_command("123", "off")
+        assert "disabled" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_followups_on(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"followups_enabled": False}}
+        mock_update.return_value = True
+        result = handle_followups_command("123", "on")
+        assert "enabled" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_followups_status(self, mock_get_sub):
+        mock_get_sub.return_value = {
+            "alert_preferences": {
+                "followups_enabled": True,
+                "followup_horizons": ["1h", "1d", "7d"],
+            }
+        }
+        result = handle_followups_command("123")
+        assert "enabled" in result
+        assert "1h" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_selective_horizons(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {}}
+        mock_update.return_value = True
+        result = handle_followups_command("123", "1h,7d")
+        assert "1h" in result
+        assert "7d" in result
+        call_args = mock_update.call_args
+        prefs = call_args[1]["alert_preferences"]
+        assert prefs["followup_horizons"] == ["1h", "7d"]
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_default_enabled(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {}}
+        result = handle_followups_command("123")
+        assert "enabled" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_json_string_prefs(self, mock_get_sub):
+        mock_get_sub.return_value = {
+            "alert_preferences": json.dumps({"followups_enabled": True})
+        }
+        result = handle_followups_command("123")
+        assert "enabled" in result
+
+
+# ============================================================
+# Process Due Follow-ups Tests
+# ============================================================
+
+
+class TestProcessDueFollowups:
+    """Test process_due_followups orchestrator."""
+
+    @patch("notifications.followups.get_due_followups")
+    def test_empty_returns_zeros(self, mock_due):
+        mock_due.return_value = []
+        results = process_due_followups()
+        assert results["checked"] == 0
+        assert results["sent"] == 0
+
+    @patch("notifications.followups.time_module")
+    @patch("notifications.followups.send_telegram_message")
+    @patch("notifications.followups._get_subscriber_prefs")
+    @patch("notifications.followups._check_daily_limit")
+    @patch("notifications.followups.get_followup_outcomes")
+    @patch("notifications.followups._update_followup_sent")
+    @patch("notifications.followups._defer_followup")
+    @patch("notifications.followups.get_due_followups")
+    def test_sends_when_data_available(
+        self,
+        mock_due,
+        mock_defer,
+        mock_update_sent,
+        mock_outcomes,
+        mock_limit,
+        mock_prefs,
+        mock_send,
+        mock_time,
+    ):
+        now = datetime.now(timezone.utc)
+        mock_due.return_value = [
+            {
+                "id": 1,
+                "prediction_id": 42,
+                "chat_id": "123",
+                "sent_1h": None,
+                "sent_1d": None,
+                "sent_7d": None,
+                "original_alert_sent_at": now - timedelta(hours=2),
+                "next_check_at": now - timedelta(minutes=5),
+                "assets": ["TSLA"],
+                "market_impact": {"TSLA": "bearish"},
+                "confidence": 0.85,
+                "calibrated_confidence": None,
+                "post_text": "Bad news",
+            }
+        ]
+        mock_limit.return_value = True
+        mock_prefs.return_value = {
+            "followups_enabled": True,
+            "followup_horizons": ["1h", "1d", "7d"],
+        }
+        mock_outcomes.return_value = [
+            {
+                "symbol": "TSLA",
+                "prediction_sentiment": "bearish",
+                "prediction_confidence": 0.85,
+                "price_at_post": 245.50,
+                "price_1h_after": 243.20,
+                "return_1h": -0.9,
+                "correct_1h": True,
+                "pnl_1h": 9.0,
+                "return_t1": None,
+                "return_t7": None,
+            }
+        ]
+        mock_send.return_value = (True, None)
+        mock_update_sent.return_value = True
+
+        results = process_due_followups()
+        assert results["sent"] == 1
+        mock_send.assert_called_once()
+        mock_update_sent.assert_called_once()
+
+    @patch("notifications.followups._check_daily_limit")
+    @patch("notifications.followups.get_due_followups")
+    def test_respects_daily_limit(self, mock_due, mock_limit):
+        now = datetime.now(timezone.utc)
+        mock_due.return_value = [
+            {
+                "id": 1,
+                "prediction_id": 42,
+                "chat_id": "123",
+                "sent_1h": None,
+                "sent_1d": None,
+                "sent_7d": None,
+                "original_alert_sent_at": now - timedelta(hours=2),
+                "next_check_at": now,
+            }
+        ]
+        mock_limit.return_value = False  # Limit reached
+
+        results = process_due_followups()
+        assert results["skipped"] == 1
+        assert results["sent"] == 0
+
+
+# ============================================================
+# Process Update Routing Tests
+# ============================================================
+
+
+class TestProcessUpdateFollowups:
+    """Test /followups routing through process_update."""
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_routes_to_followups_handler(self, mock_get_sub, mock_send):
+        mock_get_sub.return_value = {"alert_preferences": {"followups_enabled": True}}
+        update = {
+            "message": {
+                "chat": {"id": 123, "type": "private"},
+                "from": {"username": "testuser"},
+                "text": "/followups",
+            }
+        }
+        result = process_update(update)
+        assert result is not None
+        assert "enabled" in result

--- a/shit_tests/notifications/test_scorecard.py
+++ b/shit_tests/notifications/test_scorecard.py
@@ -1,0 +1,403 @@
+"""Tests for weekly scorecard (Feature 12)."""
+
+from datetime import date
+from unittest.mock import patch
+
+from notifications.scorecard_formatter import (
+    format_weekly_scorecard,
+    truncate_to_telegram_limit,
+)
+from notifications.scorecard_service import (
+    generate_scorecard,
+    get_current_week_range,
+    send_weekly_scorecard,
+)
+from notifications.telegram_bot import handle_scorecard_command, process_update
+
+
+# ============================================================
+# Formatter Tests
+# ============================================================
+
+
+class TestScorecardFormatter:
+    """Test format_weekly_scorecard()."""
+
+    def _make_scorecard(self, **overrides):
+        """Build a scorecard with sensible defaults."""
+        defaults = {
+            "week_start": date(2026, 4, 7),
+            "week_end": date(2026, 4, 13),
+            "prediction_stats": {
+                "total_predictions": 15,
+                "completed": 12,
+                "bypassed": 3,
+                "errors": 0,
+                "avg_confidence": 0.77,
+            },
+            "accuracy": {
+                "correct": 8,
+                "incorrect": 3,
+                "pending": 1,
+                "bullish_correct": 5,
+                "bullish_total": 7,
+                "bearish_correct": 3,
+                "bearish_total": 4,
+            },
+            "pnl": {
+                "total_pnl": 187.5,
+                "best_pnl": 42.0,
+                "worst_pnl": -12.0,
+                "trade_count": 11,
+            },
+            "top_wins": [
+                {
+                    "symbol": "TSLA",
+                    "sentiment": "bullish",
+                    "confidence": 0.92,
+                    "return_pct": 4.2,
+                    "pnl": 42.0,
+                },
+            ],
+            "worst_misses": [
+                {
+                    "symbol": "F",
+                    "sentiment": "bearish",
+                    "confidence": 0.81,
+                    "return_pct": 1.2,
+                    "pnl": -12.0,
+                },
+            ],
+            "asset_breakdown": [
+                {
+                    "symbol": "TSLA",
+                    "signal_count": 5,
+                    "accuracy_pct": 80.0,
+                    "total_pnl": 67.5,
+                },
+            ],
+        }
+        defaults.update(overrides)
+        return format_weekly_scorecard(**defaults)
+
+    def test_includes_header(self):
+        message = self._make_scorecard()
+        assert "WEEKLY SCORECARD" in message
+        assert "Apr" in message
+
+    def test_includes_signals_section(self):
+        message = self._make_scorecard()
+        assert "SIGNALS" in message
+        assert "15" in message  # total
+        assert "12" in message  # completed
+
+    def test_includes_accuracy(self):
+        message = self._make_scorecard()
+        assert "ACCURACY" in message
+        assert "73%" in message  # 8/11 = 72.7%
+
+    def test_includes_pnl(self):
+        message = self._make_scorecard()
+        assert "P&L" in message
+        assert "187" in message
+
+    def test_includes_top_wins(self):
+        message = self._make_scorecard()
+        assert "TOP WINS" in message
+        assert "TSLA" in message
+
+    def test_includes_misses(self):
+        message = self._make_scorecard()
+        assert "BIGGEST MISSES" in message
+        assert "F" in message
+
+    def test_includes_asset_breakdown(self):
+        message = self._make_scorecard()
+        assert "TOP ASSETS" in message
+        assert "5 signals" in message
+
+    def test_no_misses_when_all_positive(self):
+        message = self._make_scorecard(worst_misses=[{"symbol": "TSLA", "pnl": 5.0}])
+        assert "BIGGEST MISSES" not in message
+
+    def test_footer_present(self):
+        message = self._make_scorecard()
+        assert "NOT financial advice" in message
+        assert "/scorecard off" in message
+
+    def test_with_leaderboard(self):
+        message = self._make_scorecard(
+            leaderboard=[
+                {
+                    "display_name": "TraderJoe",
+                    "accuracy_pct": 78,
+                    "correct": 7,
+                    "evaluated": 9,
+                },
+            ],
+        )
+        assert "LEADERBOARD" in message
+        assert "TraderJoe" in message
+
+    def test_without_leaderboard(self):
+        message = self._make_scorecard(leaderboard=None)
+        assert "LEADERBOARD" not in message
+
+    def test_with_streak(self):
+        message = self._make_scorecard(
+            streak_info={"streak_type": "winning", "streak_length": 3}
+        )
+        assert "3 winning weeks" in message
+
+    def test_no_streak(self):
+        message = self._make_scorecard(
+            streak_info={"streak_type": None, "streak_length": 0}
+        )
+        assert "Streak" not in message
+
+    def test_pending_shown(self):
+        message = self._make_scorecard()
+        assert "Pending" in message
+
+    def test_no_pending_when_zero(self):
+        accuracy = {
+            "correct": 8,
+            "incorrect": 3,
+            "pending": 0,
+            "bullish_correct": 5,
+            "bullish_total": 7,
+            "bearish_correct": 3,
+            "bearish_total": 4,
+        }
+        message = self._make_scorecard(accuracy=accuracy)
+        assert "Pending" not in message
+
+    def test_under_telegram_limit(self):
+        message = self._make_scorecard()
+        assert len(message) <= 4096
+
+    def test_empty_week(self):
+        message = self._make_scorecard(
+            prediction_stats={
+                "total_predictions": 0,
+                "completed": 0,
+                "bypassed": 0,
+                "avg_confidence": 0,
+            },
+            accuracy={
+                "correct": 0,
+                "incorrect": 0,
+                "pending": 0,
+                "bullish_correct": 0,
+                "bullish_total": 0,
+                "bearish_correct": 0,
+                "bearish_total": 0,
+            },
+            pnl={"total_pnl": 0, "best_pnl": 0, "worst_pnl": 0, "trade_count": 0},
+            top_wins=[],
+            worst_misses=[],
+            asset_breakdown=[],
+        )
+        assert "WEEKLY SCORECARD" in message
+        assert "N/A" in message
+
+
+class TestTruncation:
+    """Test truncate_to_telegram_limit."""
+
+    def test_short_message_unchanged(self):
+        msg = "Short message"
+        assert truncate_to_telegram_limit(msg) == msg
+
+    def test_long_message_truncated(self):
+        msg = "Line\n" * 2000
+        result = truncate_to_telegram_limit(msg)
+        assert len(result) <= 4096
+        assert "truncated" in result
+
+
+# ============================================================
+# Service Tests
+# ============================================================
+
+
+class TestScorecardService:
+    """Test scorecard service."""
+
+    def test_get_current_week_range(self):
+        monday, sunday = get_current_week_range()
+        assert monday.weekday() == 0  # Monday
+        assert sunday.weekday() == 6  # Sunday
+        assert (sunday - monday).days == 6
+
+    @patch("notifications.scorecard_service.send_telegram_message")
+    @patch("notifications.scorecard_service.get_active_subscriptions")
+    @patch("notifications.scorecard_service.get_weekly_streak")
+    @patch("notifications.scorecard_service.get_asset_breakdown")
+    @patch("notifications.scorecard_service.get_worst_misses")
+    @patch("notifications.scorecard_service.get_top_wins")
+    @patch("notifications.scorecard_service.get_weekly_pnl")
+    @patch("notifications.scorecard_service.get_weekly_accuracy")
+    @patch("notifications.scorecard_service.get_weekly_prediction_stats")
+    def test_sends_to_opted_in(
+        self,
+        mock_stats,
+        mock_acc,
+        mock_pnl,
+        mock_wins,
+        mock_misses,
+        mock_assets,
+        mock_streak,
+        mock_subs,
+        mock_send,
+    ):
+        mock_stats.return_value = {
+            "total_predictions": 10,
+            "completed": 8,
+            "bypassed": 2,
+            "avg_confidence": 0.8,
+        }
+        mock_acc.return_value = {
+            "correct": 5,
+            "incorrect": 3,
+            "pending": 0,
+            "bullish_correct": 3,
+            "bullish_total": 5,
+            "bearish_correct": 2,
+            "bearish_total": 3,
+        }
+        mock_pnl.return_value = {
+            "total_pnl": 100.0,
+            "best_pnl": 30.0,
+            "worst_pnl": -10.0,
+            "trade_count": 8,
+        }
+        mock_wins.return_value = []
+        mock_misses.return_value = []
+        mock_assets.return_value = []
+        mock_streak.return_value = {"streak_type": None, "streak_length": 0}
+        mock_subs.return_value = [
+            {"chat_id": "111", "alert_preferences": {"scorecard_enabled": True}},
+            {"chat_id": "222", "alert_preferences": {"scorecard_enabled": False}},
+        ]
+        mock_send.return_value = (True, None)
+
+        stats = send_weekly_scorecard()
+        assert stats["sent"] == 1
+        assert stats["skipped"] == 1
+
+    @patch("notifications.scorecard_service.get_weekly_streak")
+    @patch("notifications.scorecard_service.get_asset_breakdown")
+    @patch("notifications.scorecard_service.get_worst_misses")
+    @patch("notifications.scorecard_service.get_top_wins")
+    @patch("notifications.scorecard_service.get_weekly_pnl")
+    @patch("notifications.scorecard_service.get_weekly_accuracy")
+    @patch("notifications.scorecard_service.get_weekly_prediction_stats")
+    def test_generate_scorecard_returns_string(
+        self,
+        mock_stats,
+        mock_acc,
+        mock_pnl,
+        mock_wins,
+        mock_misses,
+        mock_assets,
+        mock_streak,
+    ):
+        mock_stats.return_value = {
+            "total_predictions": 5,
+            "completed": 5,
+            "bypassed": 0,
+            "avg_confidence": 0.75,
+        }
+        mock_acc.return_value = {
+            "correct": 3,
+            "incorrect": 2,
+            "pending": 0,
+            "bullish_correct": 2,
+            "bullish_total": 3,
+            "bearish_correct": 1,
+            "bearish_total": 2,
+        }
+        mock_pnl.return_value = {
+            "total_pnl": 50.0,
+            "best_pnl": 20.0,
+            "worst_pnl": -5.0,
+            "trade_count": 5,
+        }
+        mock_wins.return_value = []
+        mock_misses.return_value = []
+        mock_assets.return_value = []
+        mock_streak.return_value = {"streak_type": None, "streak_length": 0}
+
+        result = generate_scorecard(date(2026, 4, 7), date(2026, 4, 13))
+        assert isinstance(result, str)
+        assert "WEEKLY SCORECARD" in result
+
+
+# ============================================================
+# Bot Command Tests
+# ============================================================
+
+
+class TestScorecardCommand:
+    """Test /scorecard bot command."""
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_not_subscribed(self, mock_get_sub):
+        mock_get_sub.return_value = None
+        result = handle_scorecard_command("123")
+        assert "not subscribed" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_scorecard_off(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"scorecard_enabled": True}}
+        mock_update.return_value = True
+        result = handle_scorecard_command("123", "off")
+        assert "disabled" in result
+
+    @patch("notifications.telegram_bot.update_subscription")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_scorecard_on(self, mock_get_sub, mock_update):
+        mock_get_sub.return_value = {"alert_preferences": {"scorecard_enabled": False}}
+        mock_update.return_value = True
+        result = handle_scorecard_command("123", "on")
+        assert "enabled" in result
+        assert "Sunday" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_scorecard_status(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {"scorecard_enabled": True}}
+        result = handle_scorecard_command("123")
+        assert "enabled" in result
+        assert "Sunday" in result
+
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_default_enabled(self, mock_get_sub):
+        mock_get_sub.return_value = {"alert_preferences": {}}
+        result = handle_scorecard_command("123")
+        assert "enabled" in result
+
+
+# ============================================================
+# Process Update Routing
+# ============================================================
+
+
+class TestProcessUpdateScorecard:
+    """Test /scorecard routing through process_update."""
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    @patch("notifications.telegram_bot.get_subscription")
+    def test_routes_to_scorecard_handler(self, mock_get_sub, mock_send):
+        mock_get_sub.return_value = {"alert_preferences": {"scorecard_enabled": True}}
+        update = {
+            "message": {
+                "chat": {"id": 123, "type": "private"},
+                "from": {"username": "testuser"},
+                "text": "/scorecard",
+            }
+        }
+        result = process_update(update)
+        assert result is not None
+        assert "enabled" in result


### PR DESCRIPTION
## Summary
- **Feature 07: Pre-Market Briefing** — Daily 8:30 AM ET digest summarizing overnight Trump activity with per-asset sentiment breakdown, confidence ranges, and post previews. Quiet night messages when no activity. `/briefing` on/off command.
- **Feature 08: "What Happened" Follow-Ups** — Automatic T+1h, T+1d, T+7d follow-up messages showing actual market moves vs predictions with P&L simulation. `alert_followups` table with state machine. Fail-open integration in alert engine and event consumer. `/followups` on/off/selective horizons.
- **Feature 12: Weekly Scorecard** — Sunday evening performance digest with accuracy by sentiment, simulated P&L, top wins/misses, per-asset breakdown, and streak tracking. Optional Feature 11 leaderboard integration. `/scorecard` on/off/preview.

All 3 features use `python -m notifications <subcommand>` CLI pattern. 99 new tests (38 + 33 + 28), 285 total notification tests passing.

## Production Deployment
- **Feature 07**: New Railway service `briefing-sender`, cron `30 12 * * 1-5` and `30 13 * * 1-5` (DST handling)
- **Feature 08**: `CREATE TABLE alert_followups` migration required. New Railway service `followup-sender`, cron `*/5 * * * *`
- **Feature 12**: New Railway service `weekly-scorecard`, cron `0 0 * * 1` (midnight UTC Monday = 7 PM ET Sunday)

## Test plan
- [x] 285 notification tests pass (99 new)
- [x] `ruff check` — all clean
- [x] Existing watchlist/bot tests unaffected
- [ ] Deploy and run `python -m notifications briefing --dry-run` to verify formatting
- [ ] Run `CREATE TABLE alert_followups` migration on Neon
- [ ] Deploy Railway cron services

🤖 Generated with [Claude Code](https://claude.com/claude-code)