### PR TITLE
refactor: DRY service loggers + fix broken shit.logging star-export (#196, #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Broken `shit.logging` star-export (Phase 3, #196 ≡ #230 L12)** — `__all__` listed `get_cli_logger` but no module imported it, so `from shit.logging import *` raised `AttributeError` and `from shit.logging import get_cli_logger` raised `ImportError`. Wired the surviving `CLILogger` factory into the package root and deleted the duplicate plain-`logging.Logger` `get_cli_logger` in `cli_logging.py`. Added a regression test pinning `import *` and the package-root export.
+
+### Changed
+- **DRY service loggers (Phase 3, #197)** — the four service-logger classes (`S3Logger`, `DatabaseLogger`, `LLMLogger`, `CLILogger`) now share a private `_BaseServiceLogger._emit` helper instead of each re-implementing the same message + `extra`-dict scaffolding. No public class/method/signature change; behavior is pinned byte-for-byte by the existing `test_service_loggers.py` harness.
+
 ### Security
 - **Ignore Claude fleet bot telemetry paths** — narrow any-depth `.gitignore` rules for `data/events/fleet-*.jsonl`, `data/.last-tool-call`, `data/.idle`: the files Claudlobby supervision hooks can write relative to the session cwd when the bot environment is absent (Claudfather/Claudlobby#874). Prevents a broad `git add` in an agent checkout from staging fleet telemetry into this public repo; product `data/` paths are unaffected.
 

--- a/documentation/planning/dead-code-cleanup_2026-07-24/03_logging-module-cleanup.md
+++ b/documentation/planning/dead-code-cleanup_2026-07-24/03_logging-module-cleanup.md
@@ -1,7 +1,10 @@
 ---
 title: "Phase 3 — Logging module cleanup"
 session: dead-code-cleanup_2026-07-24
-status: READY
+status: COMPLETE
+started: 2026-07-30
+completed: 2026-07-30
+pr: 237
 issues: [196, 197]
 code_area: shit/logging
 risk: low
@@ -163,12 +166,12 @@ the exact message text and full `extra` dict for every method.
 7. **Lint/format + CHANGELOG.** `ruff check .`, `ruff format .`, and add an `[Unreleased]` entry.
 
 ## Acceptance Criteria
-- [ ] `from shit.logging import get_cli_logger` works AND `from shit.logging import *` does not raise.
-- [ ] Only one `get_cli_logger` definition remains (in `service_loggers.py`, returning `CLILogger`).
-- [ ] All four service loggers delegate to `_emit` on a shared base; every public method name and signature is unchanged, and `self.logger` still exists as an instance attribute.
-- [ ] `pytest shit_tests/shit/logging/` green (`test_service_loggers.py` unmodified; `test_cli_logging.py` only loses the three plain-Logger `get_cli_logger` tests).
-- [ ] `ruff check .` / `ruff format .` clean.
-- [ ] `CHANGELOG.md` `[Unreleased]` updated (closes #196 ≡ #230 L12, and #197).
+- [x] `from shit.logging import get_cli_logger` works AND `from shit.logging import *` does not raise. (Reproduced the `AttributeError` on `main`; now succeeds.)
+- [x] Only one `get_cli_logger` definition remains (in `service_loggers.py`, returning `CLILogger`).
+- [x] All four service loggers delegate to `_emit` on a shared base; every public method name and signature is unchanged, and `self.logger` still exists as an instance attribute. **`_emit` takes the per-call `extra` as a dict (not `**fields`)** — callers legitimately pass keys like `operation` via `**kwargs` (`progress(25, operation="harvest_posts")`), which collide with a formal param; the dict form reproduces the original override semantics exactly (caught by `test_progress_without_total`).
+- [x] `pytest shit_tests/shit/logging/` green — **126 passed**. `test_service_loggers.py`'s existing tests are unmodified; it gains a `TestPackageStarImport` regression class (user-approved). `test_cli_logging.py` loses the three plain-Logger `get_cli_logger` tests.
+- [x] Lint-neutral: `ruff check` on the touched files shows the **same 8 pre-existing F401s as `main`** (no new findings). Repo-wide `ruff format .` deliberately NOT run (would churn unrelated pre-existing drift); the class section was spliced deterministically, head/tail preserved byte-for-byte.
+- [x] `CHANGELOG.md` `[Unreleased]` updated — `### Fixed` (#196 ≡ #230 L12) + `### Changed` (#197).
 
 ## Test Plan
 - **Existing harness (must stay green, unmodified):** `shit_tests/shit/logging/test_service_loggers.py` asserts, for every method, the exact message string — including the suffix forms `"...(1KB)"`, `"...(5 rows)"`, `"...(150 tokens)"`, `"...(confidence: 85.0%)"` and the *no-suffix* forms `"✅ Uploaded to S3: test-key"`, `"✅ Query completed: INSERT"`, `"✅ LLM API call completed: gpt-4"` — plus the full `extra` dict (`service`, `operation`, and each field, e.g. `extra['size'] is None` in `test_uploaded_without_size`) and the log level (`.info`/`.debug`/`.error`). Passing this harness after the refactor is the proof of behavior preservation.

--- a/shit/logging/__init__.py
+++ b/shit/logging/__init__.py
@@ -37,6 +37,7 @@ from .service_loggers import (
     get_s3_logger,
     get_database_logger,
     get_llm_logger,
+    get_cli_logger,
 )
 
 from .cli_logging import (

--- a/shit/logging/cli_logging.py
+++ b/shit/logging/cli_logging.py
@@ -192,15 +192,3 @@ def setup_database_logging(verbose: bool = False) -> None:
         database_logger.setLevel(logging.DEBUG)
     else:
         database_logger.setLevel(logging.INFO)
-
-
-def get_cli_logger(module_name: str):
-    """Get a logger for a CLI module.
-    
-    Args:
-        module_name: Name of the CLI module
-        
-    Returns:
-        Logger instance
-    """
-    return logging.getLogger(module_name)

--- a/shit/logging/service_loggers.py
+++ b/shit/logging/service_loggers.py
@@ -54,328 +54,282 @@ def _create_disabled_logger(service: str) -> logging.Logger:
     return logger
 
 
-class S3Logger:
+class _BaseServiceLogger:
+    """Shared scaffolding for the service loggers.
+
+    Holds the underlying stdlib logger and emits a message with the standard
+    ``extra`` envelope. Private on purpose — not exported from the package.
+    """
+
+    def __init__(self, service: str, module_name: Optional[str] = None):
+        self.service = service
+        self.logger = get_service_logger(service, module_name)
+
+    def _emit(
+        self,
+        level: str,
+        msg: str,
+        fields: dict,
+        suffix: Optional[str] = None,
+    ) -> None:
+        """Emit ``msg`` at ``level`` with the standard ``extra`` envelope.
+
+        ``fields`` is the per-call ``extra`` payload (``operation`` plus any
+        method-specific keys, with the caller's ``**kwargs`` already merged in
+        last so it overrides — matching the original inline dict literals).
+        ``self.service`` is injected first so a caller-supplied ``service`` in
+        ``fields`` still wins. When ``suffix`` is truthy it is appended as
+        `` (suffix)``; callers pass ``None`` when absent, so no trailing
+        `` (...)`` ever appears otherwise.
+
+        Taking ``fields`` as a dict (rather than ``**fields``) is deliberate:
+        callers legitimately pass keys like ``operation`` in ``**kwargs``
+        (e.g. ``progress(25, operation="harvest_posts")``), which would collide
+        with a formal parameter of the same name.
+        """
+        if suffix:
+            msg = f"{msg} ({suffix})"
+        getattr(self.logger, level)(
+            msg,
+            extra={'service': self.service, **fields},
+        )
+
+
+class S3Logger(_BaseServiceLogger):
     """Logger for S3 operations."""
-    
+
     def __init__(self, module_name: Optional[str] = None):
         """Initialize S3 logger.
-        
+
         Args:
             module_name: Optional module name
         """
-        self.logger = get_service_logger("s3", module_name)
-    
+        super().__init__("s3", module_name)
+
     def uploading(self, key: str, **kwargs):
         """Log S3 upload start.
-        
+
         Args:
             key: S3 object key
             **kwargs: Additional context
         """
-        self.logger.info(f"📁 Uploading to S3: {key}", extra={
-            'service': 's3',
-            'operation': 'upload',
-            'key': key,
-            **kwargs
-        })
-    
+        self._emit('info', f"📁 Uploading to S3: {key}",
+                   {'operation': 'upload', 'key': key, **kwargs})
+
     def uploaded(self, key: str, size: Optional[str] = None, **kwargs):
         """Log successful S3 upload.
-        
+
         Args:
             key: S3 object key
             size: File size (optional)
             **kwargs: Additional context
         """
-        message = f"✅ Uploaded to S3: {key}"
-        if size:
-            message += f" ({size})"
-        self.logger.info(message, extra={
-            'service': 's3',
-            'operation': 'upload_success',
-            'key': key,
-            'size': size,
-            **kwargs
-        })
-    
+        self._emit('info', f"✅ Uploaded to S3: {key}",
+                   {'operation': 'upload_success', 'key': key, 'size': size, **kwargs},
+                   suffix=size if size else None)
+
     def downloading(self, key: str, **kwargs):
         """Log S3 download start.
-        
+
         Args:
             key: S3 object key
             **kwargs: Additional context
         """
-        self.logger.info(f"📥 Downloading from S3: {key}", extra={
-            'service': 's3',
-            'operation': 'download',
-            'key': key,
-            **kwargs
-        })
-    
+        self._emit('info', f"📥 Downloading from S3: {key}",
+                   {'operation': 'download', 'key': key, **kwargs})
+
     def downloaded(self, key: str, size: Optional[str] = None, **kwargs):
         """Log successful S3 download.
-        
+
         Args:
             key: S3 object key
             size: File size (optional)
             **kwargs: Additional context
         """
-        message = f"✅ Downloaded from S3: {key}"
-        if size:
-            message += f" ({size})"
-        self.logger.info(message, extra={
-            'service': 's3',
-            'operation': 'download_success',
-            'key': key,
-            'size': size,
-            **kwargs
-        })
-    
+        self._emit('info', f"✅ Downloaded from S3: {key}",
+                   {'operation': 'download_success', 'key': key, 'size': size, **kwargs},
+                   suffix=size if size else None)
+
     def checking_exists(self, key: str, **kwargs):
         """Log S3 existence check.
-        
+
         Args:
             key: S3 object key
             **kwargs: Additional context
         """
-        self.logger.debug(f"🔍 Checking S3 object exists: {key}", extra={
-            'service': 's3',
-            'operation': 'exists',
-            'key': key,
-            **kwargs
-        })
-    
+        self._emit('debug', f"🔍 Checking S3 object exists: {key}",
+                   {'operation': 'exists', 'key': key, **kwargs})
+
     def exists(self, key: str, exists: bool, **kwargs):
         """Log S3 existence check result.
-        
+
         Args:
             key: S3 object key
             exists: Whether object exists
             **kwargs: Additional context
         """
         status = "✅ Exists" if exists else "❌ Not found"
-        self.logger.debug(f"{status}: {key}", extra={
-            'service': 's3',
-            'operation': 'exists_result',
-            'key': key,
-            'exists': exists,
-            **kwargs
-        })
+        self._emit('debug', f"{status}: {key}",
+                   {'operation': 'exists_result', 'key': key, 'exists': exists, **kwargs})
 
 
-class DatabaseLogger:
+class DatabaseLogger(_BaseServiceLogger):
     """Logger for database operations."""
-    
+
     def __init__(self, module_name: Optional[str] = None):
         """Initialize database logger.
-        
+
         Args:
             module_name: Optional module name
         """
-        self.logger = get_service_logger("database", module_name)
-    
+        super().__init__("database", module_name)
+
     def executing_query(self, query_type: str, **kwargs):
         """Log database query execution.
-        
+
         Args:
             query_type: Type of query
             **kwargs: Additional context
         """
-        self.logger.debug(f"🗄️ Executing {query_type} query", extra={
-            'service': 'database',
-            'operation': 'query',
-            'query_type': query_type,
-            **kwargs
-        })
-    
+        self._emit('debug', f"🗄️ Executing {query_type} query",
+                   {'operation': 'query', 'query_type': query_type, **kwargs})
+
     def query_result(self, query_type: str, rows: Optional[int] = None, **kwargs):
         """Log database query result.
-        
+
         Args:
             query_type: Type of query
             rows: Number of rows (optional)
             **kwargs: Additional context
         """
-        message = f"✅ Query completed: {query_type}"
-        if rows is not None:
-            message += f" ({rows} rows)"
-        self.logger.debug(message, extra={
-            'service': 'database',
-            'operation': 'query_result',
-            'query_type': query_type,
-            'rows': rows,
-            **kwargs
-        })
-    
+        self._emit('debug', f"✅ Query completed: {query_type}",
+                   {'operation': 'query_result', 'query_type': query_type, 'rows': rows, **kwargs},
+                   suffix=f"{rows} rows" if rows is not None else None)
+
     def inserting(self, table: str, count: int = 1, **kwargs):
         """Log database insert operation.
-        
+
         Args:
             table: Table name
             count: Number of records
             **kwargs: Additional context
         """
-        self.logger.info(f"💾 Inserting {count} record(s) into {table}", extra={
-            'service': 'database',
-            'operation': 'insert',
-            'table': table,
-            'count': count,
-            **kwargs
-        })
-    
+        self._emit('info', f"💾 Inserting {count} record(s) into {table}",
+                   {'operation': 'insert', 'table': table, 'count': count, **kwargs})
+
     def inserted(self, table: str, count: int = 1, **kwargs):
         """Log successful database insert.
-        
+
         Args:
             table: Table name
             count: Number of records
             **kwargs: Additional context
         """
-        self.logger.info(f"✅ Inserted {count} record(s) into {table}", extra={
-            'service': 'database',
-            'operation': 'insert_success',
-            'table': table,
-            'count': count,
-            **kwargs
-        })
+        self._emit('info', f"✅ Inserted {count} record(s) into {table}",
+                   {'operation': 'insert_success', 'table': table, 'count': count, **kwargs})
 
 
-class LLMLogger:
+class LLMLogger(_BaseServiceLogger):
     """Logger for LLM operations."""
-    
+
     def __init__(self, module_name: Optional[str] = None):
         """Initialize LLM logger.
-        
+
         Args:
             module_name: Optional module name
         """
-        self.logger = get_service_logger("llm", module_name)
-    
+        super().__init__("llm", module_name)
+
     def api_call_start(self, model: str, **kwargs):
         """Log LLM API call start.
-        
+
         Args:
             model: Model name
             **kwargs: Additional context
         """
-        self.logger.info(f"🤖 Calling LLM API: {model}", extra={
-            'service': 'llm',
-            'operation': 'api_call',
-            'model': model,
-            **kwargs
-        })
-    
+        self._emit('info', f"🤖 Calling LLM API: {model}",
+                   {'operation': 'api_call', 'model': model, **kwargs})
+
     def api_call_success(self, model: str, tokens: Optional[int] = None, **kwargs):
         """Log successful LLM API call.
-        
+
         Args:
             model: Model name
             tokens: Number of tokens (optional)
             **kwargs: Additional context
         """
-        message = f"✅ LLM API call completed: {model}"
-        if tokens is not None:
-            message += f" ({tokens} tokens)"
-        self.logger.info(message, extra={
-            'service': 'llm',
-            'operation': 'api_call_success',
-            'model': model,
-            'tokens': tokens,
-            **kwargs
-        })
-    
+        self._emit('info', f"✅ LLM API call completed: {model}",
+                   {'operation': 'api_call_success', 'model': model, 'tokens': tokens, **kwargs},
+                   suffix=f"{tokens} tokens" if tokens is not None else None)
+
     def analyzing(self, item: str, **kwargs):
         """Log LLM analysis start.
-        
+
         Args:
             item: Item being analyzed
             **kwargs: Additional context
         """
-        self.logger.info(f"🔬 Analyzing: {item[:50]}...", extra={
-            'service': 'llm',
-            'operation': 'analyze',
-            'item': item[:100],  # Truncate for logging
-            **kwargs
-        })
-    
+        self._emit('info', f"🔬 Analyzing: {item[:50]}...",
+                   {'operation': 'analyze', 'item': item[:100], **kwargs})
+
     def analysis_complete(self, item: str, confidence: Optional[float] = None, **kwargs):
         """Log completed LLM analysis.
-        
+
         Args:
             item: Item analyzed
             confidence: Confidence score (optional)
             **kwargs: Additional context
         """
-        message = f"✅ Analysis complete: {item[:50]}..."
-        if confidence is not None:
-            message += f" (confidence: {confidence:.1%})"
-        self.logger.info(message, extra={
-            'service': 'llm',
-            'operation': 'analyze_success',
-            'item': item[:100],
-            'confidence': confidence,
-            **kwargs
-        })
+        self._emit('info', f"✅ Analysis complete: {item[:50]}...",
+                   {'operation': 'analyze_success', 'item': item[:100], 'confidence': confidence, **kwargs},
+                   suffix=f"confidence: {confidence:.1%}" if confidence is not None else None)
 
 
-class CLILogger:
+class CLILogger(_BaseServiceLogger):
     """Logger for CLI operations."""
-    
+
     def __init__(self, module_name: Optional[str] = None):
         """Initialize CLI logger.
-        
+
         Args:
             module_name: Optional module name
         """
-        self.logger = get_service_logger("cli", module_name)
-    
+        super().__init__("cli", module_name)
+
     def operation_start(self, operation: str, **kwargs):
         """Log CLI operation start.
-        
+
         Args:
             operation: Operation name
             **kwargs: Additional context
         """
-        self.logger.info(f"🚀 Starting: {operation}", extra={
-            'service': 'cli',
-            'operation': operation,
-            'status': 'start',
-            **kwargs
-        })
-    
+        self._emit('info', f"🚀 Starting: {operation}",
+                   {'operation': operation, 'status': 'start', **kwargs})
+
     def operation_complete(self, operation: str, **kwargs):
         """Log successful CLI operation completion.
-        
+
         Args:
             operation: Operation name
             **kwargs: Additional context
         """
-        self.logger.info(f"✅ Completed: {operation}", extra={
-            'service': 'cli',
-            'operation': operation,
-            'status': 'complete',
-            **kwargs
-        })
-    
+        self._emit('info', f"✅ Completed: {operation}",
+                   {'operation': operation, 'status': 'complete', **kwargs})
+
     def operation_error(self, operation: str, error: str, **kwargs):
         """Log CLI operation error.
-        
+
         Args:
             operation: Operation name
             error: Error message
             **kwargs: Additional context
         """
-        self.logger.error(f"❌ Error in {operation}: {error}", extra={
-            'service': 'cli',
-            'operation': operation,
-            'status': 'error',
-            'error': error,
-            **kwargs
-        })
-    
+        self._emit('error', f"❌ Error in {operation}: {error}",
+                   {'operation': operation, 'status': 'error', 'error': error, **kwargs})
+
     def progress(self, current: int, total: Optional[int] = None, **kwargs):
         """Log CLI operation progress.
-        
+
         Args:
             current: Current progress
             total: Total items (optional)
@@ -386,14 +340,8 @@ class CLILogger:
             message = f"📊 Progress: {current}/{total} ({percentage:.1f}%)"
         else:
             message = f"📊 Progress: {current}"
-        
-        self.logger.info(message, extra={
-            'service': 'cli',
-            'operation': 'progress',
-            'current': current,
-            'total': total,
-            **kwargs
-        })
+        self._emit('info', message,
+                   {'operation': 'progress', 'current': current, 'total': total, **kwargs})
 
 
 # Convenience functions for getting service loggers

--- a/shit_tests/shit/logging/test_cli_logging.py
+++ b/shit_tests/shit/logging/test_cli_logging.py
@@ -13,7 +13,6 @@ from shit.logging.cli_logging import (
     setup_harvester_logging,
     setup_analyzer_logging,
     setup_database_logging,
-    get_cli_logger,
     _suppress_third_party_logging
 )
 
@@ -372,32 +371,6 @@ class TestSetupDatabaseLogging:
             mock_database_logger.setLevel.assert_called_once_with(logging.INFO)
 
 
-class TestGetCLILogger:
-    """Test get_cli_logger function."""
-    
-    def test_get_cli_logger(self):
-        """Test get_cli_logger function."""
-        with patch('logging.getLogger') as mock_get_logger:
-            mock_logger = MagicMock()
-            mock_get_logger.return_value = mock_logger
-            
-            result = get_cli_logger("test_module")
-            
-            mock_get_logger.assert_called_once_with("test_module")
-            assert result == mock_logger
-    
-    def test_get_cli_logger_without_module(self):
-        """Test get_cli_logger function with empty module name."""
-        with patch('logging.getLogger') as mock_get_logger:
-            mock_logger = MagicMock()
-            mock_get_logger.return_value = mock_logger
-            
-            result = get_cli_logger("")
-            
-            mock_get_logger.assert_called_once_with("")
-            assert result == mock_logger
-
-
 class TestCLILoggingEdgeCases:
     """Test edge cases and error scenarios for CLI logging."""
     
@@ -500,17 +473,6 @@ class TestCLILoggingEdgeCases:
             
             # Should have called setup_cli_logging
             mock_setup_cli.assert_called_once_with(verbose=True, service_name='harvester')
-    
-    def test_get_cli_logger_with_special_characters(self):
-        """Test get_cli_logger with special characters in module name."""
-        with patch('logging.getLogger') as mock_get_logger:
-            mock_logger = MagicMock()
-            mock_get_logger.return_value = mock_logger
-            
-            result = get_cli_logger("test-module_123")
-            
-            mock_get_logger.assert_called_once_with("test-module_123")
-            assert result == mock_logger
     
     def test_setup_cli_logging_clears_existing_handlers(self):
         """Test that setup_cli_logging clears existing handlers."""

--- a/shit_tests/shit/logging/test_service_loggers.py
+++ b/shit_tests/shit/logging/test_service_loggers.py
@@ -577,3 +577,26 @@ class TestServiceLoggerEdgeCases:
             
             logger = get_service_logger("test-service_123")
             assert logger.name == "test-service_123"
+
+
+class TestPackageStarImport:
+    """Regression guard for the shit.logging package __all__ / re-export wiring.
+
+    #196 shipped a broken export: __all__ listed 'get_cli_logger' but no module
+    imported it, so `from shit.logging import *` raised AttributeError and
+    `from shit.logging import get_cli_logger` raised ImportError. This test pins
+    that every __all__ name resolves and that get_cli_logger returns a CLILogger.
+    """
+
+    def test_star_import_resolves_all_exports(self):
+        """`from shit.logging import *` must not raise (validates every __all__ entry)."""
+        ns = {}
+        exec("from shit.logging import *", ns)  # raises AttributeError if __all__ drifts
+        assert "get_cli_logger" in ns
+
+    def test_get_cli_logger_from_package_root_returns_clilogger(self):
+        """The single surviving get_cli_logger is the CLILogger factory."""
+        from shit.logging import get_cli_logger as pkg_get_cli_logger
+        from shit.logging import CLILogger as PkgCLILogger
+
+        assert isinstance(pkg_get_cli_logger("x"), PkgCLILogger)


### PR DESCRIPTION
## Summary

Phase 3 of the dead-code cleanup cluster (`documentation/planning/dead-code-cleanup_2026-07-24/`). Two mechanical, behavior-preserving fixes inside `shit/logging/`.

### #196 — Fix the broken `get_cli_logger` export (also closes #230 L12)
`shit/logging/__init__.py`'s `__all__` listed `get_cli_logger`, but **no module ever imported it into the package namespace** — so the export was simply broken:
- `from shit.logging import *` → `AttributeError: module 'shit.logging' has no attribute 'get_cli_logger'` (CPython validates every `__all__` entry on `import *`)
- `from shit.logging import get_cli_logger` → `ImportError`

Compounding it, the name was **defined twice** with divergent contracts: `service_loggers.py` (returns a `CLILogger`, matching the `get_s3_logger`/`get_database_logger`/`get_llm_logger` sibling pattern) and `cli_logging.py` (a trivial `logging.getLogger` pass-through with a *required* positional arg).

**Fix:** keep the `CLILogger` factory, wire it into the package root, delete the `cli_logging.py` duplicate. Added a **permanent regression test** (`TestPackageStarImport`) pinning that `import *` resolves every `__all__` entry and that the package-root `get_cli_logger` returns a `CLILogger` — this bug shipped silently precisely because nothing guarded it.

### #197 — DRY the four service-logger classes
`S3Logger`, `DatabaseLogger`, `LLMLogger`, `CLILogger` each re-implemented the same scaffolding (build message, optionally append ` (suffix)`, call `self.logger.<level>(msg, extra={...})`). Introduced a private `_BaseServiceLogger` with one `_emit` helper; every class now subclasses it and routes each method through `self._emit(...)`. **No public class name, method name, or signature changes; `self.logger` preserved** (the test harness patches it).

## Notable implementation decision — `_emit` takes a dict, not `**fields`

The plan specified `_emit(self, level, msg, operation, suffix=None, **fields)`. During verification, `test_progress_without_total` (`cli_logger.progress(25, operation="harvest_posts")`) exposed a defect: callers legitimately pass `operation` (and potentially other keys) via `**kwargs`. With `operation` as a **formal parameter**, that collides at the call boundary (`TypeError: got multiple values for argument 'operation'`) — whereas the original inline-dict code just let `**kwargs` override the key.

So `_emit` takes the per-call `extra` payload as a **plain dict** (`_emit(self, level, msg, fields, suffix=None)`) and merges `{'service': self.service, **fields}`. This eliminates every formal-parameter collision (not just `operation`) and reproduces the original override semantics exactly. It's a small, more-robust deviation that stays within #197's intent.

## Verification

- **`pytest shit_tests/shit/logging/` → 126 passed.** `test_service_loggers.py` is the behavior harness (pins exact message text — including suffix forms like `(1KB)`, `(5 rows)`, `(150 tokens)`, `(confidence: 85.0%)` and the no-suffix forms — plus the full `extra` dict and log level for every method); it passes with only the regression class appended.
- **Bug reproduced then fixed:** `from shit.logging import *` raised `AttributeError` on `main`; now succeeds. Confirmed `get_cli_logger("x")` returns a `CLILogger`.
- **Suite guard:** `pytest --co` collects **1880 tests** with no import errors — nothing trips on the `__init__.py` change. No remaining importer of the deleted `cli_logging.get_cli_logger`.
- **Lint-neutral:** `ruff check` on the touched files reports the **same 8 pre-existing F401s on this branch as on `main`** (all unused-import noise that predates this work) — zero new findings. Net **−77 LOC**.

## Notes

- **Simplification pass skipped.** The refactor *is* the simplification; the remaining repetition (per-method docstrings/wrappers) is required by the preserved public API, and the behavior contract is byte-exact — a working-tree reshape carries real risk of perturbing the `**kwargs`-override / suffix semantics for no clear gain.
- **Formatting kept minimal** (no repo-wide `ruff format` — it would rewrite unrelated pre-existing drift); the class section was spliced deterministically, preserving the module head (`get_service_logger`) and factory tail byte-for-byte.

Closes #196, closes #197. (Multi-finding issue #230 stays open until its remaining findings land in Phases 4/5.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
