### PR TITLE
feat: conviction voting — inline Bull/Bear/Skip on Telegram alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Conviction Voting** — Inline Bull/Bear/Skip voting buttons on Telegram alerts with accuracy tracking
+  - `ConvictionVote` model with `conviction_votes` table (one vote per user per prediction)
+  - `vote_db.py`: CRUD operations (record_vote, get_vote, get_vote_tally, get_user_stats, get_user_streak, get_leaderboard, get_llm_vs_crowd_stats)
+  - `vote_maturation.py`: majority-of-assets correctness evaluation against T+7 outcomes
+  - Telegram sender: `build_vote_keyboard`, `build_voted_keyboard`, `answer_callback_query`, `edit_message_reply_markup`
+  - Bot: callback_query routing in `process_update`, `/mystats` and `/leaderboard` commands
+  - Both alert paths (cron engine + event consumer) attach vote keyboard to alerts
+  - Scorecard integration pre-wired (leaderboard + LLM vs crowd comparison)
+  - 52 new tests across test_vote_db, test_vote_maturation, test_vote_callback
 - **Multi-LLM Ensemble Analysis** — Run posts through GPT-4o, Claude, and Grok in parallel; merge into consensus prediction
   - Extended `ProviderComparator` with `ConsensusBuilder` (majority-vote sentiment, raw mean confidence, Jaccard asset agreement)
   - `EnsembleResult`/`ConsensusResult` dataclasses with DB serialization

--- a/documentation/planning/product-brainstorm_2026-04-09/11_CONVICTION_VOTING.md
+++ b/documentation/planning/product-brainstorm_2026-04-09/11_CONVICTION_VOTING.md
@@ -1,6 +1,6 @@
 # Feature 11: Conviction Voting
 
-**Status:** Planning
+**Status:** COMPLETE (PR #139, 2026-04-12)
 **Date:** 2026-04-09
 **Priority:** Medium -- social engagement feature, builds community, generates crowd-sourced signal data
 

--- a/notifications/alert_engine.py
+++ b/notifications/alert_engine.py
@@ -17,7 +17,11 @@ from notifications.db import (
     record_alert_sent,
     record_error,
 )
-from notifications.telegram_sender import format_telegram_alert, send_telegram_message
+from notifications.telegram_sender import (
+    build_vote_keyboard,
+    format_telegram_alert,
+    send_telegram_message,
+)
 from shit.logging import get_service_logger
 
 logger = get_service_logger("alert_engine")
@@ -103,14 +107,19 @@ def check_and_dispatch() -> Dict[str, Any]:
         chat_id = sub["chat_id"]
         for alert in matched:
             message = format_telegram_alert(alert)
-            success, error = send_telegram_message(chat_id, message)
+            prediction_id = alert.get("prediction_id")
+            reply_markup = (
+                build_vote_keyboard(prediction_id) if prediction_id else None
+            )
+            success, error = send_telegram_message(
+                chat_id, message, reply_markup=reply_markup
+            )
 
             if success:
                 record_alert_sent(chat_id)
                 results["alerts_sent"] += 1
 
                 # Create follow-up tracking (fail-open)
-                prediction_id = alert.get("prediction_id")
                 if prediction_id:
                     try:
                         from notifications.followups import create_followup_tracking

--- a/notifications/alert_engine.py
+++ b/notifications/alert_engine.py
@@ -108,9 +108,7 @@ def check_and_dispatch() -> Dict[str, Any]:
         for alert in matched:
             message = format_telegram_alert(alert)
             prediction_id = alert.get("prediction_id")
-            reply_markup = (
-                build_vote_keyboard(prediction_id) if prediction_id else None
-            )
+            reply_markup = build_vote_keyboard(prediction_id) if prediction_id else None
             success, error = send_telegram_message(
                 chat_id, message, reply_markup=reply_markup
             )

--- a/notifications/event_consumer.py
+++ b/notifications/event_consumer.py
@@ -41,6 +41,7 @@ class NotificationsWorker(EventWorker):
             record_error,
         )
         from notifications.telegram_sender import (
+            build_vote_keyboard,
             format_telegram_alert,
             send_telegram_message,
         )
@@ -104,7 +105,12 @@ class NotificationsWorker(EventWorker):
             chat_id = sub["chat_id"]
             for a in matched:
                 message = format_telegram_alert(a)
-                success, error = send_telegram_message(chat_id, message)
+                reply_markup = (
+                    build_vote_keyboard(prediction_id) if prediction_id else None
+                )
+                success, error = send_telegram_message(
+                    chat_id, message, reply_markup=reply_markup
+                )
 
                 if success:
                     record_alert_sent(chat_id)

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -122,3 +122,40 @@ class AlertFollowup(Base, IDMixin, TimestampMixin):
             f"chat_id={self.chat_id}, "
             f"1h={self.sent_1h}, 1d={self.sent_1d}, 7d={self.sent_7d})>"
         )
+
+
+class ConvictionVote(Base, IDMixin, TimestampMixin):
+    """Tracks user votes on predictions for crowd-sourced accuracy.
+
+    Each subscriber can vote bull/bear/skip on a prediction. Votes are
+    evaluated against T+7 market outcomes by the vote maturation job.
+    """
+
+    __tablename__ = "conviction_votes"
+    __table_args__ = (
+        UniqueConstraint(
+            "prediction_id",
+            "chat_id",
+            name="uq_conviction_votes_prediction_chat",
+        ),
+    )
+
+    prediction_id = Column(
+        Integer, ForeignKey("predictions.id"), nullable=False, index=True
+    )
+    chat_id = Column(String(50), nullable=False, index=True)
+    username = Column(String(100), nullable=True)
+
+    vote = Column(String(10), nullable=False)  # bull, bear, skip
+    voted_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    # Filled by vote maturation job after T+7 outcomes
+    vote_correct = Column(Boolean, nullable=True)
+    evaluated_at = Column(DateTime, nullable=True)
+
+    def __repr__(self):
+        return (
+            f"<ConvictionVote(prediction_id={self.prediction_id}, "
+            f"chat_id={self.chat_id}, vote={self.vote}, "
+            f"correct={self.vote_correct})>"
+        )

--- a/notifications/telegram_bot.py
+++ b/notifications/telegram_bot.py
@@ -2,8 +2,8 @@
 Telegram Bot command handlers for Shitpost Alpha.
 
 Handles /start, /stop, /status, /settings, /watchlist, /briefing, /followups,
-/scorecard, /stats, /latest, /help
-commands and routes incoming webhook updates to the appropriate handler.
+/scorecard, /stats, /latest, /mystats, /leaderboard, /help commands,
+inline keyboard vote callbacks, and routes incoming webhook updates.
 """
 
 import json
@@ -18,7 +18,13 @@ from notifications.db import (
     get_subscription,
     update_subscription,
 )
-from notifications.telegram_sender import escape_markdown, send_telegram_message
+from notifications.telegram_sender import (
+    answer_callback_query,
+    build_voted_keyboard,
+    edit_message_reply_markup,
+    escape_markdown,
+    send_telegram_message,
+)
 from shit.logging import get_service_logger
 
 logger = get_service_logger("telegram_bot")
@@ -76,9 +82,12 @@ You're now subscribed to receive real\\-time prediction alerts\\.
 /status \\- Check subscription status
 /stats \\- View prediction accuracy
 /latest \\- Show recent predictions
+/mystats \\- Your voting accuracy
+/leaderboard \\- Top voters leaderboard
 /stop \\- Unsubscribe from alerts
 /help \\- Show all commands
 
+_Alerts include voting buttons \\- tap Bull, Bear, or Skip to track your accuracy\\!_
 _Alerts will be sent when new high\\-confidence predictions are detected\\._
 """
     else:
@@ -363,6 +372,8 @@ def handle_help_command() -> str:
 /scorecard \\- Weekly performance scorecard
 /stats \\- View prediction accuracy stats
 /latest \\- Show recent predictions
+/mystats \\- Your personal voting accuracy
+/leaderboard \\- Top voters vs LLM accuracy
 /help \\- Show this help message
 
 *Watchlist Examples:*
@@ -842,6 +853,172 @@ def handle_watchlist_command(chat_id: str, args: str = "") -> str:
 
 
 # ============================================================
+# Conviction Voting
+# ============================================================
+
+
+def handle_vote_callback(callback_query: dict) -> None:
+    """Process an inline keyboard vote callback.
+
+    Args:
+        callback_query: Telegram callback_query object.
+    """
+    from notifications.vote_db import (
+        get_vote,
+        get_vote_tally,
+        is_prediction_evaluated,
+        record_vote,
+    )
+
+    callback_data = callback_query.get("data", "")
+    from_user = callback_query.get("from", {})
+    chat_id = str(from_user.get("id", ""))
+    username = from_user.get("username")
+    message = callback_query.get("message", {})
+    message_id = message.get("message_id")
+    message_chat_id = str(message.get("chat", {}).get("id", ""))
+    callback_id = callback_query.get("id")
+
+    # Parse callback data: "vote:{prediction_id}:{vote_value}"
+    parts = callback_data.split(":")
+    if len(parts) != 3 or parts[0] != "vote":
+        answer_callback_query(callback_id, "Invalid vote")
+        return
+
+    try:
+        prediction_id = int(parts[1])
+    except (ValueError, TypeError):
+        answer_callback_query(callback_id, "Invalid prediction")
+        return
+
+    vote_value = parts[2]
+    if vote_value not in ("bull", "bear", "skip"):
+        answer_callback_query(callback_id, "Invalid vote value")
+        return
+
+    # Check if voting is closed (prediction already evaluated)
+    if is_prediction_evaluated(prediction_id):
+        answer_callback_query(
+            callback_id, "Voting closed for this prediction", show_alert=True
+        )
+        return
+
+    # Check if user already voted
+    existing = get_vote(prediction_id, chat_id)
+    if existing:
+        vote_emoji = {
+            "bull": "\U0001f7e2",
+            "bear": "\U0001f534",
+            "skip": "\u23ed",
+        }.get(existing["vote"], "")
+        answer_callback_query(
+            callback_id,
+            f"Already voted {vote_emoji} {existing['vote'].upper()}",
+        )
+        return
+
+    # Record the vote
+    record_vote(prediction_id, chat_id, vote_value, username=username)
+
+    # Acknowledge with toast
+    vote_emoji = {
+        "bull": "\U0001f7e2",
+        "bear": "\U0001f534",
+        "skip": "\u23ed",
+    }.get(vote_value, "")
+    answer_callback_query(callback_id, f"{vote_emoji} Voted {vote_value.upper()}")
+
+    # Update keyboard with tallies
+    tally = get_vote_tally(prediction_id)
+    edit_message_reply_markup(
+        chat_id=message_chat_id,
+        message_id=message_id,
+        reply_markup=build_voted_keyboard(prediction_id, tally),
+    )
+
+
+def handle_mystats_command(chat_id: str) -> str:
+    """Handle /mystats command — show personal voting accuracy."""
+    from notifications.vote_db import get_user_stats, get_user_streak
+
+    stats = get_user_stats(chat_id)
+    if stats.get("total_votes", 0) == 0:
+        return (
+            "\U0001f4ca *Your Voting Stats*\n\n"
+            "You haven't voted on any predictions yet\\.\n"
+            "Start voting on alerts to track your accuracy\\!"
+        )
+
+    streak = get_user_streak(chat_id)
+    streak_text = ""
+    if streak.get("streak_type"):
+        streak_emoji = (
+            "\U0001f525" if streak["streak_type"] == "win" else "\u2744\ufe0f"
+        )
+        streak_text = (
+            f"\n{streak_emoji} *Current streak:* "
+            f"{streak['streak_length']} "
+            f"{'wins' if streak['streak_type'] == 'win' else 'losses'}"
+        )
+
+    accuracy = stats["accuracy_pct"]
+    if accuracy >= 60:
+        grade = "\U0001f3c6"
+    elif accuracy >= 50:
+        grade = "\U0001f44d"
+    else:
+        grade = "\U0001f914"
+
+    return (
+        f"\U0001f4ca *Your Voting Stats*\n\n"
+        f"{grade} *Overall Accuracy:* {accuracy}%\n"
+        f"\u2705 Correct: {stats['correct']}\n"
+        f"\u274c Incorrect: {stats['incorrect']}\n"
+        f"\u23f3 Pending: {stats['pending']}\n"
+        f"\u23ed Skipped: {stats['skipped']}\n\n"
+        f"*By Direction:*\n"
+        f"\U0001f7e2 Bull accuracy: {stats['bull_accuracy']}%\n"
+        f"\U0001f534 Bear accuracy: {stats['bear_accuracy']}%"
+        f"{streak_text}\n\n"
+        f"_Stats based on T\\+7 trading day outcomes\\._"
+    )
+
+
+def handle_leaderboard_command(chat_id: str) -> str:
+    """Handle /leaderboard command — show top voters by accuracy."""
+    from notifications.vote_db import get_leaderboard, get_llm_vs_crowd_stats
+
+    leaders = get_leaderboard(limit=10)
+    if not leaders:
+        return (
+            "\U0001f3c6 *Leaderboard*\n\n"
+            "Not enough data yet\\. Need at least 5 evaluated votes per voter\\."
+        )
+
+    lines = ["\U0001f3c6 *Conviction Voting Leaderboard*\n"]
+
+    for i, leader in enumerate(leaders, 1):
+        medal = {1: "\U0001f947", 2: "\U0001f948", 3: "\U0001f949"}.get(i, f"{i}\\.")
+        name = escape_markdown(str(leader["display_name"])[:15])
+        acc = leader["accuracy_pct"]
+        correct = leader["correct"]
+        total = leader["evaluated"]
+        lines.append(f"{medal} *{name}* \\- {acc}% \\({correct}/{total}\\)")
+
+    # LLM vs Crowd comparison
+    comparison = get_llm_vs_crowd_stats()
+    if comparison.get("total_evaluated", 0) >= 5:
+        lines.append("")
+        lines.append("*LLM vs Crowd:*")
+        lines.append(f"\U0001f916 LLM: {comparison['llm_accuracy']}% accurate")
+        lines.append(f"\U0001f465 Crowd: {comparison['crowd_accuracy']}% accurate")
+        lines.append(f"\U0001f91d Agreement: {comparison['agreement_rate']}%")
+
+    lines.append("\n_Min 5 evaluated votes to qualify\\._")
+    return "\n".join(lines)
+
+
+# ============================================================
 # Update Router
 # ============================================================
 
@@ -859,6 +1036,12 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
     Returns:
         Response message, or None if no response needed.
     """
+    # Handle callback queries (inline keyboard votes)
+    callback_query = update.get("callback_query")
+    if callback_query:
+        handle_vote_callback(callback_query)
+        return None
+
     message = update.get("message", {})
     if not message:
         return None
@@ -908,6 +1091,10 @@ def process_update(update: Dict[str, Any]) -> Optional[str]:
         response = handle_stats_command(chat_id)
     elif command == "/latest":
         response = handle_latest_command(chat_id)
+    elif command == "/mystats":
+        response = handle_mystats_command(chat_id)
+    elif command == "/leaderboard":
+        response = handle_leaderboard_command(chat_id)
     elif command == "/help":
         response = handle_help_command()
 

--- a/notifications/telegram_sender.py
+++ b/notifications/telegram_sender.py
@@ -245,6 +245,140 @@ def _format_ensemble_section(alert: Dict[str, Any]) -> str:
     return f"\U0001f916 {line}\n\n"
 
 
+def build_vote_keyboard(prediction_id: int) -> dict:
+    """Build inline keyboard with voting buttons.
+
+    Args:
+        prediction_id: ID to embed in callback_data.
+
+    Returns:
+        reply_markup dict for Telegram API.
+    """
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "\U0001f7e2 Bull",
+                    "callback_data": f"vote:{prediction_id}:bull",
+                },
+                {
+                    "text": "\U0001f534 Bear",
+                    "callback_data": f"vote:{prediction_id}:bear",
+                },
+                {
+                    "text": "\u23ed Skip",
+                    "callback_data": f"vote:{prediction_id}:skip",
+                },
+            ]
+        ]
+    }
+
+
+def build_voted_keyboard(prediction_id: int, tally: dict) -> dict:
+    """Build keyboard showing current vote tallies.
+
+    Args:
+        prediction_id: Prediction ID.
+        tally: Dict with bull, bear, skip counts.
+
+    Returns:
+        reply_markup dict.
+    """
+    bull_count = tally.get("bull", 0)
+    bear_count = tally.get("bear", 0)
+    skip_count = tally.get("skip", 0)
+
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": f"\U0001f7e2 Bull ({bull_count})",
+                    "callback_data": f"vote:{prediction_id}:bull",
+                },
+                {
+                    "text": f"\U0001f534 Bear ({bear_count})",
+                    "callback_data": f"vote:{prediction_id}:bear",
+                },
+                {
+                    "text": f"\u23ed Skip ({skip_count})",
+                    "callback_data": f"vote:{prediction_id}:skip",
+                },
+            ]
+        ]
+    }
+
+
+def answer_callback_query(
+    callback_query_id: str,
+    text: str,
+    show_alert: bool = False,
+) -> Tuple[bool, Optional[str]]:
+    """Answer a callback query (toast notification to the user).
+
+    Args:
+        callback_query_id: The callback query ID from Telegram.
+        text: Text to show in the toast.
+        show_alert: If True, show as a popup instead of a toast.
+
+    Returns:
+        Tuple of (success, error_message).
+    """
+    bot_token = get_bot_token()
+    if not bot_token:
+        return False, "Bot token not configured"
+
+    url = TELEGRAM_API_BASE.format(token=bot_token, method="answerCallbackQuery")
+    payload = {
+        "callback_query_id": callback_query_id,
+        "text": text,
+        "show_alert": show_alert,
+    }
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        data = response.json()
+        return (True, None) if data.get("ok") else (False, data.get("description"))
+    except Exception as e:
+        logger.error(f"Error answering callback query: {e}")
+        return False, str(e)
+
+
+def edit_message_reply_markup(
+    chat_id: str,
+    message_id: int,
+    reply_markup: Optional[dict] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Edit the inline keyboard of an existing message.
+
+    Args:
+        chat_id: Chat where the message lives.
+        message_id: ID of the message to edit.
+        reply_markup: New inline keyboard markup (or None to remove).
+
+    Returns:
+        Tuple of (success, error_message).
+    """
+    bot_token = get_bot_token()
+    if not bot_token:
+        return False, "Bot token not configured"
+
+    url = TELEGRAM_API_BASE.format(token=bot_token, method="editMessageReplyMarkup")
+    payload: Dict[str, Any] = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+    }
+    if reply_markup:
+        payload["reply_markup"] = json.dumps(reply_markup)
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        data = response.json()
+        return (True, None) if data.get("ok") else (False, data.get("description"))
+    except Exception as e:
+        logger.error(f"Error editing message reply markup: {e}")
+        return False, str(e)
+
+
 def escape_markdown(text: str) -> str:
     """Escape special Markdown characters for Telegram."""
     if not text:

--- a/notifications/vote_db.py
+++ b/notifications/vote_db.py
@@ -12,7 +12,6 @@ from notifications.db import (
     _execute_write,
     _extract_scalar,
     _row_to_dict,
-    _rows_to_dicts,
 )
 from shit.logging import get_service_logger
 

--- a/notifications/vote_db.py
+++ b/notifications/vote_db.py
@@ -1,0 +1,304 @@
+"""
+Database operations for conviction voting.
+
+Provides CRUD for votes, tallies, user stats, leaderboard,
+and LLM-vs-crowd comparison queries.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from notifications.db import (
+    _execute_read,
+    _execute_write,
+    _extract_scalar,
+    _row_to_dict,
+    _rows_to_dicts,
+)
+from shit.logging import get_service_logger
+
+logger = get_service_logger("vote_db")
+
+
+def record_vote(
+    prediction_id: int,
+    chat_id: str,
+    vote: str,
+    username: Optional[str] = None,
+) -> bool:
+    """Record a conviction vote. Silently ignores duplicates.
+
+    Args:
+        prediction_id: Prediction being voted on.
+        chat_id: Voter's Telegram chat ID.
+        vote: 'bull', 'bear', or 'skip'.
+        username: Optional Telegram username for leaderboard display.
+
+    Returns:
+        True if recorded successfully.
+    """
+    return _execute_write(
+        """
+        INSERT INTO conviction_votes
+            (prediction_id, chat_id, username, vote, voted_at, created_at, updated_at)
+        VALUES
+            (:prediction_id, :chat_id, :username, :vote, NOW(), NOW(), NOW())
+        ON CONFLICT (prediction_id, chat_id) DO NOTHING
+        """,
+        params={
+            "prediction_id": prediction_id,
+            "chat_id": str(chat_id),
+            "username": username,
+            "vote": vote,
+        },
+        context="record_vote",
+    )
+
+
+def get_vote(prediction_id: int, chat_id: str) -> Optional[Dict[str, Any]]:
+    """Get a specific user's vote on a prediction."""
+    return _execute_read(
+        """
+        SELECT id, prediction_id, chat_id, vote, voted_at, vote_correct, evaluated_at
+        FROM conviction_votes
+        WHERE prediction_id = :prediction_id AND chat_id = :chat_id
+        """,
+        params={"prediction_id": prediction_id, "chat_id": str(chat_id)},
+        processor=_row_to_dict,
+        default=None,
+        context="get_vote",
+    )
+
+
+def is_prediction_evaluated(prediction_id: int) -> bool:
+    """Check if votes for this prediction have already been evaluated."""
+    result = _execute_read(
+        """
+        SELECT COUNT(*) as cnt
+        FROM conviction_votes
+        WHERE prediction_id = :prediction_id
+            AND vote_correct IS NOT NULL
+        """,
+        params={"prediction_id": prediction_id},
+        processor=_extract_scalar,
+        default=0,
+        context="is_prediction_evaluated",
+    )
+    return (result or 0) > 0
+
+
+def get_vote_tally(prediction_id: int) -> Dict[str, int]:
+    """Get vote counts for a prediction.
+
+    Returns:
+        Dict like {"bull": 7, "bear": 3, "skip": 2, "total": 12}.
+    """
+    rows = _execute_read(
+        """
+        SELECT vote, COUNT(*) as count
+        FROM conviction_votes
+        WHERE prediction_id = :prediction_id
+        GROUP BY vote
+        """,
+        params={"prediction_id": prediction_id},
+        default=[],
+        context="get_vote_tally",
+    )
+
+    tally: Dict[str, int] = {"bull": 0, "bear": 0, "skip": 0}
+    for row in rows:
+        tally[row["vote"]] = row["count"]
+    tally["total"] = sum(tally.values())
+    return tally
+
+
+def get_user_stats(chat_id: str) -> Dict[str, Any]:
+    """Get accuracy statistics for a specific user.
+
+    Returns:
+        Dict with total_votes, correct, incorrect, pending, skipped,
+        accuracy_pct, bull_accuracy, bear_accuracy.
+    """
+    row = _execute_read(
+        """
+        SELECT
+            COUNT(*) as total_votes,
+            COUNT(CASE WHEN vote_correct = true THEN 1 END) as correct,
+            COUNT(CASE WHEN vote_correct = false THEN 1 END) as incorrect,
+            COUNT(CASE WHEN vote_correct IS NULL AND vote != 'skip' THEN 1 END) as pending,
+            COUNT(CASE WHEN vote = 'skip' THEN 1 END) as skipped,
+            COUNT(CASE WHEN vote = 'bull' AND vote_correct = true THEN 1 END) as bull_correct,
+            COUNT(CASE WHEN vote = 'bull' AND vote_correct IS NOT NULL THEN 1 END) as bull_total,
+            COUNT(CASE WHEN vote = 'bear' AND vote_correct = true THEN 1 END) as bear_correct,
+            COUNT(CASE WHEN vote = 'bear' AND vote_correct IS NOT NULL THEN 1 END) as bear_total
+        FROM conviction_votes
+        WHERE chat_id = :chat_id
+        """,
+        params={"chat_id": str(chat_id)},
+        processor=_row_to_dict,
+        default=None,
+        context="get_user_stats",
+    )
+
+    if not row:
+        return {"total_votes": 0}
+
+    evaluated = (row["correct"] or 0) + (row["incorrect"] or 0)
+    accuracy = (row["correct"] / evaluated * 100) if evaluated > 0 else 0.0
+
+    bull_total = row["bull_total"] or 0
+    bear_total = row["bear_total"] or 0
+
+    return {
+        "total_votes": row["total_votes"] or 0,
+        "correct": row["correct"] or 0,
+        "incorrect": row["incorrect"] or 0,
+        "pending": row["pending"] or 0,
+        "skipped": row["skipped"] or 0,
+        "accuracy_pct": round(accuracy, 1),
+        "bull_accuracy": round(
+            (row["bull_correct"] / bull_total * 100) if bull_total > 0 else 0, 1
+        ),
+        "bear_accuracy": round(
+            (row["bear_correct"] / bear_total * 100) if bear_total > 0 else 0, 1
+        ),
+    }
+
+
+def get_user_streak(chat_id: str) -> Dict[str, Any]:
+    """Get current win/loss streak for a user.
+
+    Returns:
+        Dict with streak_type ('win' or 'loss') and streak_length.
+    """
+    rows = _execute_read(
+        """
+        SELECT vote_correct
+        FROM conviction_votes
+        WHERE chat_id = :chat_id
+            AND vote_correct IS NOT NULL
+            AND vote != 'skip'
+        ORDER BY voted_at DESC
+        LIMIT 50
+        """,
+        params={"chat_id": str(chat_id)},
+        default=[],
+        context="get_user_streak",
+    )
+
+    if not rows:
+        return {"streak_type": None, "streak_length": 0}
+
+    current_value = rows[0]["vote_correct"]
+    streak = 0
+    for row in rows:
+        if row["vote_correct"] == current_value:
+            streak += 1
+        else:
+            break
+
+    return {
+        "streak_type": "win" if current_value else "loss",
+        "streak_length": streak,
+    }
+
+
+def get_leaderboard(limit: int = 10) -> List[Dict[str, Any]]:
+    """Get the top voters by accuracy (min 5 evaluated votes).
+
+    Returns:
+        List of dicts with display_name, accuracy_pct, correct, evaluated.
+    """
+    return _execute_read(
+        """
+        SELECT
+            chat_id,
+            COALESCE(username, 'Anonymous') as display_name,
+            COUNT(CASE WHEN vote_correct = true THEN 1 END) as correct,
+            COUNT(CASE WHEN vote_correct IS NOT NULL THEN 1 END) as evaluated,
+            ROUND(
+                COUNT(CASE WHEN vote_correct = true THEN 1 END)::numeric
+                / NULLIF(COUNT(CASE WHEN vote_correct IS NOT NULL THEN 1 END), 0)
+                * 100, 1
+            ) as accuracy_pct
+        FROM conviction_votes
+        WHERE vote != 'skip'
+        GROUP BY chat_id, username
+        HAVING COUNT(CASE WHEN vote_correct IS NOT NULL THEN 1 END) >= 5
+        ORDER BY accuracy_pct DESC, correct DESC
+        LIMIT :limit
+        """,
+        params={"limit": limit},
+        default=[],
+        context="get_leaderboard",
+    )
+
+
+def get_llm_vs_crowd_stats() -> Dict[str, Any]:
+    """Compare LLM accuracy vs crowd vote accuracy.
+
+    Uses majority vote across non-skip voters as the crowd signal.
+    Requires at least 3 non-skip votes per prediction.
+
+    Returns:
+        Dict with total_evaluated, llm_accuracy, crowd_accuracy, agreement_rate.
+    """
+    row = _execute_read(
+        """
+        WITH vote_majority AS (
+            SELECT
+                cv.prediction_id,
+                MODE() WITHIN GROUP (ORDER BY cv.vote) as crowd_vote,
+                COUNT(*) as vote_count
+            FROM conviction_votes cv
+            WHERE cv.vote != 'skip'
+            GROUP BY cv.prediction_id
+            HAVING COUNT(*) >= 3
+        ),
+        outcomes AS (
+            SELECT
+                po.prediction_id,
+                po.prediction_sentiment as llm_vote,
+                po.correct_t7 as llm_correct,
+                CASE
+                    WHEN vm.crowd_vote = 'bull' AND po.return_t7 > 0.5 THEN true
+                    WHEN vm.crowd_vote = 'bear' AND po.return_t7 < -0.5 THEN true
+                    WHEN vm.crowd_vote = 'bull' AND po.return_t7 <= 0.5 THEN false
+                    WHEN vm.crowd_vote = 'bear' AND po.return_t7 >= -0.5 THEN false
+                    ELSE NULL
+                END as crowd_correct,
+                CASE
+                    WHEN vm.crowd_vote =
+                        CASE po.prediction_sentiment
+                            WHEN 'bullish' THEN 'bull'
+                            WHEN 'bearish' THEN 'bear'
+                            ELSE 'skip'
+                        END
+                    THEN true
+                    ELSE false
+                END as agreed
+            FROM vote_majority vm
+            JOIN prediction_outcomes po ON po.prediction_id = vm.prediction_id
+            WHERE po.correct_t7 IS NOT NULL
+        )
+        SELECT
+            COUNT(*) as total_evaluated,
+            COUNT(CASE WHEN llm_correct = true THEN 1 END) as llm_correct_count,
+            COUNT(CASE WHEN crowd_correct = true THEN 1 END) as crowd_correct_count,
+            COUNT(CASE WHEN agreed = true THEN 1 END) as agreement_count
+        FROM outcomes
+        """,
+        processor=_row_to_dict,
+        default=None,
+        context="get_llm_vs_crowd_stats",
+    )
+
+    if not row or not row.get("total_evaluated"):
+        return {"total_evaluated": 0}
+
+    total = row["total_evaluated"]
+    return {
+        "total_evaluated": total,
+        "llm_accuracy": round((row["llm_correct_count"] / total) * 100, 1),
+        "crowd_accuracy": round((row["crowd_correct_count"] / total) * 100, 1),
+        "agreement_rate": round((row["agreement_count"] / total) * 100, 1),
+    }

--- a/notifications/vote_maturation.py
+++ b/notifications/vote_maturation.py
@@ -7,9 +7,9 @@ logic: a bull vote is correct if the majority of the prediction's assets
 had return_t7 > +0.5%, and vice versa for bear.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-from notifications.db import _execute_read, _execute_write, _rows_to_dicts
+from notifications.db import _execute_read, _execute_write
 from shit.logging import get_service_logger
 
 logger = get_service_logger("vote_maturation")

--- a/notifications/vote_maturation.py
+++ b/notifications/vote_maturation.py
@@ -1,0 +1,119 @@
+"""
+Vote maturation — evaluates conviction votes against T+7 outcomes.
+
+Runs alongside the outcome maturation cron job. After prediction_outcomes
+are filled, this module checks each vote's correctness using majority-of-assets
+logic: a bull vote is correct if the majority of the prediction's assets
+had return_t7 > +0.5%, and vice versa for bear.
+"""
+
+from typing import Any, Dict, List
+
+from notifications.db import _execute_read, _execute_write, _rows_to_dicts
+from shit.logging import get_service_logger
+
+logger = get_service_logger("vote_maturation")
+
+
+def evaluate_votes_for_prediction(prediction_id: int) -> bool:
+    """Evaluate all votes for a prediction against T+7 outcomes.
+
+    Uses majority-of-assets logic:
+    - Count assets with return_t7 > +0.5% (bullish) and < -0.5% (bearish)
+    - If more assets are bullish, bull votes are correct
+    - If more assets are bearish, bear votes are correct
+    - If tied or all flat, no votes are marked correct
+    - Skip votes are never evaluated
+
+    Args:
+        prediction_id: Prediction whose votes to evaluate.
+
+    Returns:
+        True if any votes were evaluated.
+    """
+    # Get all outcomes for this prediction
+    outcomes = _execute_read(
+        """
+        SELECT symbol, return_t7
+        FROM prediction_outcomes
+        WHERE prediction_id = :pid AND return_t7 IS NOT NULL
+        """,
+        params={"pid": prediction_id},
+        default=[],
+        context="get_outcomes_for_vote_eval",
+    )
+
+    if not outcomes:
+        return False
+
+    # Majority-of-assets: count bullish vs bearish outcomes
+    bullish_count = sum(1 for o in outcomes if (o["return_t7"] or 0) > 0.5)
+    bearish_count = sum(1 for o in outcomes if (o["return_t7"] or 0) < -0.5)
+
+    if bullish_count == 0 and bearish_count == 0:
+        # All assets flat — mark all non-skip votes as incorrect
+        market_direction = "flat"
+    elif bullish_count > bearish_count:
+        market_direction = "bull"
+    elif bearish_count > bullish_count:
+        market_direction = "bear"
+    else:
+        # Tied — can't determine, mark as incorrect
+        market_direction = "flat"
+
+    # Evaluate votes: bull correct if market went bull, bear correct if market went bear
+    return _execute_write(
+        """
+        UPDATE conviction_votes
+        SET vote_correct = CASE
+                WHEN :direction = 'flat' THEN false
+                WHEN vote = :direction THEN true
+                ELSE false
+            END,
+            evaluated_at = NOW(),
+            updated_at = NOW()
+        WHERE prediction_id = :pid
+            AND vote != 'skip'
+            AND vote_correct IS NULL
+        """,
+        params={"pid": prediction_id, "direction": market_direction},
+        context="evaluate_votes",
+    )
+
+
+def mature_all_votes() -> Dict[str, Any]:
+    """Evaluate votes for all predictions with matured outcomes.
+
+    Finds predictions that have:
+    - T+7 outcomes available (return_t7 IS NOT NULL)
+    - Unevaluated votes (vote_correct IS NULL, vote != 'skip')
+
+    Returns:
+        Stats dict with predictions_processed count.
+    """
+    predictions = _execute_read(
+        """
+        SELECT DISTINCT cv.prediction_id
+        FROM conviction_votes cv
+        JOIN prediction_outcomes po ON po.prediction_id = cv.prediction_id
+        WHERE cv.vote_correct IS NULL
+            AND cv.vote != 'skip'
+            AND po.return_t7 IS NOT NULL
+        LIMIT 100
+        """,
+        default=[],
+        context="find_votes_to_mature",
+    )
+
+    stats: Dict[str, Any] = {"predictions_processed": 0}
+    for row in predictions:
+        success = evaluate_votes_for_prediction(row["prediction_id"])
+        if success:
+            stats["predictions_processed"] += 1
+
+    if stats["predictions_processed"] > 0:
+        logger.info(
+            f"Vote maturation: {stats['predictions_processed']} predictions processed"
+        )
+
+    return stats

--- a/shit_tests/notifications/test_vote_callback.py
+++ b/shit_tests/notifications/test_vote_callback.py
@@ -1,0 +1,333 @@
+"""Tests for vote callback handling and new bot commands."""
+
+from unittest.mock import patch
+
+from notifications.telegram_bot import (
+    handle_leaderboard_command,
+    handle_mystats_command,
+    handle_vote_callback,
+    process_update,
+)
+from notifications.telegram_sender import (
+    build_vote_keyboard,
+    build_voted_keyboard,
+)
+
+
+class TestBuildVoteKeyboard:
+    def test_keyboard_structure(self):
+        kb = build_vote_keyboard(123)
+        assert "inline_keyboard" in kb
+        buttons = kb["inline_keyboard"][0]
+        assert len(buttons) == 3
+        assert buttons[0]["callback_data"] == "vote:123:bull"
+        assert buttons[1]["callback_data"] == "vote:123:bear"
+        assert buttons[2]["callback_data"] == "vote:123:skip"
+
+    def test_button_labels(self):
+        kb = build_vote_keyboard(456)
+        buttons = kb["inline_keyboard"][0]
+        assert "Bull" in buttons[0]["text"]
+        assert "Bear" in buttons[1]["text"]
+        assert "Skip" in buttons[2]["text"]
+
+
+class TestBuildVotedKeyboard:
+    def test_shows_tallies(self):
+        tally = {"bull": 5, "bear": 3, "skip": 1}
+        kb = build_voted_keyboard(123, tally)
+        buttons = kb["inline_keyboard"][0]
+        assert "(5)" in buttons[0]["text"]
+        assert "(3)" in buttons[1]["text"]
+        assert "(1)" in buttons[2]["text"]
+
+    def test_zero_tallies(self):
+        tally = {"bull": 0, "bear": 0, "skip": 0}
+        kb = build_voted_keyboard(123, tally)
+        buttons = kb["inline_keyboard"][0]
+        assert "(0)" in buttons[0]["text"]
+
+
+class TestHandleVoteCallback:
+    def _make_callback(self, pred_id=123, chat_id="456", vote="bull"):
+        return {
+            "id": "callback_123",
+            "data": f"vote:{pred_id}:{vote}",
+            "from": {"id": chat_id, "username": "testuser"},
+            "message": {
+                "message_id": 789,
+                "chat": {"id": chat_id},
+            },
+        }
+
+    @patch("notifications.telegram_bot.edit_message_reply_markup")
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_valid_bull_vote(self, mock_answer, mock_edit, mock_sync_session):
+        with (
+            patch("notifications.vote_db.is_prediction_evaluated", return_value=False),
+            patch("notifications.vote_db.get_vote", return_value=None),
+            patch(
+                "notifications.vote_db.record_vote", return_value=True
+            ) as mock_record,
+            patch(
+                "notifications.vote_db.get_vote_tally",
+                return_value={"bull": 1, "bear": 0, "skip": 0, "total": 1},
+            ),
+        ):
+            handle_vote_callback(self._make_callback())
+
+            mock_record.assert_called_once_with(123, "456", "bull", username="testuser")
+            mock_answer.assert_called_once()
+            assert "Bull" in str(mock_answer.call_args) or "BULL" in str(
+                mock_answer.call_args
+            )
+
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_voting_closed(self, mock_answer, mock_sync_session):
+        with patch("notifications.vote_db.is_prediction_evaluated", return_value=True):
+            handle_vote_callback(self._make_callback())
+
+            mock_answer.assert_called_once()
+            assert "closed" in str(mock_answer.call_args).lower()
+
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_already_voted(self, mock_answer, mock_sync_session):
+        with (
+            patch("notifications.vote_db.is_prediction_evaluated", return_value=False),
+            patch(
+                "notifications.vote_db.get_vote",
+                return_value={"vote": "bull"},
+            ),
+        ):
+            handle_vote_callback(self._make_callback())
+
+            mock_answer.assert_called_once()
+            assert "Already voted" in str(mock_answer.call_args)
+
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_invalid_callback_data(self, mock_answer, mock_sync_session):
+        callback = {
+            "id": "cb_1",
+            "data": "invalid_data",
+            "from": {"id": "456"},
+            "message": {"message_id": 1, "chat": {"id": "456"}},
+        }
+        handle_vote_callback(callback)
+        mock_answer.assert_called_once()
+        assert "Invalid" in str(mock_answer.call_args)
+
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_invalid_vote_value(self, mock_answer, mock_sync_session):
+        callback = {
+            "id": "cb_1",
+            "data": "vote:123:maybe",
+            "from": {"id": "456"},
+            "message": {"message_id": 1, "chat": {"id": "456"}},
+        }
+        handle_vote_callback(callback)
+        mock_answer.assert_called_once()
+        assert "Invalid" in str(mock_answer.call_args)
+
+    @patch("notifications.telegram_bot.answer_callback_query")
+    def test_invalid_prediction_id(self, mock_answer, mock_sync_session):
+        callback = {
+            "id": "cb_1",
+            "data": "vote:abc:bull",
+            "from": {"id": "456"},
+            "message": {"message_id": 1, "chat": {"id": "456"}},
+        }
+        handle_vote_callback(callback)
+        mock_answer.assert_called_once()
+        assert "Invalid" in str(mock_answer.call_args)
+
+
+class TestProcessUpdateCallbackQuery:
+    @patch("notifications.telegram_bot.handle_vote_callback")
+    def test_callback_query_routed(self, mock_handler, mock_sync_session):
+        update = {
+            "callback_query": {
+                "id": "cb_1",
+                "data": "vote:123:bull",
+                "from": {"id": "456"},
+                "message": {"message_id": 1, "chat": {"id": "456"}},
+            }
+        }
+        result = process_update(update)
+        assert result is None
+        mock_handler.assert_called_once()
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    def test_message_still_works(self, mock_send, mock_sync_session):
+        """Regular messages still route to command handlers."""
+        update = {
+            "message": {
+                "chat": {"id": "456", "type": "private"},
+                "text": "/help",
+                "from": {"username": "test"},
+            }
+        }
+        result = process_update(update)
+        assert result is not None
+        assert "Commands" in result or "commands" in result.lower()
+
+
+class TestHandleMystatsCommand:
+    def test_no_votes(self, mock_sync_session):
+        with patch(
+            "notifications.vote_db.get_user_stats",
+            return_value={"total_votes": 0},
+        ):
+            result = handle_mystats_command("456")
+            assert "haven't voted" in result
+
+    def test_with_stats(self, mock_sync_session):
+        with (
+            patch(
+                "notifications.vote_db.get_user_stats",
+                return_value={
+                    "total_votes": 20,
+                    "correct": 12,
+                    "incorrect": 5,
+                    "pending": 3,
+                    "skipped": 0,
+                    "accuracy_pct": 70.6,
+                    "bull_accuracy": 75.0,
+                    "bear_accuracy": 60.0,
+                },
+            ),
+            patch(
+                "notifications.vote_db.get_user_streak",
+                return_value={"streak_type": "win", "streak_length": 4},
+            ),
+        ):
+            result = handle_mystats_command("456")
+            assert "70.6%" in result
+            assert "12" in result
+            assert "5" in result
+            assert "win" in result.lower()
+            assert "4" in result
+
+    def test_with_losing_streak(self, mock_sync_session):
+        with (
+            patch(
+                "notifications.vote_db.get_user_stats",
+                return_value={
+                    "total_votes": 10,
+                    "correct": 3,
+                    "incorrect": 7,
+                    "pending": 0,
+                    "skipped": 0,
+                    "accuracy_pct": 30.0,
+                    "bull_accuracy": 25.0,
+                    "bear_accuracy": 40.0,
+                },
+            ),
+            patch(
+                "notifications.vote_db.get_user_streak",
+                return_value={"streak_type": "loss", "streak_length": 3},
+            ),
+        ):
+            result = handle_mystats_command("456")
+            assert "30.0%" in result
+            assert "loss" in result.lower()
+
+
+class TestHandleLeaderboardCommand:
+    def test_no_data(self, mock_sync_session):
+        with patch("notifications.vote_db.get_leaderboard", return_value=[]):
+            result = handle_leaderboard_command("456")
+            assert "Not enough data" in result
+
+    def test_with_leaders(self, mock_sync_session):
+        with (
+            patch(
+                "notifications.vote_db.get_leaderboard",
+                return_value=[
+                    {
+                        "chat_id": "1",
+                        "display_name": "TraderJoe",
+                        "correct": 8,
+                        "evaluated": 10,
+                        "accuracy_pct": 80.0,
+                    },
+                    {
+                        "chat_id": "2",
+                        "display_name": "CryptoKing",
+                        "correct": 6,
+                        "evaluated": 10,
+                        "accuracy_pct": 60.0,
+                    },
+                ],
+            ),
+            patch(
+                "notifications.vote_db.get_llm_vs_crowd_stats",
+                return_value={"total_evaluated": 0},
+            ),
+        ):
+            result = handle_leaderboard_command("456")
+            assert "TraderJoe" in result
+            assert "CryptoKing" in result
+            assert "80" in result
+
+    def test_with_llm_comparison(self, mock_sync_session):
+        with (
+            patch(
+                "notifications.vote_db.get_leaderboard",
+                return_value=[
+                    {
+                        "chat_id": "1",
+                        "display_name": "User1",
+                        "correct": 8,
+                        "evaluated": 10,
+                        "accuracy_pct": 80.0,
+                    },
+                ],
+            ),
+            patch(
+                "notifications.vote_db.get_llm_vs_crowd_stats",
+                return_value={
+                    "total_evaluated": 10,
+                    "llm_accuracy": 65.0,
+                    "crowd_accuracy": 70.0,
+                    "agreement_rate": 75.0,
+                },
+            ),
+        ):
+            result = handle_leaderboard_command("456")
+            assert "LLM" in result
+            assert "Crowd" in result
+            assert "65" in result
+            assert "70" in result
+
+
+class TestMystatsAndLeaderboardRouting:
+    @patch("notifications.telegram_bot.send_telegram_message")
+    def test_mystats_routed(self, mock_send, mock_sync_session):
+        with patch(
+            "notifications.vote_db.get_user_stats",
+            return_value={"total_votes": 0},
+        ):
+            update = {
+                "message": {
+                    "chat": {"id": "456", "type": "private"},
+                    "text": "/mystats",
+                    "from": {"username": "test"},
+                }
+            }
+            result = process_update(update)
+            assert result is not None
+            assert "haven't voted" in result
+
+    @patch("notifications.telegram_bot.send_telegram_message")
+    def test_leaderboard_routed(self, mock_send, mock_sync_session):
+        with patch("notifications.vote_db.get_leaderboard", return_value=[]):
+            update = {
+                "message": {
+                    "chat": {"id": "456", "type": "private"},
+                    "text": "/leaderboard",
+                    "from": {"username": "test"},
+                }
+            }
+            result = process_update(update)
+            assert result is not None
+            assert "Not enough data" in result

--- a/shit_tests/notifications/test_vote_db.py
+++ b/shit_tests/notifications/test_vote_db.py
@@ -1,0 +1,288 @@
+"""Tests for conviction voting database operations."""
+
+from unittest.mock import MagicMock, patch
+
+from notifications.vote_db import (
+    get_leaderboard,
+    get_llm_vs_crowd_stats,
+    get_user_stats,
+    get_user_streak,
+    get_vote,
+    get_vote_tally,
+    is_prediction_evaluated,
+    record_vote,
+)
+
+
+class TestRecordVote:
+    def test_record_vote_success(self, mock_sync_session):
+        mock_sync_session.execute = MagicMock()
+        result = record_vote(123, "456", "bull", username="testuser")
+        assert result is True
+
+    def test_record_vote_with_username(self, mock_sync_session):
+        mock_sync_session.execute = MagicMock()
+        result = record_vote(123, "456", "bull", username="trader1")
+        assert result is True
+        call_args = mock_sync_session.execute.call_args
+        params = call_args[0][1]
+        assert params["username"] == "trader1"
+
+    def test_record_vote_db_error(self, mock_sync_session):
+        mock_sync_session.execute = MagicMock(side_effect=Exception("DB error"))
+        result = record_vote(123, "456", "bull")
+        assert result is False
+
+
+class TestGetVote:
+    def test_get_vote_found(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(1, 123, "456", "bull", None, None, None)]
+        mock_result.keys.return_value = [
+            "id",
+            "prediction_id",
+            "chat_id",
+            "vote",
+            "voted_at",
+            "vote_correct",
+            "evaluated_at",
+        ]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        vote = get_vote(123, "456")
+        assert vote is not None
+        assert vote["vote"] == "bull"
+        assert vote["prediction_id"] == 123
+
+    def test_get_vote_not_found(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = []
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        vote = get_vote(999, "456")
+        assert vote is None
+
+
+class TestIsPredictionEvaluated:
+    def test_evaluated(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (3,)
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        assert is_prediction_evaluated(123) is True
+
+    def test_not_evaluated(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (0,)
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        assert is_prediction_evaluated(123) is False
+
+    def test_no_votes(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (0,)
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        assert is_prediction_evaluated(999) is False
+
+
+class TestGetVoteTally:
+    def test_tally_with_votes(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("bull", 5),
+            ("bear", 3),
+            ("skip", 1),
+        ]
+        mock_result.keys.return_value = ["vote", "count"]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        tally = get_vote_tally(123)
+        assert tally == {"bull": 5, "bear": 3, "skip": 1, "total": 9}
+
+    def test_tally_empty(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = ["vote", "count"]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        tally = get_vote_tally(999)
+        assert tally == {"bull": 0, "bear": 0, "skip": 0, "total": 0}
+
+    def test_tally_only_bulls(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("bull", 7)]
+        mock_result.keys.return_value = ["vote", "count"]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        tally = get_vote_tally(123)
+        assert tally == {"bull": 7, "bear": 0, "skip": 0, "total": 7}
+
+
+class TestGetUserStats:
+    def test_user_with_stats(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(20, 8, 5, 5, 2, 6, 10, 2, 3)]
+        mock_result.keys.return_value = [
+            "total_votes",
+            "correct",
+            "incorrect",
+            "pending",
+            "skipped",
+            "bull_correct",
+            "bull_total",
+            "bear_correct",
+            "bear_total",
+        ]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        stats = get_user_stats("456")
+        assert stats["total_votes"] == 20
+        assert stats["correct"] == 8
+        assert stats["incorrect"] == 5
+        assert stats["pending"] == 5
+        assert stats["skipped"] == 2
+        assert stats["accuracy_pct"] == 61.5  # 8/13 * 100
+        assert stats["bull_accuracy"] == 60.0  # 6/10 * 100
+        assert stats["bear_accuracy"] == 66.7  # 2/3 * 100
+
+    def test_user_no_votes(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = []
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        stats = get_user_stats("nonexistent")
+        assert stats == {"total_votes": 0}
+
+    def test_user_zero_evaluated(self, mock_sync_session):
+        """All votes pending — accuracy should be 0."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(5, 0, 0, 5, 0, 0, 0, 0, 0)]
+        mock_result.keys.return_value = [
+            "total_votes",
+            "correct",
+            "incorrect",
+            "pending",
+            "skipped",
+            "bull_correct",
+            "bull_total",
+            "bear_correct",
+            "bear_total",
+        ]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        stats = get_user_stats("456")
+        assert stats["accuracy_pct"] == 0.0
+
+
+class TestGetUserStreak:
+    def test_winning_streak(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            (True,),
+            (True,),
+            (True,),
+            (False,),
+        ]
+        mock_result.keys.return_value = ["vote_correct"]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        # _rows_to_dicts will create dicts
+        with patch(
+            "notifications.vote_db._execute_read",
+            return_value=[
+                {"vote_correct": True},
+                {"vote_correct": True},
+                {"vote_correct": True},
+                {"vote_correct": False},
+            ],
+        ):
+            streak = get_user_streak("456")
+            assert streak["streak_type"] == "win"
+            assert streak["streak_length"] == 3
+
+    def test_losing_streak(self, mock_sync_session):
+        with patch(
+            "notifications.vote_db._execute_read",
+            return_value=[
+                {"vote_correct": False},
+                {"vote_correct": False},
+                {"vote_correct": True},
+            ],
+        ):
+            streak = get_user_streak("456")
+            assert streak["streak_type"] == "loss"
+            assert streak["streak_length"] == 2
+
+    def test_no_evaluated_votes(self, mock_sync_session):
+        with patch("notifications.vote_db._execute_read", return_value=[]):
+            streak = get_user_streak("456")
+            assert streak["streak_type"] is None
+            assert streak["streak_length"] == 0
+
+
+class TestGetLeaderboard:
+    def test_leaderboard_returns_data(self, mock_sync_session):
+        with patch(
+            "notifications.vote_db._execute_read",
+            return_value=[
+                {
+                    "chat_id": "1",
+                    "display_name": "TraderJoe",
+                    "correct": 8,
+                    "evaluated": 10,
+                    "accuracy_pct": 80.0,
+                },
+                {
+                    "chat_id": "2",
+                    "display_name": "CryptoKing",
+                    "correct": 6,
+                    "evaluated": 10,
+                    "accuracy_pct": 60.0,
+                },
+            ],
+        ):
+            leaders = get_leaderboard(limit=10)
+            assert len(leaders) == 2
+            assert leaders[0]["display_name"] == "TraderJoe"
+            assert leaders[0]["accuracy_pct"] == 80.0
+
+    def test_leaderboard_empty(self, mock_sync_session):
+        with patch("notifications.vote_db._execute_read", return_value=[]):
+            leaders = get_leaderboard()
+            assert leaders == []
+
+
+class TestGetLLMVsCrowdStats:
+    def test_with_data(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(10, 6, 7, 8)]
+        mock_result.keys.return_value = [
+            "total_evaluated",
+            "llm_correct_count",
+            "crowd_correct_count",
+            "agreement_count",
+        ]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        stats = get_llm_vs_crowd_stats()
+        assert stats["total_evaluated"] == 10
+        assert stats["llm_accuracy"] == 60.0
+        assert stats["crowd_accuracy"] == 70.0
+        assert stats["agreement_rate"] == 80.0
+
+    def test_no_data(self, mock_sync_session):
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [(0, 0, 0, 0)]
+        mock_result.keys.return_value = [
+            "total_evaluated",
+            "llm_correct_count",
+            "crowd_correct_count",
+            "agreement_count",
+        ]
+        mock_sync_session.execute = MagicMock(return_value=mock_result)
+
+        stats = get_llm_vs_crowd_stats()
+        assert stats == {"total_evaluated": 0}

--- a/shit_tests/notifications/test_vote_maturation.py
+++ b/shit_tests/notifications/test_vote_maturation.py
@@ -1,0 +1,193 @@
+"""Tests for vote maturation — evaluating conviction votes against outcomes."""
+
+from unittest.mock import patch
+
+from notifications.vote_maturation import (
+    evaluate_votes_for_prediction,
+    mature_all_votes,
+)
+
+
+class TestEvaluateVotesForPrediction:
+    def test_bull_majority_outcomes(self, mock_sync_session):
+        """When majority of assets went up, bull votes are correct."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[
+                    {"symbol": "TSLA", "return_t7": 2.5},
+                    {"symbol": "AAPL", "return_t7": 1.3},
+                    {"symbol": "F", "return_t7": -0.2},  # Flat (within threshold)
+                ],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            # Check the direction parameter
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "bull"
+
+    def test_bear_majority_outcomes(self, mock_sync_session):
+        """When majority of assets went down, bear votes are correct."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[
+                    {"symbol": "TSLA", "return_t7": -3.0},
+                    {"symbol": "AAPL", "return_t7": -1.5},
+                    {"symbol": "F", "return_t7": 0.1},
+                ],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "bear"
+
+    def test_flat_market(self, mock_sync_session):
+        """When all assets are flat, all non-skip votes are incorrect."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[
+                    {"symbol": "TSLA", "return_t7": 0.1},
+                    {"symbol": "AAPL", "return_t7": -0.3},
+                ],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "flat"
+
+    def test_tied_directions(self, mock_sync_session):
+        """When equal bull and bear assets, treat as flat."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[
+                    {"symbol": "TSLA", "return_t7": 2.0},
+                    {"symbol": "AAPL", "return_t7": -2.0},
+                ],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "flat"
+
+    def test_no_outcomes(self, mock_sync_session):
+        """No outcomes yet — nothing to evaluate."""
+        with patch("notifications.vote_maturation._execute_read", return_value=[]):
+            result = evaluate_votes_for_prediction(123)
+            assert result is False
+
+    def test_single_asset_bullish(self, mock_sync_session):
+        """Single asset prediction with positive return."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[{"symbol": "TSLA", "return_t7": 5.0}],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "bull"
+
+    def test_single_asset_bearish(self, mock_sync_session):
+        """Single asset prediction with negative return."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[{"symbol": "TSLA", "return_t7": -3.0}],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "bear"
+
+    def test_none_return_treated_as_zero(self, mock_sync_session):
+        """None return_t7 values treated as 0 (flat)."""
+        with (
+            patch(
+                "notifications.vote_maturation._execute_read",
+                return_value=[{"symbol": "TSLA", "return_t7": None}],
+            ),
+            patch(
+                "notifications.vote_maturation._execute_write", return_value=True
+            ) as mock_write,
+        ):
+            result = evaluate_votes_for_prediction(123)
+            assert result is True
+            call_args = mock_write.call_args
+            assert call_args[1]["params"]["direction"] == "flat"
+
+
+class TestMatureAllVotes:
+    def test_processes_pending_predictions(self, mock_sync_session):
+        """Finds and processes predictions with pending votes."""
+        call_count = 0
+
+        def mock_read(query_str, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # find_votes_to_mature query
+                return [{"prediction_id": 100}, {"prediction_id": 200}]
+            else:
+                # get_outcomes_for_vote_eval query
+                return [{"symbol": "TSLA", "return_t7": 2.0}]
+
+        with (
+            patch("notifications.vote_maturation._execute_read", side_effect=mock_read),
+            patch("notifications.vote_maturation._execute_write", return_value=True),
+        ):
+            stats = mature_all_votes()
+            assert stats["predictions_processed"] == 2
+
+    def test_no_pending_votes(self, mock_sync_session):
+        """Nothing to process — returns zero."""
+        with patch("notifications.vote_maturation._execute_read", return_value=[]):
+            stats = mature_all_votes()
+            assert stats["predictions_processed"] == 0
+
+    def test_partial_failure(self, mock_sync_session):
+        """Some predictions succeed, others fail."""
+        call_count = 0
+
+        def mock_read(query_str, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"prediction_id": 100}, {"prediction_id": 200}]
+            elif call_count == 2:
+                return [{"symbol": "TSLA", "return_t7": 2.0}]
+            else:
+                return []  # No outcomes for second prediction
+
+        with (
+            patch("notifications.vote_maturation._execute_read", side_effect=mock_read),
+            patch("notifications.vote_maturation._execute_write", return_value=True),
+        ):
+            stats = mature_all_votes()
+            assert stats["predictions_processed"] == 1


### PR DESCRIPTION
## Summary

- **Inline voting buttons** on every Telegram alert: Bull, Bear, Skip
- **Callback handling**: `process_update()` routes callback queries to `handle_vote_callback()`
- **Vote DB layer**: `vote_db.py` with 7 operations (record, tally, stats, streak, leaderboard, LLM-vs-crowd)
- **Vote maturation**: majority-of-assets correctness evaluation against T+7 outcomes
- **New commands**: `/mystats` (personal accuracy) and `/leaderboard` (top voters + LLM comparison)
- **Both alert paths** (cron engine + event consumer) attach vote keyboard
- **Scorecard integration** pre-wired (Feature 12 already imports from `vote_db`)

### Challenge Round Decisions
- **Multi-asset correctness**: Majority of assets determines vote correctness (not just primary)
- **Vote window**: Voting blocked after T+7 evaluation ("Voting closed" toast)
- **Anchoring**: Accept anchoring (show prediction before vote) — contrarian signals still valuable
- **Stats tracking**: Prediction-level (bool per prediction), not individual vote count

### Production Deploy Steps
```sql
CREATE TABLE conviction_votes (
    id SERIAL PRIMARY KEY,
    prediction_id INTEGER NOT NULL REFERENCES predictions(id),
    chat_id VARCHAR(50) NOT NULL,
    username VARCHAR(100),
    vote VARCHAR(10) NOT NULL,
    voted_at TIMESTAMP NOT NULL DEFAULT NOW(),
    vote_correct BOOLEAN,
    evaluated_at TIMESTAMP,
    created_at TIMESTAMP DEFAULT NOW(),
    updated_at TIMESTAMP DEFAULT NOW(),
    UNIQUE (prediction_id, chat_id)
);
CREATE INDEX idx_conviction_votes_prediction ON conviction_votes (prediction_id);
CREATE INDEX idx_conviction_votes_chat_id ON conviction_votes (chat_id);
CREATE INDEX idx_conviction_votes_voted_at ON conviction_votes (voted_at);
CREATE INDEX idx_conviction_votes_correct ON conviction_votes (vote_correct) WHERE vote_correct IS NOT NULL;
```

Add `mature_all_votes()` call to outcome-maturation Railway cron service.

## Test plan
- [x] 52 new tests: vote_db (19), vote_maturation (11), vote_callback (22)
- [x] Full notification suite: 337 passed, 0 regressions
- [x] Lint: `ruff check` all clear
- [x] Format: `ruff format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)