### PR TITLE
security: add rate limiting and security headers to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API Key Authentication** — All data endpoints (`/api/feed`, `/api/prices`, `/api/calibration`, `/api/echoes`) now require an `X-API-Key` header when `API_KEY` env var is set. Health endpoints remain public. Frontend passes the key via `VITE_API_KEY` build-time env var.
 - **Telegram Webhook Verification** — `POST /telegram/webhook` now verifies the `X-Telegram-Bot-Api-Secret-Token` header against `TELEGRAM_WEBHOOK_SECRET` env var when configured. Prevents spoofed webhook payloads.
 
+### Added
+- **API Rate Limiting** — Per-IP rate limiting via `slowapi` on all REST endpoints
+  - `/api/feed/*`: 60 req/min
+  - `/api/prices/*`: 30 req/min (protects upstream yfinance)
+  - `/api/calibration/*`: 10 req/min
+  - `/api/echoes/*`: 30 req/min
+  - `/telegram/webhook`: 60 req/min
+- **Security Headers Middleware** — Standard security headers on all responses
+  - `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`
+  - `Strict-Transport-Security` (HSTS), `Referrer-Policy`, `Permissions-Policy`
+
 ### Changed
 - **Alert Quality (Play 4)** — Unified alert enrichment across both dispatch paths
   - Calibrated confidence displayed in all Telegram alerts

--- a/api/main.py
+++ b/api/main.py
@@ -10,8 +10,12 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 
 from api.dependencies import verify_api_key  # noqa: F401 — used in router deps
+from api.middleware import SecurityHeadersMiddleware
+from api.rate_limit import limiter
 from api.routers import calibration, echoes, feed, prices, telegram
 
 
@@ -27,6 +31,13 @@ app = FastAPI(
     version="2.0.0",
     lifespan=lifespan,
 )
+
+# Rate limiting
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+# Security headers
+app.add_middleware(SecurityHeadersMiddleware)
 
 # CORS — restrict origins in production, allow all in development
 _default_origins = "https://shitpost-alpha-web-production.up.railway.app"

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,0 +1,22 @@
+"""Security middleware for the FastAPI application."""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add standard security headers to all responses."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=()"
+        )
+        return response

--- a/api/rate_limit.py
+++ b/api/rate_limit.py
@@ -5,6 +5,6 @@ and decorate endpoints with @limiter.limit("N/minute").
 """
 
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+from slowapi.util import get_ipaddr
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_ipaddr)

--- a/api/rate_limit.py
+++ b/api/rate_limit.py
@@ -1,0 +1,10 @@
+"""Rate limiting for API endpoints.
+
+Uses slowapi with per-IP limiting. Import `limiter` in routers
+and decorate endpoints with @limiter.limit("N/minute").
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/api/routers/calibration.py
+++ b/api/routers/calibration.py
@@ -1,14 +1,17 @@
 """Calibration curve API endpoint."""
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
+from api.rate_limit import limiter
 from api.schemas.calibration import CalibrationCurveResponse
 
 router = APIRouter()
 
 
 @router.get("/curve", response_model=CalibrationCurveResponse)
+@limiter.limit("10/minute")
 def get_calibration_curve(
+    request: Request,
     timeframe: str = Query("t7", pattern="^t(1|3|7|30)$"),
 ):
     """Get the latest calibration curve for a given timeframe."""

--- a/api/routers/echoes.py
+++ b/api/routers/echoes.py
@@ -1,12 +1,17 @@
 """API router for Historical Echoes — semantic similarity matches."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+
+from api.rate_limit import limiter
 
 router = APIRouter()
 
 
 @router.get("/for-prediction/{prediction_id}")
-def get_echoes(prediction_id: int, timeframe: str = "t7", limit: int = 5):
+@limiter.limit("30/minute")
+def get_echoes(
+    request: Request, prediction_id: int, timeframe: str = "t7", limit: int = 5
+):
     """Get historical echo matches for a prediction.
 
     Args:

--- a/api/routers/feed.py
+++ b/api/routers/feed.py
@@ -1,7 +1,8 @@
 """Feed API router — single-post-at-a-time endpoint."""
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
+from api.rate_limit import limiter
 from api.schemas.feed import FeedResponse
 from api.services.feed_service import FeedService
 
@@ -10,7 +11,8 @@ _service = FeedService()
 
 
 @router.get("/latest", response_model=FeedResponse)
-def get_latest_post():
+@limiter.limit("60/minute")
+def get_latest_post(request: Request):
     """Get the most recent analyzed shitpost."""
     result = _service.get_feed_response(0)
     if result is None:
@@ -19,7 +21,8 @@ def get_latest_post():
 
 
 @router.get("/at", response_model=FeedResponse)
-def get_post_at_offset(offset: int = Query(default=0, ge=0)):
+@limiter.limit("60/minute")
+def get_post_at_offset(request: Request, offset: int = Query(default=0, ge=0)):
     """Get the Nth most recent analyzed shitpost."""
     result = _service.get_feed_response(offset)
     if result is None:

--- a/api/routers/prices.py
+++ b/api/routers/prices.py
@@ -2,16 +2,18 @@
 
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from api.queries.price_queries import get_price_data
+from api.rate_limit import limiter
 from api.schemas.feed import LiveQuoteResponse, PriceResponse
 
 router = APIRouter()
 
 
 @router.get("/{symbol}/live", response_model=LiveQuoteResponse)
-def get_live_quote(symbol: str):
+@limiter.limit("30/minute")
+def get_live_quote(request: Request, symbol: str):
     """Get the current live price for a symbol.
 
     Uses yfinance fast_info for a lightweight single HTTP call (~300ms).
@@ -34,7 +36,9 @@ def get_live_quote(symbol: str):
 
 
 @router.get("/{symbol}", response_model=PriceResponse)
+@limiter.limit("30/minute")
 def get_prices(
+    request: Request,
     symbol: str,
     days: int = Query(default=30, ge=1, le=365),
     post_timestamp: Optional[str] = Query(default=None),

--- a/api/routers/telegram.py
+++ b/api/routers/telegram.py
@@ -5,6 +5,7 @@ import hmac
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from api.rate_limit import limiter
 from shit.config.shitpost_settings import settings
 from shit.logging import get_service_logger
 
@@ -14,6 +15,7 @@ router = APIRouter()
 
 
 @router.post("/telegram/webhook")
+@limiter.limit("60/minute")
 async def telegram_webhook(request: Request):
     """Receive Telegram updates. Verifies secret token when configured."""
     if settings.TELEGRAM_WEBHOOK_SECRET:

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ exchange_calendars>=4.5.0
 # FastAPI web server (React frontend API)
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
+slowapi>=0.1.9


### PR DESCRIPTION
## Summary

- **Rate limiting** (#157): Per-IP rate limiting via `slowapi` on all REST endpoints. Limits tuned per endpoint to protect upstream resources (yfinance at 30/min) and prevent DB cost amplification.
- **Security headers** (#159): Middleware adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security` (HSTS), `Referrer-Policy`, and `Permissions-Policy` to all responses.

### Rate limits

| Endpoint group | Limit |
|----------------|-------|
| `/api/feed/*` | 60/min |
| `/api/prices/*` | 30/min |
| `/api/calibration/*` | 10/min |
| `/api/echoes/*` | 30/min |
| `/telegram/webhook` | 60/min |

### Files changed

- `api/rate_limit.py` — shared `Limiter` instance (new)
- `api/middleware.py` — `SecurityHeadersMiddleware` (new)
- `api/main.py` — registers limiter + middleware
- `api/routers/*.py` — `@limiter.limit()` decorators + `Request` param
- `requirements.txt` — adds `slowapi>=0.1.9`

Closes #157, closes #159.

## Test plan

- [x] All 2005 unit tests pass (115 API tests pass)
- [x] `ruff check` clean on all changed files
- [x] Imports verified: `api.rate_limit`, `api.middleware` load correctly
- [ ] Manual: verify 429 response after exceeding rate limit
- [ ] Manual: verify security headers present in response (`curl -I`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)