### PR TITLE
refactor: remove use_signal shim + hoist harvester identity to settings (#188, #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Strict-Transport-Security` (HSTS), `Referrer-Policy`, `Permissions-Policy`
 
 ### Changed
+- **Truth Social harvester identity now settings-driven (Phase 2, #195)** — harvester `base_url` and account `user_id` now read from new `SCRAPECREATORS_BASE_URL` and `TRUTH_SOCIAL_USER_ID` settings (both defaulted) instead of hardcoded literals in `__init__`. New env vars: `SCRAPECREATORS_BASE_URL`, `TRUTH_SOCIAL_USER_ID` (replaces the removed `TRUTH_SOCIAL_USERNAME`).
 - **Alert Quality (Play 4)** — Unified alert enrichment across both dispatch paths
   - Calibrated confidence displayed in all Telegram alerts
   - Historical Echoes (similar posts + win rate) included in alerts via shared `enrich_alert()`
@@ -51,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DatabaseUtils.transform_s3_data_to_shitpost` — superseded by `SignalTransformer` on the S3→`signals` path
   - Unused resilience machinery in `shit/utils/error_handling.py` — `async_retry`, `sync_retry`, `CircuitBreaker`, `RateLimiter`, and their module-global instances (never wired into any live path; `handle_exceptions` retained)
   - `shit/logging/progress_tracker.py` — dead progress-tracking module and its import-time `Icons.PROGRESS` monkeypatch
+- **Dead params & config (Phase 2)** — removed dead parameters and a dead setting (#188 ≡ #229 L15, #195)
+  - `use_signal` keyword-only parameter — no-op backwards-compat shim from the signals migration; removed from `PredictionOperations.store_analysis`/`handle_no_text_prediction`/`check_prediction_exists` and their three analyzer call-sites (predictions always store/check `signal_id`)
+  - `TRUTH_SOCIAL_USERNAME` setting — loaded into `self.username` but never read anywhere; the ScrapeCreators API selects the account by numeric user id, not username
 
 ### Added
 - **Conviction Voting** — Inline Bull/Bear/Skip voting buttons on Telegram alerts with accuracy tracking

--- a/documentation/planning/dead-code-cleanup_2026-07-24/02_dead-params-and-config.md
+++ b/documentation/planning/dead-code-cleanup_2026-07-24/02_dead-params-and-config.md
@@ -1,7 +1,10 @@
 ---
 title: "Phase 2 — Dead params & config"
 session: dead-code-cleanup_2026-07-24
-status: READY
+status: COMPLETE
+started: 2026-07-28
+completed: 2026-07-28
+pr: 235
 issues: [188, 195]
 code_area: shitvault, shitpost_ai, shitposts, shit/config
 risk: low
@@ -120,13 +123,13 @@ selects the account. Both are low-risk and were verified line-by-line against
 13. `ruff check .` / `ruff format .`; run the targeted test suites.
 
 ## Acceptance Criteria
-- [ ] No `use_signal` token remains in any `.py` file (`rg use_signal -g '*.py'` is empty); remaining matches are only historical CHANGELOG/spec/plan/archive/overview docs, intentionally retained.
-- [ ] `store_analysis` / `handle_no_text_prediction` no longer have a dangling `*,`; `check_prediction_exists` keeps `*,` for `llm_provider`/`llm_model`. Module imports without `SyntaxError`.
-- [ ] Harvester reads `base_url` + user id from settings (`settings.SCRAPECREATORS_BASE_URL`, `settings.TRUTH_SOCIAL_USER_ID`); `self.username` is gone and `TRUTH_SOCIAL_USERNAME` is removed from `shit/config/shitpost_settings.py`.
-- [ ] `rg 'self\.username' shitposts/` and `rg TRUTH_SOCIAL_USERNAME -g '*.py'` are both empty.
-- [ ] `source venv/bin/activate && pytest shit_tests/shitpost_ai/ shit_tests/shitvault/ shit_tests/shitposts/ shit_tests/shit/config/` green.
-- [ ] `ruff check .` / `ruff format .` clean.
-- [ ] `CHANGELOG.md` `[Unreleased]` updated (Removed + Changed; new env-var names noted).
+- [x] No `use_signal` token remains in any `.py` file (`rg use_signal -g '*.py'` is empty); remaining matches are only historical CHANGELOG/spec/plan/archive/overview docs, intentionally retained.
+- [x] `store_analysis` / `handle_no_text_prediction` no longer have a dangling `*,`; `check_prediction_exists` keeps `*,` for `llm_provider`/`llm_model`. Module imports without `SyntaxError`.
+- [x] Harvester reads `base_url` + user id from settings (`settings.SCRAPECREATORS_BASE_URL`, `settings.TRUTH_SOCIAL_USER_ID`); `self.username` is gone and `TRUTH_SOCIAL_USERNAME` is removed from `shit/config/shitpost_settings.py`.
+- [x] `rg 'self\.username' shitposts/` and `rg TRUTH_SOCIAL_USERNAME -g '*.py'` are both empty.
+- [x] `source venv/bin/activate && pytest shit_tests/shitpost_ai/ shit_tests/shitvault/ shit_tests/shitposts/ shit_tests/shit/config/` green — **503 passed**.
+- [x] Lint-neutral: `ruff check` on the 9 touched files shows the **same 53 pre-existing errors on this branch as on `main`** (no new findings). Repo-wide `ruff format .` was deliberately NOT run — it would reformat ~1,300 lines of pre-existing quote-style drift across the test tree; formatting was kept to the touched lines to avoid unrelated churn.
+- [x] `CHANGELOG.md` `[Unreleased]` updated (Removed + Changed; new env-var names noted).
 
 ## Test Plan
 - **#188:** run `shit_tests/shitpost_ai/test_shitpost_analyzer.py` (the :352 assertion is the only test that references `use_signal`) and `shit_tests/shitvault/test_prediction_operations.py` (confirms the three methods still behave — those tests never passed `use_signal`, so they should pass unchanged once the signatures drop the param).

--- a/shit/README.md
+++ b/shit/README.md
@@ -223,9 +223,10 @@ LLM_PROVIDER=openai  # or anthropic
 LLM_MODEL=gpt-4  # or claude-3-sonnet-20240229
 
 # Truth Social Configuration
-TRUTH_SOCIAL_USERNAME=realDonaldTrump
+TRUTH_SOCIAL_USER_ID=107780257626128497
 TRUTH_SOCIAL_SHITPOST_INTERVAL=30
 SCRAPECREATORS_API_KEY=your_scrapecreators_api_key
+SCRAPECREATORS_BASE_URL=https://api.scrapecreators.com/v1
 
 # Analysis Configuration
 CONFIDENCE_THRESHOLD=0.7

--- a/shit/config/shitpost_settings.py
+++ b/shit/config/shitpost_settings.py
@@ -50,7 +50,9 @@ class Settings(BaseSettings):
     )  # Minimum successful providers for valid ensemble
 
     # Truth Social Shitpost Configuration
-    TRUTH_SOCIAL_USERNAME: str = Field(default="realDonaldTrump")
+    TRUTH_SOCIAL_USER_ID: str = Field(
+        default="107780257626128497"
+    )  # Trump's Truth Social account id
     TRUTH_SOCIAL_SHITPOST_INTERVAL: int = Field(
         default=30
     )  # seconds between shitpost harvests
@@ -102,6 +104,7 @@ class Settings(BaseSettings):
 
     # ScrapeCreators API Configuration
     SCRAPECREATORS_API_KEY: Optional[str] = Field(default=None)
+    SCRAPECREATORS_BASE_URL: str = Field(default="https://api.scrapecreators.com/v1")
 
     # S3 Data Lake Configuration
     S3_BUCKET_NAME: str = Field(default="shitpost-alpha-raw-data")

--- a/shit_tests/conftest.py
+++ b/shit_tests/conftest.py
@@ -181,7 +181,8 @@ def mock_settings():
         mock_settings.ANTHROPIC_API_KEY = "test_anthropic_key"
         mock_settings.LLM_PROVIDER = "openai"
         mock_settings.LLM_MODEL = "gpt-4"
-        mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+        mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
+        mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
         mock_settings.TRUTH_SOCIAL_SHITPOST_INTERVAL = 30
         mock_settings.SCRAPECREATORS_API_KEY = "test_scrapecreators_key"
         mock_settings.CONFIDENCE_THRESHOLD = 0.7
@@ -543,7 +544,7 @@ def setup_test_environment():
     os.environ['XAI_API_KEY'] = 'test_xai_key'
     os.environ['LLM_PROVIDER'] = 'openai'
     os.environ['LLM_MODEL'] = 'gpt-4'
-    os.environ['TRUTH_SOCIAL_USERNAME'] = 'realDonaldTrump'
+    os.environ['TRUTH_SOCIAL_USER_ID'] = '107780257626128497'
     os.environ['TRUTH_SOCIAL_MONITOR_INTERVAL'] = '30'
     os.environ['CONFIDENCE_THRESHOLD'] = '0.7'
     os.environ['MAX_POST_LENGTH'] = '4000'
@@ -553,7 +554,7 @@ def setup_test_environment():
     # Cleanup
     for key in ['ENVIRONMENT', 'DEBUG', 'DATABASE_URL', 'OPENAI_API_KEY',
                 'ANTHROPIC_API_KEY', 'XAI_API_KEY', 'LLM_PROVIDER', 'LLM_MODEL',
-                'TRUTH_SOCIAL_USERNAME', 'TRUTH_SOCIAL_MONITOR_INTERVAL',
+                'TRUTH_SOCIAL_USER_ID', 'TRUTH_SOCIAL_MONITOR_INTERVAL',
                 'CONFIDENCE_THRESHOLD', 'MAX_POST_LENGTH']:
         if key in os.environ:
             del os.environ[key]

--- a/shit_tests/shit/config/test_shitpost_settings.py
+++ b/shit_tests/shit/config/test_shitpost_settings.py
@@ -28,7 +28,7 @@ class TestSettingsInitialization:
         assert hasattr(settings, 'ANTHROPIC_API_KEY')
         assert hasattr(settings, 'LLM_PROVIDER')
         assert hasattr(settings, 'LLM_MODEL')
-        assert hasattr(settings, 'TRUTH_SOCIAL_USERNAME')
+        assert hasattr(settings, 'TRUTH_SOCIAL_USER_ID')
         assert hasattr(settings, 'TRUTH_SOCIAL_SHITPOST_INTERVAL')
         assert hasattr(settings, 'CONFIDENCE_THRESHOLD')
         assert hasattr(settings, 'MAX_SHITPOST_LENGTH')
@@ -50,7 +50,7 @@ class TestSettingsInitialization:
         assert isinstance(settings.DATABASE_URL, str)
         assert isinstance(settings.LLM_PROVIDER, str)
         assert isinstance(settings.LLM_MODEL, str)
-        assert isinstance(settings.TRUTH_SOCIAL_USERNAME, str)
+        assert isinstance(settings.TRUTH_SOCIAL_USER_ID, str)
         assert isinstance(settings.TRUTH_SOCIAL_SHITPOST_INTERVAL, int)
         assert isinstance(settings.CONFIDENCE_THRESHOLD, float)
         assert isinstance(settings.MAX_SHITPOST_LENGTH, int)
@@ -70,7 +70,7 @@ class TestSettingsInitialization:
             'ANTHROPIC_API_KEY': 'test-anthropic-key',
             'LLM_PROVIDER': 'anthropic',
             'LLM_MODEL': 'claude-3-sonnet',
-            'TRUTH_SOCIAL_USERNAME': 'testuser',
+            'TRUTH_SOCIAL_USER_ID': 'testuser',
             'TRUTH_SOCIAL_SHITPOST_INTERVAL': '60',
             'CONFIDENCE_THRESHOLD': '0.8',
             'MAX_SHITPOST_LENGTH': '5000',
@@ -98,7 +98,7 @@ class TestSettingsInitialization:
             assert settings.ANTHROPIC_API_KEY == "test-anthropic-key"
             assert settings.LLM_PROVIDER == "anthropic"
             assert settings.LLM_MODEL == "claude-3-sonnet"
-            assert settings.TRUTH_SOCIAL_USERNAME == "testuser"
+            assert settings.TRUTH_SOCIAL_USER_ID == "testuser"
             assert settings.TRUTH_SOCIAL_SHITPOST_INTERVAL == 60
             assert settings.CONFIDENCE_THRESHOLD == 0.8
             assert settings.MAX_SHITPOST_LENGTH == 5000
@@ -413,7 +413,8 @@ class TestGlobalSettingsInstance:
         assert settings.ENVIRONMENT == "development"
         assert settings.DEBUG is True
         assert settings.LLM_PROVIDER == "openai"
-        assert settings.TRUTH_SOCIAL_USERNAME == "realDonaldTrump"
+        assert settings.TRUTH_SOCIAL_USER_ID == "107780257626128497"
+        assert settings.SCRAPECREATORS_BASE_URL == "https://api.scrapecreators.com/v1"
 
 
 class TestEnvironmentFileLoading:
@@ -556,11 +557,11 @@ class TestEdgeCases:
         unicode_bucket = "shitpost-alpha-raw-data-测试"
         
         settings = Settings(
-            TRUTH_SOCIAL_USERNAME=unicode_username,
+            TRUTH_SOCIAL_USER_ID=unicode_username,
             S3_BUCKET_NAME=unicode_bucket
         )
         
-        assert settings.TRUTH_SOCIAL_USERNAME == unicode_username
+        assert settings.TRUTH_SOCIAL_USER_ID == unicode_username
         assert settings.S3_BUCKET_NAME == unicode_bucket
 
     def test_special_characters_in_values(self):
@@ -591,7 +592,7 @@ class TestSettingsDocumentation:
         assert settings.DATABASE_URL is not None
         assert settings.LLM_PROVIDER is not None
         assert settings.LLM_MODEL is not None
-        assert settings.TRUTH_SOCIAL_USERNAME is not None
+        assert settings.TRUTH_SOCIAL_USER_ID is not None
         assert settings.TRUTH_SOCIAL_SHITPOST_INTERVAL is not None
         assert settings.CONFIDENCE_THRESHOLD is not None
         assert settings.MAX_SHITPOST_LENGTH is not None
@@ -636,7 +637,7 @@ class TestSettingsDocumentation:
         assert isinstance(settings.DATABASE_URL, str)
         assert isinstance(settings.LLM_PROVIDER, str)
         assert isinstance(settings.LLM_MODEL, str)
-        assert isinstance(settings.TRUTH_SOCIAL_USERNAME, str)
+        assert isinstance(settings.TRUTH_SOCIAL_USER_ID, str)
         assert isinstance(settings.TRUTH_SOCIAL_SHITPOST_INTERVAL, int)
         assert isinstance(settings.CONFIDENCE_THRESHOLD, float)
         assert isinstance(settings.MAX_SHITPOST_LENGTH, int)

--- a/shit_tests/shitpost_ai/test_shitpost_analyzer.py
+++ b/shit_tests/shitpost_ai/test_shitpost_analyzer.py
@@ -349,7 +349,7 @@ class TestShitpostAnalyzer:
             result = await analyzer._analyze_batch(shitposts, dry_run=False, batch_number=1)
             
             assert result == 1
-            mock_check.assert_called_once_with(sample_shitpost_data['shitpost_id'], use_signal=True)
+            mock_check.assert_called_once_with(sample_shitpost_data['shitpost_id'])
             mock_analyze.assert_called_once_with(sample_shitpost_data, False)
 
     @pytest.mark.asyncio

--- a/shit_tests/shitposts/test_harvester_registry.py
+++ b/shit_tests/shitposts/test_harvester_registry.py
@@ -177,14 +177,16 @@ class TestCreateDefaultRegistry:
 
     def test_includes_truth_social(self):
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             registry = create_default_registry()
             assert "truth_social" in registry.list_sources()
 
     def test_truth_social_is_enabled(self):
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             registry = create_default_registry()
             assert "truth_social" in registry.list_enabled_sources()
@@ -192,7 +194,8 @@ class TestCreateDefaultRegistry:
     def test_creates_truth_social_harvester(self):
         from shitposts.truth_social_s3_harvester import TruthSocialS3Harvester
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             registry = create_default_registry()
             harvester = registry.create_harvester("truth_social")

--- a/shit_tests/shitposts/test_truth_social_s3_harvester.py
+++ b/shit_tests/shitposts/test_truth_social_s3_harvester.py
@@ -46,7 +46,8 @@ class TestTruthSocialS3Harvester:
     def harvester(self):
         """TruthSocialS3Harvester instance for testing."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             mock_settings.S3_BUCKET_NAME = "test-bucket"
             mock_settings.S3_PREFIX = "test-prefix"
@@ -65,7 +66,8 @@ class TestTruthSocialS3Harvester:
     def test_initialization_defaults(self):
         """Test harvester initialization with default values."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             mock_settings.S3_BUCKET_NAME = "test-bucket"
             mock_settings.S3_PREFIX = "test-prefix"
@@ -80,13 +82,13 @@ class TestTruthSocialS3Harvester:
             assert harvester.end_date is None
             assert harvester.limit is None
             assert harvester.max_id is None
-            assert harvester.username == "realDonaldTrump"
             assert harvester.user_id == "107780257626128497"
 
     def test_initialization_with_parameters(self):
         """Test harvester initialization with all parameters."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             mock_settings.S3_BUCKET_NAME = "test-bucket"
             mock_settings.S3_PREFIX = "test-prefix"
@@ -113,7 +115,8 @@ class TestTruthSocialS3Harvester:
         """Test harvester initialization defaults end_date to today."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings, \
              patch('shitposts.base_harvester.datetime') as mock_datetime:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             mock_settings.S3_BUCKET_NAME = "test-bucket"
             mock_settings.S3_PREFIX = "test-prefix"
@@ -136,7 +139,8 @@ class TestTruthSocialS3Harvester:
     def test_source_name(self):
         """Test that get_source_name returns correct value."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             harvester = TruthSocialS3Harvester()
             assert harvester.get_source_name() == "truth_social"
@@ -144,7 +148,8 @@ class TestTruthSocialS3Harvester:
     def test_s3_prefix_backward_compat(self):
         """Test that S3 prefix uses hyphenated form for backward compatibility."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
             harvester = TruthSocialS3Harvester()
             assert harvester._get_s3_prefix() == "truth-social"
@@ -597,7 +602,8 @@ class TestTruthSocialS3Harvester:
     async def test_harvest_range_mode_date_filtering(self):
         """Test harvesting with date range filtering."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
 
             harvester = TruthSocialS3Harvester(
@@ -652,7 +658,8 @@ class TestTruthSocialS3Harvester:
     async def test_harvest_stops_before_start_date(self):
         """Test harvest stops when reaching posts before start date."""
         with patch('shitposts.truth_social_s3_harvester.settings') as mock_settings:
-            mock_settings.TRUTH_SOCIAL_USERNAME = "realDonaldTrump"
+            mock_settings.SCRAPECREATORS_BASE_URL = "https://api.scrapecreators.com/v1"
+            mock_settings.TRUTH_SOCIAL_USER_ID = "107780257626128497"
             mock_settings.SCRAPECREATORS_API_KEY = "test_key"
 
             harvester = TruthSocialS3Harvester(

--- a/shitpost_ai/shitpost_analyzer.py
+++ b/shitpost_ai/shitpost_analyzer.py
@@ -391,7 +391,7 @@ class ShitpostAnalyzer:
                     skipped_count += 1
                     continue
 
-                if await self.prediction_ops.check_prediction_exists(shitpost_id, use_signal=True):
+                if await self.prediction_ops.check_prediction_exists(shitpost_id):
                     print(
                         f"⏭️  Post {i}/{len(shitposts)}: {shitpost_id} already analyzed, skipping"
                     )
@@ -475,7 +475,7 @@ class ShitpostAnalyzer:
                 if not dry_run:
                     # Create bypassed prediction record
                     await self.prediction_ops.handle_no_text_prediction(
-                        shitpost_id, shitpost, bypass_reason, use_signal=True
+                        shitpost_id, shitpost, bypass_reason
                     )
 
                 return {
@@ -562,7 +562,7 @@ class ShitpostAnalyzer:
             if not dry_run:
                 # Store analysis in database
                 analysis_id = await self.prediction_ops.store_analysis(
-                    shitpost_id, enhanced_analysis, shitpost, use_signal=True
+                    shitpost_id, enhanced_analysis, shitpost
                 )
 
                 if analysis_id:

--- a/shitposts/README.md
+++ b/shitposts/README.md
@@ -108,9 +108,10 @@ async def get_data_stats(self) -> S3Stats
 ### Environment Variables
 ```bash
 # Truth Social Configuration
-TRUTH_SOCIAL_USERNAME=realDonaldTrump        # Target username
+TRUTH_SOCIAL_USER_ID=107780257626128497      # Target account id (selects the account)
 TRUTH_SOCIAL_SHITPOST_INTERVAL=30            # Harvest interval (seconds)
 SCRAPECREATORS_API_KEY=your_api_key_here     # ScrapeCreators API key
+SCRAPECREATORS_BASE_URL=https://api.scrapecreators.com/v1  # API base URL (default; override rarely needed)
 
 # S3 Data Lake Configuration
 S3_BUCKET_NAME=your-s3-bucket-name           # S3 bucket for raw data storage

--- a/shitposts/truth_social_s3_harvester.py
+++ b/shitposts/truth_social_s3_harvester.py
@@ -38,11 +38,10 @@ class TruthSocialS3Harvester(SignalHarvester):
         super().__init__(mode=mode, start_date=start_date, end_date=end_date, limit=limit)
 
         # Truth Social-specific config
-        self.username = settings.TRUTH_SOCIAL_USERNAME
         self.max_id = max_id
         self.api_key = settings.SCRAPECREATORS_API_KEY
-        self.base_url = "https://api.scrapecreators.com/v1"
-        self.user_id = "107780257626128497"  # Trump's Truth Social user ID
+        self.base_url = settings.SCRAPECREATORS_BASE_URL
+        self.user_id = settings.TRUTH_SOCIAL_USER_ID
 
         # HTTP session (created in _test_connection)
         self.session: Optional[aiohttp.ClientSession] = None

--- a/shitvault/prediction_operations.py
+++ b/shitvault/prediction_operations.py
@@ -45,8 +45,6 @@ class PredictionOperations:
         content_id: str,
         analysis_data: Dict[str, Any],
         content_data: Dict[str, Any] = None,
-        *,
-        use_signal: bool = True,
     ) -> Optional[str]:
         """Store LLM analysis results in the database with enhanced content data.
 
@@ -54,7 +52,6 @@ class PredictionOperations:
             content_id: Signal ID for the content.
             analysis_data: LLM analysis results dict.
             content_data: Content data dict (signal or shitpost format).
-            use_signal: Deprecated, ignored. Always stores as signal_id.
         """
         try:
             # Calculate engagement scores (use generic names with fallback)
@@ -153,8 +150,6 @@ class PredictionOperations:
         content_id: str,
         content_data: Dict[str, Any],
         bypass_reason: Optional[BypassReason] = None,
-        *,
-        use_signal: bool = True,
     ) -> Optional[str]:
         """
         Create a prediction record for posts that can't be analyzed.
@@ -164,7 +159,6 @@ class PredictionOperations:
             content_data: Content data dictionary (signal or shitpost format).
             bypass_reason: Optional pre-determined bypass reason. If not provided,
                           will be determined using BypassService.
-            use_signal: Deprecated, ignored. Always stores as signal_id.
 
         Returns:
             Prediction ID if successful, None otherwise
@@ -223,7 +217,6 @@ class PredictionOperations:
         self,
         content_id: str,
         *,
-        use_signal: bool = True,
         llm_provider: Optional[str] = None,
         llm_model: Optional[str] = None,
     ) -> bool:
@@ -235,7 +228,6 @@ class PredictionOperations:
 
         Args:
             content_id: Signal ID to check.
-            use_signal: Deprecated, ignored. Always checks signal_id.
             llm_provider: If set, only match predictions from this provider.
             llm_model: If set, only match predictions from this model.
         """


### PR DESCRIPTION
## Summary

Phase 2 of the dead-code cleanup cluster (`documentation/planning/dead-code-cleanup_2026-07-24/`). Two independent, no-behavior-change cleanups.

### #188 — Remove `use_signal` deprecated-ignored param (also closes #229 L15)
`use_signal` was a keyword-only no-op shim left over from the signals migration (PR #140). Every method body already writes/queries `Prediction.signal_id` unconditionally; the docstrings literally read *"Deprecated, ignored."* Removed:
- the param + docstring line from `PredictionOperations.store_analysis`, `handle_no_text_prediction`, and `check_prediction_exists`
- the three `use_signal=True` arguments at the analyzer call-sites
- the one test assertion that passed it

Where `use_signal` was the *only* keyword-only param (`store_analysis`, `handle_no_text_prediction`), the now-dangling bare `*,` marker was removed too (it would otherwise be a `SyntaxError`). `check_prediction_exists` keeps its `*,` because `llm_provider`/`llm_model` remain keyword-only.

### #195 — Hoist hardcoded Truth Social identity into settings
The ScrapeCreators API selects the account by numeric `user_id` (plus the base URL), but both were hardcoded string literals in the harvester's `__init__`. Meanwhile `TRUTH_SOCIAL_USERNAME` was loaded into `self.username` and **never read anywhere** — config advertised a knob that did nothing while the real selector was invisible.

- Added `SCRAPECREATORS_BASE_URL` (ScrapeCreators section) and `TRUTH_SOCIAL_USER_ID` (Truth Social section) settings, both defaulted.
- Harvester now reads `self.base_url` / `self.user_id` from settings; deleted the dead `self.username` line.
- Deleted the `TRUTH_SOCIAL_USERNAME` setting. `pydantic-settings` ignores undeclared env vars, so a stale `TRUTH_SOCIAL_USERNAME=` in a dev `.env` is inert.
- Config layout: `TRUTH_SOCIAL_USER_ID` sits in the Truth Social section (replacing `USERNAME` in place), `SCRAPECREATORS_BASE_URL` in the ScrapeCreators section — split by concern.

Out of scope (separate cluster #193/#211): harvester source-dispatch / `--source` / registry logic. No changes to `ENABLED_HARVESTERS` or `base_harvester.py`.

## Verification

- **Targeted suites green:** `pytest shit_tests/shitpost_ai/ shit_tests/shitvault/ shit_tests/shitposts/ shit_tests/shit/config/` → **503 passed**.
- **Symbol sweeps clean:** `rg use_signal -g '*.py'`, `rg TRUTH_SOCIAL_USERNAME -g '*.py'`, and `rg 'self\.username' shitposts/` all return nothing. Remaining `use_signal`/`TRUTH_SOCIAL_USERNAME` matches are historical CHANGELOG/spec/plan/archive docs, intentionally retained.
- **Module import check:** `prediction_operations` and `shitpost_analyzer` import without `SyntaxError` (dangling-`*,` trap avoided).
- **Lint-neutral:** `ruff check` on the 9 touched Python files reports the **same 53 pre-existing errors on this branch as on `main`** (E402/F401/F841 that predate this work) — this change introduces zero new lint findings.

## Notes

- **Formatting kept minimal on purpose.** `ruff format` wanted to reformat ~1,300 lines across the test files (pre-existing single→double-quote drift, since `main` was never fully formatted). That whole-file churn was reverted; only the functional lines changed, matching each file's existing style, to keep the review diff readable.
- **Simplification pass skipped.** The diff crosses the line/file threshold only because it's spread thinly across many files (1–3 lines each); it's pure deletion + identifier rename with no changed logic to reshape. The dead-code removal is itself the simplification.

Closes #188, closes #195. (Multi-finding issue #229 stays open until its remaining findings land in later phases.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
