### PR TITLE
feat: multi-LLM ensemble analysis (Feature 05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Multi-LLM Ensemble Analysis** — Run posts through GPT-4o, Claude, and Grok in parallel; merge into consensus prediction
+  - Extended `ProviderComparator` with `ConsensusBuilder` (majority-vote sentiment, raw mean confidence, Jaccard asset agreement)
+  - `EnsembleResult`/`ConsensusResult` dataclasses with DB serialization
+  - `ENSEMBLE_ENABLED`, `ENSEMBLE_PROVIDERS`, `ENSEMBLE_MIN_PROVIDERS` settings (opt-in, default off)
+  - `ensemble_results` and `ensemble_metadata` JSONB columns on predictions table
+  - `ShitpostAnalyzer` uses ensemble when enabled, falls back to single-model on failure
+  - Telegram alerts show agreement level, provider count, confidence spread, dissenting views
+  - Both alert paths (cron engine + event consumer) pass ensemble metadata through
+  - React frontend: expandable "Model Comparison" section in PredictionPanel
+  - API schema includes ensemble fields; feed query fetches ensemble columns
+  - 24 new tests (20 consensus/ensemble unit + 4 analyzer integration)
 - **Weekly Scorecard** — Sunday evening performance digest with accuracy, P&L, top wins/misses, asset breakdown
   - 4 new files: `scorecard_queries.py`, `scorecard_formatter.py`, `scorecard_service.py`
   - Telegram `/scorecard` command (on/off/now preview) for subscriber opt-in/out

--- a/api/queries/feed_queries.py
+++ b/api/queries/feed_queries.py
@@ -54,6 +54,8 @@ def get_analyzed_post_at_offset(
             p.viral_score,
             p.sentiment_score,
             p.urgency_score,
+            p.ensemble_results,
+            p.ensemble_metadata,
             COUNT(*) OVER() AS total_count
         FROM truth_social_shitposts tss
         INNER JOIN predictions p ON tss.shitpost_id = p.shitpost_id
@@ -76,8 +78,12 @@ def get_analyzed_post_at_offset(
 
     # Parse JSON fields
     json_keys = (
-        "assets", "market_impact", "card",
-        "media_attachments", "in_reply_to", "reblog",
+        "assets",
+        "market_impact",
+        "card",
+        "media_attachments",
+        "in_reply_to",
+        "reblog",
     )
     for key in json_keys:
         if isinstance(row.get(key), str):
@@ -159,5 +165,3 @@ def get_outcomes_for_prediction(prediction_id: int) -> list[dict[str, Any]]:
 
     rows, columns = execute_query(query, {"prediction_id": prediction_id})
     return [dict(zip(columns, row)) for row in rows]
-
-

--- a/api/schemas/feed.py
+++ b/api/schemas/feed.py
@@ -58,6 +58,8 @@ class Prediction(BaseModel):
     assets: list[str] = []
     market_impact: dict[str, str] = {}
     scores: Scores
+    ensemble_results: Optional[dict] = None
+    ensemble_metadata: Optional[dict] = None
 
 
 class Returns(BaseModel):

--- a/api/services/feed_service.py
+++ b/api/services/feed_service.py
@@ -64,9 +64,7 @@ class FeedService:
         if valid_symbols and prediction.assets:
             prediction.assets = [a for a in prediction.assets if a in valid_symbols]
             prediction.market_impact = {
-                k: v
-                for k, v in prediction.market_impact.items()
-                if k in valid_symbols
+                k: v for k, v in prediction.market_impact.items() if k in valid_symbols
             }
 
         navigation = self.build_navigation(offset, total)
@@ -127,6 +125,8 @@ class FeedService:
                 sentiment=row.get("sentiment_score"),
                 urgency=row.get("urgency_score"),
             ),
+            ensemble_results=row.get("ensemble_results"),
+            ensemble_metadata=row.get("ensemble_metadata"),
         )
 
     @staticmethod

--- a/documentation/planning/product-brainstorm_2026-04-09/05_MULTI_LLM_ENSEMBLE.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/05_MULTI_LLM_ENSEMBLE.md
@@ -2,9 +2,17 @@
 
 **Feature**: Run each post through GPT-4, Claude, and Grok in parallel. Compare outputs, surface consensus and disagreements, use consensus for higher confidence.
 
-**Status**: Design  
+**Status**: IN PROGRESS  
+**Started**: 2026-04-11  
 **Priority**: High  
-**Estimated Effort**: 3-4 sessions  
+**Estimated Effort**: 3-4 sessions
+
+### Challenge Round Decisions (2026-04-11)
+
+1. **Extend ProviderComparator** — Add `ConsensusBuilder` to `compare_providers.py` rather than creating a new `EnsembleAnalyzer` class. One parallel-execution path.
+2. **Full scope** — Backend + alerts + frontend display (all 4 phases).
+3. **Raw mean confidence** — No agreement bonus/penalty. Store raw mean of provider confidences. Agreement metrics in `ensemble_metadata` for display only. Calibration (Feature 06) refits naturally.
+4. **Both alert paths** — `alert_engine.py` and `event_consumer.py` both pass `ensemble_metadata` to `format_telegram_alert()`.  
 
 ---
 

--- a/documentation/planning/product-brainstorm_2026-04-09/05_MULTI_LLM_ENSEMBLE.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/05_MULTI_LLM_ENSEMBLE.md
@@ -2,10 +2,12 @@
 
 **Feature**: Run each post through GPT-4, Claude, and Grok in parallel. Compare outputs, surface consensus and disagreements, use consensus for higher confidence.
 
-**Status**: IN PROGRESS  
+**Status**: COMPLETE  
 **Started**: 2026-04-11  
+**Completed**: 2026-04-12  
+**PR**: #138  
 **Priority**: High  
-**Estimated Effort**: 3-4 sessions
+**Estimated Effort**: 3-4 sessions (actual: 1 session)
 
 ### Challenge Round Decisions (2026-04-11)
 

--- a/frontend/src/components/PredictionPanel.tsx
+++ b/frontend/src/components/PredictionPanel.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties } from "react";
-import type { Prediction } from "../types/api";
+import { CSSProperties, useState } from "react";
+import type { Prediction, EnsembleProviderResult } from "../types/api";
 import { formatConfidence } from "../utils/format";
 
 const panelStyle: CSSProperties = {
@@ -77,6 +77,188 @@ export function PredictionPanel({ prediction }: Props) {
       {prediction.thesis && (
         <div style={thesisTextStyle}>{prediction.thesis}</div>
       )}
+
+      {prediction.ensemble_metadata && prediction.ensemble_results && (
+        <EnsembleSection
+          metadata={prediction.ensemble_metadata}
+          results={prediction.ensemble_results.results}
+        />
+      )}
     </div>
   );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Ensemble Model Comparison                                         */
+/* ------------------------------------------------------------------ */
+
+const agreementBadge: CSSProperties = {
+  display: "inline-block",
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  letterSpacing: "0.05em",
+  textTransform: "uppercase",
+  padding: "2px 8px",
+  borderRadius: "4px",
+  marginLeft: "8px",
+};
+
+const ensembleToggle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginTop: "14px",
+  padding: "8px 12px",
+  background: "var(--bg-sunken)",
+  borderRadius: "8px",
+  cursor: "pointer",
+  userSelect: "none",
+};
+
+const providerRow: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "110px 1fr 60px",
+  gap: "8px",
+  padding: "6px 12px",
+  fontSize: "0.8rem",
+  borderBottom: "1px solid var(--border)",
+  alignItems: "center",
+};
+
+function agreementColor(level: string): string {
+  if (level === "unanimous") return "var(--color-green, #22c55e)";
+  if (level === "majority") return "var(--color-blue, #3b82f6)";
+  return "var(--color-red)";
+}
+
+function EnsembleSection({
+  metadata,
+  results,
+}: {
+  metadata: NonNullable<Prediction["ensemble_metadata"]>;
+  results: EnsembleProviderResult[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const successfulResults = results.filter((r) => r.success);
+
+  return (
+    <div>
+      <div style={ensembleToggle} onClick={() => setExpanded(!expanded)}>
+        <span style={{ fontSize: "0.8rem", color: "var(--text-secondary)" }}>
+          {metadata.providers_succeeded}/{metadata.providers_queried} Models
+          <span
+            style={{
+              ...agreementBadge,
+              color: agreementColor(metadata.agreement_level),
+              border: `1px solid ${agreementColor(metadata.agreement_level)}`,
+            }}
+          >
+            {metadata.agreement_level}
+          </span>
+        </span>
+        <span style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}>
+          {expanded ? "▲" : "▼"}
+        </span>
+      </div>
+
+      {expanded && (
+        <div
+          style={{
+            marginTop: "4px",
+            background: "var(--bg-sunken)",
+            borderRadius: "0 0 8px 8px",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              ...providerRow,
+              fontWeight: 600,
+              fontSize: "0.72rem",
+              color: "var(--text-muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              borderBottom: "2px solid var(--border)",
+            }}
+          >
+            <span>Provider</span>
+            <span>Assets & Sentiment</span>
+            <span style={{ textAlign: "right" }}>Conf.</span>
+          </div>
+
+          {successfulResults.map((r) => (
+            <div key={r.provider} style={providerRow}>
+              <span style={{ fontWeight: 500 }}>
+                {providerLabel(r.provider)}
+              </span>
+              <span style={{ color: "var(--text-secondary)" }}>
+                {Object.entries(r.market_impact)
+                  .map(([sym, sent]) => `${sym} ${sent}`)
+                  .join(", ") || "—"}
+              </span>
+              <span
+                style={{
+                  textAlign: "right",
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 600,
+                }}
+              >
+                {Math.round(r.confidence * 100)}%
+              </span>
+            </div>
+          ))}
+
+          {results.filter((r) => !r.success).length > 0 && (
+            <div
+              style={{
+                ...providerRow,
+                color: "var(--text-muted)",
+                fontStyle: "italic",
+              }}
+            >
+              <span>
+                {results
+                  .filter((r) => !r.success)
+                  .map((r) => providerLabel(r.provider))
+                  .join(", ")}
+              </span>
+              <span>failed</span>
+              <span />
+            </div>
+          )}
+
+          <div
+            style={{
+              padding: "8px 12px",
+              fontSize: "0.72rem",
+              color: "var(--text-muted)",
+              display: "flex",
+              gap: "16px",
+            }}
+          >
+            <span>
+              Asset overlap:{" "}
+              {Math.round(metadata.asset_agreement * 100)}%
+            </span>
+            <span>
+              Sentiment match:{" "}
+              {Math.round(metadata.sentiment_agreement * 100)}%
+            </span>
+            <span>
+              Spread: {Math.round(metadata.confidence_spread * 100)}pp
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function providerLabel(id: string): string {
+  const labels: Record<string, string> = {
+    openai: "GPT-4o",
+    anthropic: "Claude",
+    grok: "Grok 2",
+  };
+  return labels[id] ?? id;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,38 @@ export interface Scores {
   urgency: number | null;
 }
 
+export interface EnsembleProviderResult {
+  provider: string;
+  model: string;
+  assets: string[];
+  market_impact: Record<string, string>;
+  confidence: number;
+  thesis: string;
+  latency_ms: number;
+  success: boolean;
+  error: string | null;
+}
+
+export interface EnsembleResults {
+  providers_queried: number;
+  providers_succeeded: number;
+  results: EnsembleProviderResult[];
+}
+
+export interface EnsembleMetadata {
+  agreement_level: string;
+  asset_agreement: number;
+  sentiment_agreement: number;
+  confidence_spread: number;
+  providers_queried: number;
+  providers_succeeded: number;
+  dissenting_views: Array<{
+    asset: string;
+    sentiments: Record<string, string>;
+    consensus: string;
+  }>;
+}
+
 export interface Prediction {
   prediction_id: number;
   confidence: number | null;
@@ -54,6 +86,8 @@ export interface Prediction {
   assets: string[];
   market_impact: Record<string, string>;
   scores: Scores;
+  ensemble_results: EnsembleResults | null;
+  ensemble_metadata: EnsembleMetadata | null;
 }
 
 export interface BinStat {

--- a/notifications/alert_engine.py
+++ b/notifications/alert_engine.py
@@ -69,6 +69,7 @@ def check_and_dispatch() -> Dict[str, Any]:
             "sentiment": _extract_sentiment(pred.get("market_impact", {})),
             "thesis": pred.get("thesis", ""),
             "timestamp": pred.get("timestamp"),
+            "ensemble_metadata": pred.get("ensemble_metadata"),
         }
         alerts.append(alert)
 

--- a/notifications/db.py
+++ b/notifications/db.py
@@ -378,6 +378,7 @@ def get_new_predictions_since(since: datetime) -> List[Dict[str, Any]]:
             p.confidence,
             p.thesis,
             p.analysis_status,
+            p.ensemble_metadata,
             p.created_at as prediction_created_at
         FROM predictions p
         WHERE p.analysis_status = 'completed'

--- a/notifications/event_consumer.py
+++ b/notifications/event_consumer.py
@@ -62,6 +62,7 @@ class NotificationsWorker(EventWorker):
             "sentiment": "neutral",  # Will be enriched if market_impact available
             "thesis": "",
             "text": "",
+            "ensemble_metadata": payload.get("ensemble_metadata"),
         }
 
         # Enrich alert with Historical Echoes

--- a/notifications/telegram_sender.py
+++ b/notifications/telegram_sender.py
@@ -158,7 +158,7 @@ _{escape_markdown(text)}_
 \U0001f4a1 *Thesis:*
 {escape_markdown(thesis)}
 
-{_format_echo_section(alert)}\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
+{_format_echo_section(alert)}{_format_ensemble_section(alert)}\u26a0\ufe0f _This is NOT financial advice\\. For entertainment only\\._
 """
     return message.strip()
 
@@ -197,6 +197,52 @@ def _format_echo_section(alert: Dict[str, Any]) -> str:
         ]
 
     return "\n".join(lines) + "\n\n"
+
+
+def _format_ensemble_section(alert: Dict[str, Any]) -> str:
+    """Format the ensemble consensus section for a Telegram alert.
+
+    Returns an empty string if no ensemble metadata is available.
+    """
+    metadata = alert.get("ensemble_metadata")
+    if not metadata:
+        return ""
+
+    level = metadata.get("agreement_level", "single")
+    n_succeeded = metadata.get("providers_succeeded", 1)
+    n_queried = metadata.get("providers_queried", 1)
+
+    if level == "single":
+        return ""
+
+    level_labels = {
+        "unanimous": "all agree",
+        "majority": "majority agree",
+        "split": "split decision",
+    }
+    label = level_labels.get(level, level)
+
+    line = escape_markdown(f"[{n_succeeded}/{n_queried} models, {label}]")
+
+    # Show confidence range if available
+    spread = metadata.get("confidence_spread", 0)
+    if spread > 0:
+        line += f" \\| spread: {escape_markdown(f'{spread:.0%}')}"
+
+    # Note dissenting views
+    dissents = metadata.get("dissenting_views", [])
+    if dissents:
+        notes = []
+        for d in dissents[:2]:  # Max 2 dissent notes
+            asset = d.get("asset", "")
+            sents = d.get("sentiments", {})
+            parts = [
+                f"{escape_markdown(p)}: {escape_markdown(s)}" for p, s in sents.items()
+            ]
+            notes.append(f"{escape_markdown(asset)} \\({', '.join(parts)}\\)")
+        line += "\n_Dissent: " + "; ".join(notes) + "_"
+
+    return f"\U0001f916 {line}\n\n"
 
 
 def escape_markdown(text: str) -> str:

--- a/shit/config/shitpost_settings.py
+++ b/shit/config/shitpost_settings.py
@@ -36,11 +36,24 @@ class Settings(BaseSettings):
     XAI_API_KEY: Optional[str] = Field(default=None)
     LLM_PROVIDER: str = Field(default="openai")  # openai, anthropic, grok
     LLM_MODEL: str = Field(default="gpt-4")
-    LLM_BASE_URL: Optional[str] = Field(default=None)  # Custom base URL for OpenAI-compatible APIs
+    LLM_BASE_URL: Optional[str] = Field(
+        default=None
+    )  # Custom base URL for OpenAI-compatible APIs
+
+    # Ensemble Configuration
+    ENSEMBLE_ENABLED: bool = Field(
+        default=False
+    )  # Opt-in; set True in Railway to activate
+    ENSEMBLE_PROVIDERS: str = Field(default="openai,anthropic,grok")
+    ENSEMBLE_MIN_PROVIDERS: int = Field(
+        default=2
+    )  # Minimum successful providers for valid ensemble
 
     # Truth Social Shitpost Configuration
     TRUTH_SOCIAL_USERNAME: str = Field(default="realDonaldTrump")
-    TRUTH_SOCIAL_SHITPOST_INTERVAL: int = Field(default=30)  # seconds between shitpost harvests
+    TRUTH_SOCIAL_SHITPOST_INTERVAL: int = Field(
+        default=30
+    )  # seconds between shitpost harvests
 
     # Analysis Configuration
     CONFIDENCE_THRESHOLD: float = Field(default=0.7)
@@ -68,7 +81,9 @@ class Settings(BaseSettings):
     # Telegram Bot Configuration (Phase 2 - Alerting)
     TELEGRAM_BOT_TOKEN: Optional[str] = Field(default=None)
     TELEGRAM_BOT_USERNAME: Optional[str] = Field(default=None)  # Without @ prefix
-    TELEGRAM_WEBHOOK_URL: Optional[str] = Field(default=None)  # For webhook mode (optional)
+    TELEGRAM_WEBHOOK_URL: Optional[str] = Field(
+        default=None
+    )  # For webhook mode (optional)
 
     # Market Data Resilience Configuration
     ALPHA_VANTAGE_API_KEY: Optional[str] = Field(default=None)
@@ -92,13 +107,17 @@ class Settings(BaseSettings):
     AWS_REGION: str = Field(default="us-east-1")
 
     # Multi-Source Harvester Configuration
-    ENABLED_HARVESTERS: str = Field(default="truth_social")  # Comma-separated list of enabled harvester source names
+    ENABLED_HARVESTERS: str = Field(
+        default="truth_social"
+    )  # Comma-separated list of enabled harvester source names
 
     # Twitter/X Configuration (Future)
     TWITTER_API_KEY: Optional[str] = Field(default=None)
     TWITTER_API_SECRET: Optional[str] = Field(default=None)
     TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None)
-    TWITTER_TARGET_USERS: str = Field(default="")  # Comma-separated Twitter usernames to monitor
+    TWITTER_TARGET_USERS: str = Field(
+        default=""
+    )  # Comma-separated Twitter usernames to monitor
 
     # Logging
     LOG_LEVEL: str = Field(default="INFO")
@@ -130,9 +149,7 @@ class Settings(BaseSettings):
             return self.ANTHROPIC_API_KEY
         elif self.LLM_PROVIDER == "grok":
             if not self.XAI_API_KEY:
-                raise ValueError(
-                    "XAI_API_KEY is required when LLM_PROVIDER is 'grok'"
-                )
+                raise ValueError("XAI_API_KEY is required when LLM_PROVIDER is 'grok'")
             return self.XAI_API_KEY
         else:
             raise ValueError(f"Unsupported LLM provider: {self.LLM_PROVIDER}")

--- a/shit/llm/__init__.py
+++ b/shit/llm/__init__.py
@@ -4,6 +4,13 @@ Base LLM client and prompt utilities for the Shitpost-Alpha project.
 """
 
 from .llm_client import LLMClient
+from .compare_providers import (
+    ConsensusBuilder,
+    ConsensusResult,
+    EnsembleResult,
+    ProviderComparator,
+    ProviderResult,
+)
 from .prompts import (
     get_analysis_prompt,
     get_detailed_analysis_prompt,
@@ -15,6 +22,11 @@ from .provider_config import PROVIDERS, get_provider, get_recommended_model
 
 __all__ = [
     "LLMClient",
+    "ConsensusBuilder",
+    "ConsensusResult",
+    "EnsembleResult",
+    "ProviderComparator",
+    "ProviderResult",
     "get_analysis_prompt",
     "get_detailed_analysis_prompt",
     "get_sector_analysis_prompt",

--- a/shit/llm/compare_providers.py
+++ b/shit/llm/compare_providers.py
@@ -1,10 +1,13 @@
 """
-LLM Provider Comparison
-Run the same content through multiple providers and compare results.
+LLM Provider Comparison and Ensemble Analysis
+
+Run the same content through multiple providers, compare results,
+and optionally merge into a consensus prediction for production use.
 """
 
 import asyncio
 import time
+from collections import Counter
 from typing import Dict, List, Optional
 from dataclasses import dataclass, field
 
@@ -18,6 +21,7 @@ logger = get_service_logger("llm_compare")
 @dataclass
 class ProviderResult:
     """Result from a single provider analysis."""
+
     provider: str
     model: str
     assets: List[str] = field(default_factory=list)
@@ -31,13 +35,265 @@ class ProviderResult:
 
 
 @dataclass
+class ConsensusResult:
+    """Merged consensus from multiple provider analyses."""
+
+    assets: List[str] = field(default_factory=list)
+    market_impact: Dict[str, str] = field(default_factory=dict)
+    confidence: float = 0.0
+    thesis: str = ""
+    agreement_level: str = "single"  # unanimous, majority, split, single
+    asset_agreement: float = 0.0
+    sentiment_agreement: float = 0.0
+    confidence_spread: float = 0.0
+    dissenting_views: List[Dict] = field(default_factory=list)
+
+    def to_analysis_dict(self) -> Dict:
+        """Convert consensus to the analysis dict format expected by store_analysis."""
+        return {
+            "assets": self.assets,
+            "market_impact": self.market_impact,
+            "confidence": self.confidence,
+            "thesis": self.thesis,
+        }
+
+
+@dataclass
+class EnsembleResult:
+    """Full ensemble result with consensus and individual outputs."""
+
+    consensus: ConsensusResult
+    individual_results: List[ProviderResult] = field(default_factory=list)
+    providers_queried: int = 0
+    providers_succeeded: int = 0
+
+    def to_storage_dict(self) -> Dict:
+        """Serialize individual results for JSON storage in ensemble_results column."""
+        return {
+            "providers_queried": self.providers_queried,
+            "providers_succeeded": self.providers_succeeded,
+            "results": [
+                {
+                    "provider": r.provider,
+                    "model": r.model,
+                    "assets": r.assets,
+                    "market_impact": r.market_impact,
+                    "confidence": r.confidence,
+                    "thesis": r.thesis,
+                    "latency_ms": round(r.latency_ms, 1),
+                    "success": r.success,
+                    "error": r.error,
+                }
+                for r in self.individual_results
+            ],
+        }
+
+    def to_metadata_dict(self) -> Dict:
+        """Serialize agreement metrics for JSON storage in ensemble_metadata column."""
+        return {
+            "agreement_level": self.consensus.agreement_level,
+            "asset_agreement": round(self.consensus.asset_agreement, 3),
+            "sentiment_agreement": round(self.consensus.sentiment_agreement, 3),
+            "confidence_spread": round(self.consensus.confidence_spread, 3),
+            "providers_queried": self.providers_queried,
+            "providers_succeeded": self.providers_succeeded,
+            "dissenting_views": self.consensus.dissenting_views,
+        }
+
+
+@dataclass
 class ComparisonResult:
     """Comparison result across multiple providers."""
+
     content: str
     results: List[ProviderResult] = field(default_factory=list)
     asset_agreement: float = 0.0  # 0.0-1.0, how much providers agree on assets
     sentiment_agreement: float = 0.0  # 0.0-1.0, how much providers agree on sentiment
     confidence_spread: float = 0.0  # Difference between max and min confidence
+
+
+class ConsensusBuilder:
+    """Merges multiple provider results into a single consensus prediction."""
+
+    def merge(self, results: List[ProviderResult]) -> ConsensusResult:
+        """Merge successful provider results into a consensus.
+
+        Args:
+            results: List of successful ProviderResult instances.
+
+        Returns:
+            ConsensusResult with merged prediction data.
+        """
+        if not results:
+            return ConsensusResult()
+
+        if len(results) == 1:
+            r = results[0]
+            return ConsensusResult(
+                assets=list(r.assets),
+                market_impact=dict(r.market_impact),
+                confidence=r.confidence,
+                thesis=r.thesis,
+                agreement_level="single",
+            )
+
+        # Union of all detected assets
+        all_assets = []
+        seen = set()
+        for r in results:
+            for asset in r.assets:
+                upper = asset.upper()
+                if upper not in seen:
+                    seen.add(upper)
+                    all_assets.append(upper)
+
+        # Majority vote on sentiment per asset
+        consensus_impact = {}
+        for asset in all_assets:
+            consensus_impact[asset] = self._vote_sentiment(asset, results)
+
+        # Raw mean confidence (no bonus/penalty — calibration handles adjustment)
+        confidences = [r.confidence for r in results]
+        mean_confidence = sum(confidences) / len(confidences)
+        spread = max(confidences) - min(confidences)
+
+        # Pick thesis from highest-confidence individual result
+        best = max(results, key=lambda r: r.confidence)
+        thesis = best.thesis
+
+        # Agreement metrics
+        asset_agreement = self._compute_asset_agreement(results)
+        sentiment_agreement = self._compute_sentiment_agreement(
+            results, all_assets, consensus_impact
+        )
+        agreement_level = self._classify_agreement(
+            results, all_assets, consensus_impact
+        )
+        dissenting_views = self._capture_dissenting_views(
+            results, all_assets, consensus_impact
+        )
+
+        return ConsensusResult(
+            assets=all_assets,
+            market_impact=consensus_impact,
+            confidence=round(mean_confidence, 4),
+            thesis=thesis,
+            agreement_level=agreement_level,
+            asset_agreement=asset_agreement,
+            sentiment_agreement=sentiment_agreement,
+            confidence_spread=spread,
+            dissenting_views=dissenting_views,
+        )
+
+    def _vote_sentiment(self, asset: str, results: List[ProviderResult]) -> str:
+        """Majority vote on sentiment for a single asset."""
+        votes = []
+        for r in results:
+            sentiment = r.market_impact.get(asset) or r.market_impact.get(asset.upper())
+            if sentiment:
+                votes.append(sentiment.lower())
+
+        if not votes:
+            return "neutral"
+
+        counts = Counter(votes)
+        winner, winner_count = counts.most_common(1)[0]
+
+        # Majority = more than half
+        if winner_count > len(votes) / 2:
+            return winner
+        # Tie between bullish/bearish = neutral (conservative)
+        return "neutral"
+
+    def _compute_asset_agreement(self, results: List[ProviderResult]) -> float:
+        """Jaccard similarity of asset sets across providers."""
+        asset_sets = [set(a.upper() for a in r.assets) for r in results]
+        non_empty = [s for s in asset_sets if s]
+        if not non_empty:
+            return 1.0  # All agree: no assets
+
+        union = set().union(*non_empty)
+        intersection = set(non_empty[0])
+        for s in non_empty[1:]:
+            intersection = intersection.intersection(s)
+
+        return len(intersection) / len(union) if union else 1.0
+
+    def _compute_sentiment_agreement(
+        self,
+        results: List[ProviderResult],
+        all_assets: List[str],
+        consensus_impact: Dict[str, str],
+    ) -> float:
+        """Fraction of per-asset sentiments that match the consensus."""
+        total = 0
+        matching = 0
+        for asset in all_assets:
+            for r in results:
+                sentiment = r.market_impact.get(asset) or r.market_impact.get(
+                    asset.upper()
+                )
+                if sentiment:
+                    total += 1
+                    if sentiment.lower() == consensus_impact.get(asset, ""):
+                        matching += 1
+        return matching / total if total > 0 else 1.0
+
+    def _classify_agreement(
+        self,
+        results: List[ProviderResult],
+        all_assets: List[str],
+        consensus_impact: Dict[str, str],
+    ) -> str:
+        """Classify the agreement level across providers."""
+        if len(results) < 2:
+            return "single"
+
+        # Check if all providers agree on all asset sentiments
+        all_agree = True
+        any_majority = True
+        for asset in all_assets:
+            sentiments = []
+            for r in results:
+                s = r.market_impact.get(asset) or r.market_impact.get(asset.upper())
+                if s:
+                    sentiments.append(s.lower())
+            if len(set(sentiments)) > 1:
+                all_agree = False
+                counts = Counter(sentiments)
+                winner_count = counts.most_common(1)[0][1]
+                if winner_count <= len(sentiments) / 2:
+                    any_majority = False
+
+        if all_agree:
+            return "unanimous"
+        if any_majority:
+            return "majority"
+        return "split"
+
+    def _capture_dissenting_views(
+        self,
+        results: List[ProviderResult],
+        all_assets: List[str],
+        consensus_impact: Dict[str, str],
+    ) -> List[Dict]:
+        """Record where models disagreed."""
+        dissenting = []
+        for asset in all_assets:
+            sentiments_by_provider = {}
+            for r in results:
+                s = r.market_impact.get(asset) or r.market_impact.get(asset.upper())
+                if s:
+                    sentiments_by_provider[r.provider] = s.lower()
+            if len(set(sentiments_by_provider.values())) > 1:
+                dissenting.append(
+                    {
+                        "asset": asset,
+                        "sentiments": sentiments_by_provider,
+                        "consensus": consensus_impact.get(asset, "neutral"),
+                    }
+                )
+        return dissenting
 
 
 class ProviderComparator:
@@ -52,6 +308,7 @@ class ProviderComparator:
         """
         self.provider_ids = providers or list(PROVIDERS.keys())
         self.clients: Dict[str, LLMClient] = {}
+        self.consensus_builder = ConsensusBuilder()
 
     async def initialize(self) -> List[str]:
         """Initialize LLM clients for all specified providers.
@@ -66,6 +323,7 @@ class ProviderComparator:
                 provider_config = get_provider(provider_id)
                 # Determine API key from settings
                 from shit.config.shitpost_settings import Settings
+
                 s = Settings()
 
                 api_key = getattr(s, provider_config.api_key_env_var, None)
@@ -96,6 +354,60 @@ class ProviderComparator:
                 logger.warning(f"Failed to initialize {provider_id}: {e}")
 
         return initialized
+
+    async def analyze_ensemble(
+        self, content: str, prompt_func=None, **kwargs
+    ) -> EnsembleResult:
+        """Run content through all initialized providers and merge into consensus.
+
+        Args:
+            content: Content to analyze.
+            prompt_func: Optional prompt function passed to each LLMClient.analyze().
+            **kwargs: Additional kwargs for the prompt function.
+
+        Returns:
+            EnsembleResult with consensus and individual results.
+
+        Raises:
+            RuntimeError: If all providers fail.
+        """
+        tasks = []
+        for provider_id, client in self.clients.items():
+            tasks.append(self._analyze_with_provider(provider_id, client, content))
+
+        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        successful = []
+        failed = []
+        for result in raw_results:
+            if isinstance(result, Exception):
+                failed.append(
+                    ProviderResult(
+                        provider="unknown",
+                        model="unknown",
+                        success=False,
+                        error=str(result),
+                    )
+                )
+            elif result.success:
+                successful.append(result)
+            else:
+                failed.append(result)
+
+        if not successful:
+            raise RuntimeError(
+                f"All {len(tasks)} ensemble providers failed: "
+                + "; ".join(r.error or "unknown" for r in failed)
+            )
+
+        consensus = self.consensus_builder.merge(successful)
+
+        return EnsembleResult(
+            consensus=consensus,
+            individual_results=successful + failed,
+            providers_queried=len(tasks),
+            providers_succeeded=len(successful),
+        )
 
     async def compare(self, content: str) -> ComparisonResult:
         """Run content through all initialized providers and compare results.

--- a/shit_tests/shit/llm/test_ensemble.py
+++ b/shit_tests/shit/llm/test_ensemble.py
@@ -1,0 +1,367 @@
+"""Tests for Multi-LLM Ensemble consensus and analysis (Feature 05)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shit.llm.compare_providers import (
+    ConsensusBuilder,
+    ConsensusResult,
+    EnsembleResult,
+    ProviderComparator,
+    ProviderResult,
+)
+
+
+# ============================================================
+# Fixtures
+# ============================================================
+
+
+def _make_result(
+    provider: str = "openai",
+    model: str = "gpt-4o",
+    assets: list | None = None,
+    market_impact: dict | None = None,
+    confidence: float = 0.85,
+    thesis: str = "Test thesis",
+    success: bool = True,
+    error: str | None = None,
+    latency_ms: float = 1000.0,
+) -> ProviderResult:
+    return ProviderResult(
+        provider=provider,
+        model=model,
+        assets=["TSLA"] if assets is None else assets,
+        market_impact={"TSLA": "bearish"} if market_impact is None else market_impact,
+        confidence=confidence,
+        thesis=thesis,
+        success=success,
+        error=error,
+        latency_ms=latency_ms,
+    )
+
+
+# ============================================================
+# ConsensusBuilder Tests
+# ============================================================
+
+
+class TestConsensusBuilder:
+    """Test consensus merge logic."""
+
+    def setup_method(self):
+        self.builder = ConsensusBuilder()
+
+    def test_unanimous_agreement(self):
+        """3 providers all agree: bearish TSLA."""
+        results = [
+            _make_result("openai", confidence=0.85, market_impact={"TSLA": "bearish"}),
+            _make_result(
+                "anthropic",
+                model="claude-sonnet-4-20250514",
+                confidence=0.80,
+                market_impact={"TSLA": "bearish"},
+            ),
+            _make_result(
+                "grok",
+                model="grok-2",
+                confidence=0.90,
+                market_impact={"TSLA": "bearish"},
+            ),
+        ]
+        consensus = self.builder.merge(results)
+
+        assert consensus.agreement_level == "unanimous"
+        assert consensus.market_impact["TSLA"] == "bearish"
+        assert consensus.assets == ["TSLA"]
+
+    def test_majority_agreement(self):
+        """2/3 agree bearish, 1 neutral -> majority bearish."""
+        results = [
+            _make_result("openai", market_impact={"TSLA": "bearish"}),
+            _make_result("anthropic", market_impact={"TSLA": "bearish"}),
+            _make_result("grok", market_impact={"TSLA": "neutral"}),
+        ]
+        consensus = self.builder.merge(results)
+
+        assert consensus.agreement_level == "majority"
+        assert consensus.market_impact["TSLA"] == "bearish"
+
+    def test_split_decision_neutral_fallback(self):
+        """Each provider has different sentiment -> neutral."""
+        results = [
+            _make_result("openai", market_impact={"TSLA": "bearish"}),
+            _make_result("anthropic", market_impact={"TSLA": "bullish"}),
+            _make_result("grok", market_impact={"TSLA": "neutral"}),
+        ]
+        consensus = self.builder.merge(results)
+
+        assert consensus.agreement_level == "split"
+        assert consensus.market_impact["TSLA"] == "neutral"
+
+    def test_single_provider(self):
+        """Only 1 result -> single mode, passthrough."""
+        result = _make_result("openai", confidence=0.85)
+        consensus = self.builder.merge([result])
+
+        assert consensus.agreement_level == "single"
+        assert consensus.confidence == 0.85
+        assert consensus.assets == ["TSLA"]
+        assert consensus.market_impact == {"TSLA": "bearish"}
+
+    def test_empty_results(self):
+        consensus = self.builder.merge([])
+        assert consensus.agreement_level == "single"
+        assert consensus.assets == []
+
+    def test_confidence_is_raw_mean(self):
+        """Confidence should be the raw mean — no agreement bonus/penalty."""
+        results = [
+            _make_result("openai", confidence=0.80),
+            _make_result("anthropic", confidence=0.90),
+            _make_result("grok", confidence=0.70),
+        ]
+        consensus = self.builder.merge(results)
+
+        expected = (0.80 + 0.90 + 0.70) / 3
+        assert abs(consensus.confidence - expected) < 0.001
+
+    def test_confidence_spread(self):
+        results = [
+            _make_result("openai", confidence=0.70),
+            _make_result("anthropic", confidence=0.90),
+        ]
+        consensus = self.builder.merge(results)
+        assert abs(consensus.confidence_spread - 0.20) < 0.001
+
+    def test_asset_union(self):
+        """All provider assets included in consensus."""
+        results = [
+            _make_result("openai", assets=["TSLA"]),
+            _make_result("anthropic", assets=["TSLA", "F"]),
+            _make_result("grok", assets=["TSLA", "F", "GM"]),
+        ]
+        consensus = self.builder.merge(results)
+
+        assert set(consensus.assets) == {"TSLA", "F", "GM"}
+
+    def test_asset_agreement_jaccard(self):
+        """Jaccard: intersection/union = 1/3."""
+        results = [
+            _make_result("openai", assets=["TSLA"]),
+            _make_result("anthropic", assets=["TSLA", "F"]),
+            _make_result("grok", assets=["TSLA", "F", "GM"]),
+        ]
+        consensus = self.builder.merge(results)
+
+        # Intersection: {TSLA}, Union: {TSLA, F, GM} -> 1/3
+        assert abs(consensus.asset_agreement - 1 / 3) < 0.01
+
+    def test_dissenting_views_captured(self):
+        """Disagreements are recorded correctly."""
+        results = [
+            _make_result(
+                "openai",
+                assets=["TSLA", "F"],
+                market_impact={"TSLA": "bearish", "F": "neutral"},
+            ),
+            _make_result(
+                "grok",
+                assets=["TSLA", "F"],
+                market_impact={"TSLA": "bearish", "F": "bearish"},
+            ),
+        ]
+        consensus = self.builder.merge(results)
+
+        # TSLA: both agree bearish -> no dissent
+        # F: openai neutral, grok bearish -> dissent
+        assert len(consensus.dissenting_views) == 1
+        assert consensus.dissenting_views[0]["asset"] == "F"
+
+    def test_all_agree_no_assets(self):
+        """All providers say no financial relevance."""
+        results = [
+            _make_result("openai", assets=[], market_impact={}, confidence=0.1),
+            _make_result("anthropic", assets=[], market_impact={}, confidence=0.15),
+        ]
+        consensus = self.builder.merge(results)
+
+        assert consensus.assets == []
+        assert consensus.market_impact == {}
+        assert consensus.asset_agreement == 1.0
+
+    def test_thesis_from_highest_confidence(self):
+        """Thesis is picked from the highest-confidence provider."""
+        results = [
+            _make_result("openai", confidence=0.70, thesis="OpenAI says bearish"),
+            _make_result(
+                "anthropic", confidence=0.95, thesis="Claude says very bearish"
+            ),
+            _make_result("grok", confidence=0.80, thesis="Grok agrees bearish"),
+        ]
+        consensus = self.builder.merge(results)
+        assert consensus.thesis == "Claude says very bearish"
+
+    def test_case_insensitive_assets(self):
+        """Asset tickers are uppercased and deduped."""
+        results = [
+            _make_result("openai", assets=["tsla", "F"]),
+            _make_result("anthropic", assets=["TSLA", "f"]),
+        ]
+        consensus = self.builder.merge(results)
+        assert set(consensus.assets) == {"TSLA", "F"}
+
+    def test_to_analysis_dict(self):
+        """ConsensusResult.to_analysis_dict() returns correct format."""
+        consensus = ConsensusResult(
+            assets=["TSLA"],
+            market_impact={"TSLA": "bearish"},
+            confidence=0.85,
+            thesis="Test thesis",
+        )
+        d = consensus.to_analysis_dict()
+        assert d["assets"] == ["TSLA"]
+        assert d["market_impact"] == {"TSLA": "bearish"}
+        assert d["confidence"] == 0.85
+        assert d["thesis"] == "Test thesis"
+
+
+# ============================================================
+# EnsembleResult Serialization Tests
+# ============================================================
+
+
+class TestEnsembleResult:
+    """Test EnsembleResult serialization for storage."""
+
+    def test_to_storage_dict(self):
+        result = EnsembleResult(
+            consensus=ConsensusResult(assets=["TSLA"]),
+            individual_results=[
+                _make_result("openai"),
+                _make_result("anthropic", success=False, error="timeout"),
+            ],
+            providers_queried=2,
+            providers_succeeded=1,
+        )
+        d = result.to_storage_dict()
+
+        assert d["providers_queried"] == 2
+        assert d["providers_succeeded"] == 1
+        assert len(d["results"]) == 2
+        assert d["results"][0]["provider"] == "openai"
+        assert d["results"][1]["success"] is False
+
+    def test_to_metadata_dict(self):
+        result = EnsembleResult(
+            consensus=ConsensusResult(
+                agreement_level="majority",
+                asset_agreement=0.333,
+                sentiment_agreement=0.833,
+                confidence_spread=0.14,
+                dissenting_views=[{"asset": "F", "sentiments": {}}],
+            ),
+            providers_queried=3,
+            providers_succeeded=3,
+        )
+        d = result.to_metadata_dict()
+
+        assert d["agreement_level"] == "majority"
+        assert d["providers_queried"] == 3
+        assert len(d["dissenting_views"]) == 1
+
+
+# ============================================================
+# ProviderComparator.analyze_ensemble Tests
+# ============================================================
+
+
+class TestProviderComparatorEnsemble:
+    """Test ensemble analysis via ProviderComparator."""
+
+    @pytest.mark.asyncio
+    async def test_all_providers_succeed(self):
+        comparator = ProviderComparator(providers=["openai", "anthropic"])
+        comparator.clients = {
+            "openai": MagicMock(),
+            "anthropic": MagicMock(),
+        }
+
+        async def mock_analyze(pid, client, content):
+            return _make_result(
+                pid,
+                confidence=0.85 if pid == "openai" else 0.80,
+            )
+
+        comparator._analyze_with_provider = mock_analyze
+
+        result = await comparator.analyze_ensemble("test content")
+
+        assert result.providers_queried == 2
+        assert result.providers_succeeded == 2
+        assert result.consensus.agreement_level in ("unanimous", "majority", "single")
+        assert len(result.individual_results) == 2
+
+    @pytest.mark.asyncio
+    async def test_one_provider_fails_graceful_degradation(self):
+        comparator = ProviderComparator(providers=["openai", "anthropic", "grok"])
+        comparator.clients = {
+            "openai": MagicMock(),
+            "anthropic": MagicMock(),
+            "grok": MagicMock(),
+        }
+
+        call_count = 0
+
+        async def mock_analyze(pid, client, content):
+            nonlocal call_count
+            call_count += 1
+            if pid == "grok":
+                return _make_result(pid, success=False, error="API timeout")
+            return _make_result(pid, confidence=0.85)
+
+        comparator._analyze_with_provider = mock_analyze
+
+        result = await comparator.analyze_ensemble("test content")
+
+        assert result.providers_queried == 3
+        assert result.providers_succeeded == 2
+        assert len(result.individual_results) == 3  # includes failed
+
+    @pytest.mark.asyncio
+    async def test_all_providers_fail_raises(self):
+        comparator = ProviderComparator(providers=["openai"])
+        comparator.clients = {"openai": MagicMock()}
+
+        async def mock_analyze(pid, client, content):
+            return _make_result(pid, success=False, error="API down")
+
+        comparator._analyze_with_provider = mock_analyze
+
+        with pytest.raises(RuntimeError, match="All.*providers failed"):
+            await comparator.analyze_ensemble("test content")
+
+    @pytest.mark.asyncio
+    async def test_exception_in_provider_handled(self):
+        """asyncio.gather with return_exceptions catches exceptions."""
+        comparator = ProviderComparator(providers=["openai", "anthropic"])
+        comparator.clients = {
+            "openai": MagicMock(),
+            "anthropic": MagicMock(),
+        }
+
+        async def mock_analyze(pid, client, content):
+            if pid == "anthropic":
+                raise ConnectionError("Network error")
+            return _make_result(pid)
+
+        comparator._analyze_with_provider = mock_analyze
+
+        result = await comparator.analyze_ensemble("test content")
+
+        assert result.providers_succeeded == 1
+        assert result.providers_queried == 2
+        # The failed one should appear with success=False
+        failed = [r for r in result.individual_results if not r.success]
+        assert len(failed) == 1

--- a/shit_tests/shitpost_ai/test_analyzer_ensemble.py
+++ b/shit_tests/shitpost_ai/test_analyzer_ensemble.py
@@ -1,0 +1,213 @@
+"""Tests for ensemble integration in ShitpostAnalyzer (Feature 05)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from shitpost_ai.shitpost_analyzer import ShitpostAnalyzer
+
+
+@pytest.fixture
+def mock_ensemble_result():
+    """Build a mock EnsembleResult."""
+    from shit.llm.compare_providers import (
+        ConsensusResult,
+        EnsembleResult,
+        ProviderResult,
+    )
+
+    consensus = ConsensusResult(
+        assets=["TSLA"],
+        market_impact={"TSLA": "bearish"},
+        confidence=0.85,
+        thesis="Negative auto sentiment",
+        agreement_level="unanimous",
+        asset_agreement=1.0,
+        sentiment_agreement=1.0,
+        confidence_spread=0.05,
+    )
+    return EnsembleResult(
+        consensus=consensus,
+        individual_results=[
+            ProviderResult(
+                provider="openai",
+                model="gpt-4o",
+                assets=["TSLA"],
+                market_impact={"TSLA": "bearish"},
+                confidence=0.87,
+                thesis="OpenAI thesis",
+                latency_ms=1200,
+                success=True,
+            ),
+            ProviderResult(
+                provider="anthropic",
+                model="claude-sonnet-4-20250514",
+                assets=["TSLA"],
+                market_impact={"TSLA": "bearish"},
+                confidence=0.83,
+                thesis="Claude thesis",
+                latency_ms=900,
+                success=True,
+            ),
+        ],
+        providers_queried=2,
+        providers_succeeded=2,
+    )
+
+
+class TestAnalyzerEnsembleIntegration:
+    """Test ensemble mode in ShitpostAnalyzer._analyze_shitpost."""
+
+    @patch("shitpost_ai.shitpost_analyzer.settings")
+    def test_ensemble_disabled_by_default(self, mock_settings):
+        """When ENSEMBLE_ENABLED=False, ensemble_analyzer is None."""
+        mock_settings.ENSEMBLE_ENABLED = False
+        mock_settings.DATABASE_URL = "sqlite://"
+        mock_settings.LLM_PROVIDER = "openai"
+        mock_settings.LLM_MODEL = "gpt-4o"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+        mock_settings.SYSTEM_LAUNCH_DATE = "2025-01-01"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+        mock_settings.get_llm_base_url.return_value = None
+
+        analyzer = ShitpostAnalyzer()
+        assert analyzer.ensemble_enabled is False
+        assert analyzer.ensemble_analyzer is None
+
+    @patch("shitpost_ai.shitpost_analyzer.settings")
+    def test_ensemble_enabled_flag(self, mock_settings):
+        """When ENSEMBLE_ENABLED=True, ensemble flag is set."""
+        mock_settings.ENSEMBLE_ENABLED = True
+        mock_settings.ENSEMBLE_PROVIDERS = "openai,anthropic"
+        mock_settings.ENSEMBLE_MIN_PROVIDERS = 2
+        mock_settings.DATABASE_URL = "sqlite://"
+        mock_settings.LLM_PROVIDER = "openai"
+        mock_settings.LLM_MODEL = "gpt-4o"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+        mock_settings.SYSTEM_LAUNCH_DATE = "2025-01-01"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+        mock_settings.get_llm_base_url.return_value = None
+
+        analyzer = ShitpostAnalyzer()
+        assert analyzer.ensemble_enabled is True
+
+    @pytest.mark.asyncio
+    @patch("shitpost_ai.shitpost_analyzer.auto_backfill_prediction")
+    @patch("shitpost_ai.shitpost_analyzer.TickerValidator")
+    @patch("shitpost_ai.shitpost_analyzer.BypassService")
+    @patch("shitpost_ai.shitpost_analyzer.LLMClient")
+    @patch("shitpost_ai.shitpost_analyzer.settings")
+    async def test_ensemble_analysis_stores_results(
+        self,
+        mock_settings,
+        mock_llm_cls,
+        mock_bypass_cls,
+        mock_ticker_cls,
+        mock_backfill,
+        mock_ensemble_result,
+    ):
+        """Ensemble results are passed to store_analysis."""
+        mock_settings.ENSEMBLE_ENABLED = True
+        mock_settings.DATABASE_URL = "sqlite://"
+        mock_settings.LLM_PROVIDER = "openai"
+        mock_settings.LLM_MODEL = "gpt-4o"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+        mock_settings.SYSTEM_LAUNCH_DATE = "2025-01-01"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+        mock_settings.get_llm_base_url.return_value = None
+
+        # Setup mocks
+        mock_bypass_cls.return_value.should_bypass_post.return_value = (False, None)
+        mock_ticker_cls.return_value.validate_symbols.return_value = ["TSLA"]
+        mock_ticker_cls.return_value._company_names = {}
+        mock_ticker_cls.return_value._known_active = set()
+        mock_ticker_cls.return_value.ALIASES = {}
+
+        analyzer = ShitpostAnalyzer()
+
+        # Mock ensemble analyzer
+        mock_ensemble = AsyncMock()
+        mock_ensemble.analyze_ensemble.return_value = mock_ensemble_result
+        analyzer.ensemble_analyzer = mock_ensemble
+
+        # Mock prediction_ops
+        analyzer.prediction_ops = AsyncMock()
+        analyzer.prediction_ops.store_analysis.return_value = "42"
+
+        shitpost = {
+            "shitpost_id": "test-123",
+            "text": "Tesla is destroying the auto industry",
+            "content": "<p>Tesla is destroying the auto industry</p>",
+            "timestamp": "2026-04-11T12:00:00Z",
+            "username": "testuser",
+        }
+
+        result = await analyzer._analyze_shitpost(shitpost, dry_run=True)
+
+        assert result is not None
+        assert result["assets"] == ["TSLA"]
+        assert result["ensemble_results"] is not None
+        assert result["ensemble_metadata"] is not None
+        assert result["ensemble_metadata"]["agreement_level"] == "unanimous"
+
+    @pytest.mark.asyncio
+    @patch("shitpost_ai.shitpost_analyzer.TickerValidator")
+    @patch("shitpost_ai.shitpost_analyzer.BypassService")
+    @patch("shitpost_ai.shitpost_analyzer.LLMClient")
+    @patch("shitpost_ai.shitpost_analyzer.settings")
+    async def test_ensemble_fallback_to_single_model(
+        self,
+        mock_settings,
+        mock_llm_cls,
+        mock_bypass_cls,
+        mock_ticker_cls,
+    ):
+        """When ensemble fails, falls back to single-model analysis."""
+        mock_settings.ENSEMBLE_ENABLED = True
+        mock_settings.DATABASE_URL = "sqlite://"
+        mock_settings.LLM_PROVIDER = "openai"
+        mock_settings.LLM_MODEL = "gpt-4o"
+        mock_settings.CONFIDENCE_THRESHOLD = 0.7
+        mock_settings.SYSTEM_LAUNCH_DATE = "2025-01-01"
+        mock_settings.get_llm_api_key.return_value = "test-key"
+        mock_settings.get_llm_base_url.return_value = None
+
+        mock_bypass_cls.return_value.should_bypass_post.return_value = (False, None)
+        mock_ticker_cls.return_value.validate_symbols.return_value = ["TSLA"]
+        mock_ticker_cls.return_value._company_names = {}
+        mock_ticker_cls.return_value._known_active = set()
+        mock_ticker_cls.return_value.ALIASES = {}
+
+        analyzer = ShitpostAnalyzer()
+
+        # Ensemble fails
+        mock_ensemble = AsyncMock()
+        mock_ensemble.analyze_ensemble.side_effect = RuntimeError(
+            "All providers failed"
+        )
+        analyzer.ensemble_analyzer = mock_ensemble
+
+        # Single model succeeds
+        mock_llm = AsyncMock()
+        mock_llm.analyze.return_value = {
+            "assets": ["TSLA"],
+            "market_impact": {"TSLA": "bearish"},
+            "confidence": 0.85,
+            "thesis": "Fallback thesis",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o",
+        }
+        analyzer.llm_client = mock_llm
+
+        shitpost = {
+            "shitpost_id": "test-456",
+            "text": "Tesla is done for",
+            "content": "<p>Tesla is done for</p>",
+            "timestamp": "2026-04-11T12:00:00Z",
+        }
+
+        result = await analyzer._analyze_shitpost(shitpost, dry_run=True)
+
+        assert result is not None
+        assert "ensemble_results" not in result
+        mock_llm.analyze.assert_called_once()

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 from datetime import datetime
 
 from shit.config.shitpost_settings import settings
-from shit.llm import LLMClient, get_analysis_prompt
+from shit.llm import LLMClient, ProviderComparator, get_analysis_prompt
 from shit.db import DatabaseConfig, DatabaseClient, DatabaseOperations
 from shitvault.shitpost_operations import ShitpostOperations
 from shitvault.prediction_operations import PredictionOperations
@@ -65,6 +65,8 @@ class ShitpostAnalyzer:
         self.llm_client = LLMClient()
         self.bypass_service = BypassService()
         self.ticker_validator = TickerValidator()
+        self.ensemble_enabled = settings.ENSEMBLE_ENABLED
+        self.ensemble_analyzer: ProviderComparator | None = None
         self.launch_date = settings.SYSTEM_LAUNCH_DATE
 
         # Analysis mode configuration
@@ -101,8 +103,27 @@ class ShitpostAnalyzer:
         self.shitpost_ops = ShitpostOperations(self.db_ops)
         self.prediction_ops = PredictionOperations(self.db_ops)
 
-        # Initialize LLM client
+        # Initialize LLM client (single-model fallback)
         await self.llm_client.initialize()
+
+        # Initialize ensemble if enabled
+        if self.ensemble_enabled:
+            provider_ids = [
+                p.strip() for p in settings.ENSEMBLE_PROVIDERS.split(",") if p.strip()
+            ]
+            self.ensemble_analyzer = ProviderComparator(providers=provider_ids)
+            initialized = await self.ensemble_analyzer.initialize()
+            if len(initialized) >= settings.ENSEMBLE_MIN_PROVIDERS:
+                logger.info(
+                    f"Ensemble enabled with {len(initialized)} providers: "
+                    + ", ".join(initialized)
+                )
+            else:
+                logger.warning(
+                    f"Ensemble disabled: only {len(initialized)} providers "
+                    f"initialized (need {settings.ENSEMBLE_MIN_PROVIDERS})"
+                )
+                self.ensemble_analyzer = None
 
         logger.info(
             f"Shitpost Analyzer initialized with launch date: {self.launch_date}"
@@ -476,12 +497,44 @@ class ShitpostAnalyzer:
                 shitpost, fundamentals=fundamentals
             )
 
-            # Analyze with LLM
-            analysis = await self.llm_client.analyze(
-                enhanced_content,
-                prompt_func=get_analysis_prompt,
-                has_fundamentals=bool(fundamentals),
-            )
+            # Analyze with LLM (ensemble or single-model)
+            ensemble_result = None
+            if self.ensemble_analyzer:
+                try:
+                    ensemble_result = await self.ensemble_analyzer.analyze_ensemble(
+                        enhanced_content,
+                    )
+                    # Build analysis dict from consensus
+                    analysis = ensemble_result.consensus.to_analysis_dict()
+                    # Attach ensemble data for storage
+                    analysis["ensemble_results"] = ensemble_result.to_storage_dict()
+                    analysis["ensemble_metadata"] = ensemble_result.to_metadata_dict()
+                    # Use the best provider's metadata for llm_provider/model fields
+                    best = max(
+                        (r for r in ensemble_result.individual_results if r.success),
+                        key=lambda r: r.confidence,
+                        default=None,
+                    )
+                    if best:
+                        analysis["llm_provider"] = best.provider
+                        analysis["llm_model"] = best.model
+                    logger.info(
+                        f"Ensemble analysis: {ensemble_result.providers_succeeded}/"
+                        f"{ensemble_result.providers_queried} providers, "
+                        f"agreement={ensemble_result.consensus.agreement_level}"
+                    )
+                except RuntimeError:
+                    logger.warning(
+                        f"Ensemble failed for {shitpost_id}, falling back to single model"
+                    )
+                    ensemble_result = None
+
+            if ensemble_result is None:
+                analysis = await self.llm_client.analyze(
+                    enhanced_content,
+                    prompt_func=get_analysis_prompt,
+                    has_fundamentals=bool(fundamentals),
+                )
 
             if not analysis:
                 logger.warning(f"LLM analysis failed for shitpost {shitpost_id}")
@@ -538,22 +591,31 @@ class ShitpostAnalyzer:
                         calibrated = None
                         try:
                             from shit.market_data.calibration import CalibrationService
-                            calibrated = CalibrationService(timeframe="t7").calibrate(confidence)
+
+                            calibrated = CalibrationService(timeframe="t7").calibrate(
+                                confidence
+                            )
                         except Exception:
                             pass
 
+                        event_payload = {
+                            "prediction_id": int(analysis_id),
+                            "shitpost_id": shitpost_id,
+                            "signal_id": None,
+                            "assets": assets,
+                            "confidence": confidence,
+                            "calibrated_confidence": calibrated,
+                            "analysis_status": analysis_status,
+                            "post_published_at": post_published,
+                        }
+                        # Include ensemble metadata in event for alert enrichment
+                        if enhanced_analysis.get("ensemble_metadata"):
+                            event_payload["ensemble_metadata"] = enhanced_analysis[
+                                "ensemble_metadata"
+                            ]
                         emit_event(
                             event_type=EventType.PREDICTION_CREATED,
-                            payload={
-                                "prediction_id": int(analysis_id),
-                                "shitpost_id": shitpost_id,
-                                "signal_id": None,
-                                "assets": assets,
-                                "confidence": confidence,
-                                "calibrated_confidence": calibrated,
-                                "analysis_status": analysis_status,
-                                "post_published_at": post_published,
-                            },
+                            payload=event_payload,
                             source_service="analyzer",
                         )
                     except Exception as e:

--- a/shitvault/prediction_operations.py
+++ b/shitvault/prediction_operations.py
@@ -4,7 +4,6 @@ Domain-specific operations for prediction management.
 Extracted from ShitpostDatabase for modularity.
 """
 
-
 from typing import Dict, Optional, Any
 from datetime import datetime
 from sqlalchemy import and_, select
@@ -21,6 +20,7 @@ from shit.logging.service_loggers import DatabaseLogger
 db_logger = DatabaseLogger("prediction_operations")
 logger = db_logger.logger
 
+
 class PredictionOperations:
     """Operations for managing predictions."""
 
@@ -35,11 +35,19 @@ class PredictionOperations:
             return None
         try:
             from shit.market_data.calibration import CalibrationService
+
             return CalibrationService(timeframe="t7").calibrate(raw_confidence)
         except Exception:
             return None
-    
-    async def store_analysis(self, content_id: str, analysis_data: Dict[str, Any], content_data: Dict[str, Any] = None, *, use_signal: bool = False) -> Optional[str]:
+
+    async def store_analysis(
+        self,
+        content_id: str,
+        analysis_data: Dict[str, Any],
+        content_data: Dict[str, Any] = None,
+        *,
+        use_signal: bool = False,
+    ) -> Optional[str]:
         """Store LLM analysis results in the database with enhanced content data.
 
         Args:
@@ -53,25 +61,31 @@ class PredictionOperations:
             engagement_score = None
             viral_score = None
             if content_data:
-                replies = content_data.get('replies_count', 0)
-                reblogs = content_data.get('shares_count', content_data.get('reblogs_count', 0))
-                favourites = content_data.get('likes_count', content_data.get('favourites_count', 0))
-                upvotes = content_data.get('upvotes_count', 0)
-                followers = content_data.get('author_followers', content_data.get('account_followers_count', 0))
-                
+                replies = content_data.get("replies_count", 0)
+                reblogs = content_data.get(
+                    "shares_count", content_data.get("reblogs_count", 0)
+                )
+                favourites = content_data.get(
+                    "likes_count", content_data.get("favourites_count", 0)
+                )
+                upvotes = content_data.get("upvotes_count", 0)
+                followers = content_data.get(
+                    "author_followers", content_data.get("account_followers_count", 0)
+                )
+
                 # Engagement score based on interaction rate
                 if followers > 0:
                     engagement_score = (replies + reblogs + favourites) / followers
-                
+
                 # Viral score based on reblog/favourite ratio
                 if favourites > 0:
                     viral_score = reblogs / favourites
-            
+
             # Extract source post timestamp for denormalization
             post_ts = None
             if content_data:
                 post_ts = DatabaseUtils.parse_timestamp(
-                    content_data.get('timestamp') or content_data.get('published_at')
+                    content_data.get("timestamp") or content_data.get("published_at")
                 )
 
             prediction = Prediction(
@@ -79,58 +93,70 @@ class PredictionOperations:
                 shitpost_id=content_id if not use_signal else None,
                 signal_id=content_id if use_signal else None,
                 post_timestamp=post_ts,
-                assets=analysis_data.get('assets', []),
-                market_impact=analysis_data.get('market_impact', {}),
-                confidence=analysis_data.get('confidence', 0.0),
-                calibrated_confidence=self._calibrate(analysis_data.get('confidence')),
-                thesis=analysis_data.get('thesis', ''),
-
+                assets=analysis_data.get("assets", []),
+                market_impact=analysis_data.get("market_impact", {}),
+                confidence=analysis_data.get("confidence", 0.0),
+                calibrated_confidence=self._calibrate(analysis_data.get("confidence")),
+                thesis=analysis_data.get("thesis", ""),
                 # Set analysis status for successful analyses
-                analysis_status='completed',
+                analysis_status="completed",
                 analysis_comment=None,
-
                 # Enhanced analysis scores
                 engagement_score=engagement_score,
                 viral_score=viral_score,
-                sentiment_score=analysis_data.get('sentiment_score'),
-                urgency_score=analysis_data.get('urgency_score'),
-
+                sentiment_score=analysis_data.get("sentiment_score"),
+                urgency_score=analysis_data.get("urgency_score"),
                 # Content analysis
-                has_media=content_data.get('has_media', False) if content_data else False,
-                mentions_count=len(content_data.get('mentions', [])) if content_data else 0,
-                hashtags_count=len(content_data.get('tags', [])) if content_data else 0,
-                content_length=len(content_data.get('text', '')) if content_data else 0,
-
+                has_media=content_data.get("has_media", False)
+                if content_data
+                else False,
+                mentions_count=len(content_data.get("mentions", []))
+                if content_data
+                else 0,
+                hashtags_count=len(content_data.get("tags", [])) if content_data else 0,
+                content_length=len(content_data.get("text", "")) if content_data else 0,
                 # Engagement metrics at analysis time
-                replies_at_analysis=content_data.get('replies_count', 0) if content_data else 0,
-                reblogs_at_analysis=content_data.get('reblogs_count', 0) if content_data else 0,
-                favourites_at_analysis=content_data.get('favourites_count', 0) if content_data else 0,
-                upvotes_at_analysis=content_data.get('upvotes_count', 0) if content_data else 0,
-
+                replies_at_analysis=content_data.get("replies_count", 0)
+                if content_data
+                else 0,
+                reblogs_at_analysis=content_data.get("reblogs_count", 0)
+                if content_data
+                else 0,
+                favourites_at_analysis=content_data.get("favourites_count", 0)
+                if content_data
+                else 0,
+                upvotes_at_analysis=content_data.get("upvotes_count", 0)
+                if content_data
+                else 0,
                 # LLM metadata
-                llm_provider=analysis_data.get('llm_provider'),
-                llm_model=analysis_data.get('llm_model'),
-                analysis_timestamp=DatabaseUtils.parse_timestamp(analysis_data.get('analysis_timestamp'))
+                llm_provider=analysis_data.get("llm_provider"),
+                llm_model=analysis_data.get("llm_model"),
+                analysis_timestamp=DatabaseUtils.parse_timestamp(
+                    analysis_data.get("analysis_timestamp")
+                ),
+                # Ensemble metadata (null for single-model predictions)
+                ensemble_results=analysis_data.get("ensemble_results"),
+                ensemble_metadata=analysis_data.get("ensemble_metadata"),
             )
-            
+
             self.db_ops.session.add(prediction)
             await self.db_ops.session.commit()
             await self.db_ops.session.refresh(prediction)
-            
+
             logger.debug(f"Stored enhanced analysis with ID: {prediction.id}")
             return str(prediction.id)
-            
+
         except Exception as e:
             logger.error(f"Error storing analysis: {e}")
             return None
-    
+
     async def handle_no_text_prediction(
         self,
         content_id: str,
         content_data: Dict[str, Any],
         bypass_reason: Optional[BypassReason] = None,
         *,
-        use_signal: bool = False
+        use_signal: bool = False,
     ) -> Optional[str]:
         """
         Create a prediction record for posts that can't be analyzed.
@@ -154,7 +180,7 @@ class PredictionOperations:
 
             # Extract source post timestamp for denormalization
             post_ts = DatabaseUtils.parse_timestamp(
-                content_data.get('timestamp') or content_data.get('published_at')
+                content_data.get("timestamp") or content_data.get("published_at")
             )
 
             prediction = Prediction(
@@ -162,7 +188,7 @@ class PredictionOperations:
                 shitpost_id=content_id if not use_signal else None,
                 signal_id=content_id if use_signal else None,
                 post_timestamp=post_ts,
-                analysis_status='bypassed',
+                analysis_status="bypassed",
                 analysis_comment=reason,
                 # Set minimal required fields for bypassed posts
                 confidence=None,
@@ -173,17 +199,17 @@ class PredictionOperations:
                 viral_score=None,
                 sentiment_score=None,
                 urgency_score=None,
-                has_media=content_data.get('has_media', False),
-                mentions_count=len(content_data.get('mentions', [])),
-                hashtags_count=len(content_data.get('tags', [])),
-                content_length=len(content_data.get('text', '')),
-                replies_at_analysis=content_data.get('replies_count', 0),
-                reblogs_at_analysis=content_data.get('reblogs_count', 0),
-                favourites_at_analysis=content_data.get('favourites_count', 0),
-                upvotes_at_analysis=content_data.get('upvotes_count', 0),
+                has_media=content_data.get("has_media", False),
+                mentions_count=len(content_data.get("mentions", [])),
+                hashtags_count=len(content_data.get("tags", [])),
+                content_length=len(content_data.get("text", "")),
+                replies_at_analysis=content_data.get("replies_count", 0),
+                reblogs_at_analysis=content_data.get("reblogs_count", 0),
+                favourites_at_analysis=content_data.get("favourites_count", 0),
+                upvotes_at_analysis=content_data.get("upvotes_count", 0),
                 llm_provider=None,
                 llm_model=None,
-                analysis_timestamp=datetime.now()
+                analysis_timestamp=datetime.now(),
             )
 
             self.db_ops.session.add(prediction)
@@ -196,8 +222,7 @@ class PredictionOperations:
         except Exception as e:
             logger.error(f"Error creating bypassed prediction: {e}")
             return None
-    
-    
+
     async def check_prediction_exists(
         self,
         content_id: str,

--- a/shitvault/shitpost_models.py
+++ b/shitvault/shitpost_models.py
@@ -127,9 +127,7 @@ class Prediction(Base, IDMixin, TimestampMixin):
         String(255), ForeignKey("truth_social_shitposts.shitpost_id"), nullable=True
     )
     # New FK -- points to the source-agnostic signals table
-    signal_id = Column(
-        String(255), ForeignKey("signals.signal_id"), nullable=True
-    )
+    signal_id = Column(String(255), ForeignKey("signals.signal_id"), nullable=True)
 
     # Denormalized source post timestamp (avoids N+1 loading shitpost/signal)
     post_timestamp = Column(DateTime(timezone=True), nullable=True)
@@ -180,9 +178,16 @@ class Prediction(Base, IDMixin, TimestampMixin):
     llm_model = Column(String(100), nullable=True)  # gpt-4, claude-3, etc.
     analysis_timestamp = Column(DateTime, nullable=True)
 
+    # Ensemble metadata (Feature 05 — null for single-model predictions)
+    ensemble_results = Column(JSON, nullable=True)  # Per-model outputs
+    ensemble_metadata = Column(JSON, nullable=True)  # Agreement metrics
+
     # Relationships
     shitpost = relationship("TruthSocialShitpost", back_populates="predictions")
-    signal = relationship("Signal", back_populates="predictions", foreign_keys=[signal_id])
+    signal = relationship(
+        "Signal", back_populates="predictions", foreign_keys=[signal_id]
+    )
+
     @property
     def content_id(self) -> str:
         """Return the signal or shitpost ID, whichever is set."""
@@ -213,5 +218,3 @@ Index("idx_predictions_shitpost_id", Prediction.shitpost_id)
 Index("idx_predictions_signal_id", Prediction.signal_id)
 Index("idx_predictions_analysis_status", Prediction.analysis_status)
 Index("idx_predictions_created_at", Prediction.created_at)
-
-


### PR DESCRIPTION
## Summary
- Run posts through GPT-4o, Claude, and Grok in parallel; merge into consensus prediction
- Extended `ProviderComparator` with `ConsensusBuilder` — majority-vote sentiment, raw mean confidence, Jaccard asset agreement, dissenting view capture
- `ENSEMBLE_ENABLED` setting (opt-in, default off) with graceful single-model fallback
- `ensemble_results` and `ensemble_metadata` JSONB columns on predictions table
- Telegram alerts show model agreement level, confidence spread, and dissents
- React frontend: expandable "Model Comparison" panel in PredictionPanel
- 24 new tests (20 consensus unit + 4 analyzer integration), 2055 total passing

## Production Deployment
```sql
ALTER TABLE predictions ADD COLUMN ensemble_results JSONB;
ALTER TABLE predictions ADD COLUMN ensemble_metadata JSONB;
```
Railway env vars (when ready to activate):
```
ENSEMBLE_ENABLED=true
ENSEMBLE_PROVIDERS=openai,anthropic,grok
ANTHROPIC_API_KEY=sk-ant-xxx
XAI_API_KEY=xai-xxx
```

## Test plan
- [x] 24 new ensemble tests pass
- [x] 2055 total tests pass (0 failures)
- [x] ruff lint clean
- [x] TypeScript compiles clean
- [x] Frontend builds successfully
- [x] Ensemble disabled by default — zero behavior change until ENSEMBLE_ENABLED=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)