### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This section captures durable, non-obvious setup/run details for future cloud agents.
+The VM snapshot already has Python deps (in `./venv`), frontend deps (`frontend/node_modules`),
+and a local PostgreSQL 16 + pgvector installed. The startup update script only refreshes those
+dependencies — it does **not** start services. See `README.md` / `CLAUDE.md` for standard,
+already-documented commands (tests, stats, pipeline CLIs); the notes below only cover things
+that are not obvious from those docs.
+
+### Services overview
+- **FastAPI backend** (`api/main:app`) — serves the JSON API and, when `frontend/dist` exists, the built React SPA. Runs on port **8000**.
+- **React + Vite frontend** (`frontend/`) — dev server on port **5173**; `vite.config.ts` proxies `/api` and `/telegram` to `http://localhost:8000`, so the backend must be on 8000.
+- **Pipeline workers** (`shitposts/`, `shitvault/`, `shitpost_ai/`, `shit/market_data/`, `notifications/`) — cron/one-shot batch jobs (not servers). They require real external credentials (ScrapeCreators, OpenAI, AWS S3) and are **not** needed to run or test the dashboard. Do not run production/backfill modes without explicit user approval (see `CLAUDE.md`).
+
+### Python environment
+- Use the project venv: `./venv/bin/python`, `./venv/bin/pytest`, `./venv/bin/uvicorn`. VM Python is 3.12 (repo docs say 3.13; 3.12 works fine).
+
+### Database: the dashboard requires PostgreSQL, not the default SQLite
+- `DATABASE_URL` defaults to `sqlite:///./shitpost_alpha.db`, which is enough to import modules and run the test suite, **but the dashboard feed query is PostgreSQL-specific** (JSON `->>`/`->` operators, `::int` / `::text` casts, `COUNT(*) OVER()`), so `GET /api/feed/at` returns **500 on SQLite**. Use Postgres for any real dashboard work.
+- A local Postgres is provisioned: database `shitpost_alpha`, role `shitpost` / password `shitpost`, with the `vector` extension enabled. The repo-root `.env` (gitignored) points `DATABASE_URL` at it and sets `ENVIRONMENT=development`.
+- Postgres does not auto-start on boot. Start it with: `sudo pg_ctlcluster 16 main start`.
+- Create/refresh the schema (also needs the pgvector extension for the `post_embeddings` table): `./venv/bin/python -c "from shit.db.sync_session import create_tables; create_tables()"`.
+
+### Running the app (development)
+- Start Postgres first (above), then:
+  - Backend: `ENVIRONMENT=development ./venv/bin/uvicorn api.main:app --reload --host 0.0.0.0 --port 8000` (it reads `.env`).
+  - Frontend: `npm run dev` in `frontend/` (port 5173).
+- Health check: `curl http://localhost:8000/api/health` → `{"ok": true, ...}`.
+- Feed endpoint is `GET /api/feed/at?offset=0` (0 = latest). It only returns posts with a `completed` prediction and non-empty `assets`; an empty DB yields 404.
+- Gotcha: because the backend mounts a catch-all SPA route (`/{full_path:path}`) whenever `frontend/dist` exists, requests to **wrong** API paths return the SPA `index.html` (HTML) rather than a JSON 404. Double-check exact route paths when an endpoint "returns HTML".
+- `frontend/dist` is a build artifact; running `npm run build` regenerates it and makes the backend serve the SPA at `/`. For hot-reload frontend dev, use the Vite dev server on 5173 instead.
+
+### Tests, lint, build
+- Tests: `./venv/bin/python -m pytest -c shit_tests/pytest.ini` (config lives in `shit_tests/pytest.ini`, not repo root). ~1976 tests pass. The heavy `shit_tests/requirements-test.txt` is **not** required — nothing in the suite imports moto/faker/etc.; base `requirements.txt` is sufficient.
+- Known pre-existing failures (not environment issues): several `shitpost_ai` analyzer/ensemble tests instantiate `LLMClient` (via the module-level `settings` singleton captured at import) and `LLMClient.initialize()` makes a **live** OpenAI call, so they need a real, valid `OPENAI_API_KEY` in the process env; a few `events/consumers` async-mock tests and `test_performance.py` timing tests also fail independent of setup.
+- Lint: there is **no** Python linter configured (CLAUDE.md mentions `ruff`, but it is not in `requirements.txt`). Frontend typecheck/build: `npm run build` (`tsc -b && vite build`) in `frontend/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ignore Claude fleet bot telemetry paths** — narrow any-depth `.gitignore` rules for `data/events/fleet-*.jsonl`, `data/.last-tool-call`, `data/.idle`: the files Claudlobby supervision hooks can write relative to the session cwd when the bot environment is absent (Claudfather/Claudlobby#874). Prevents a broad `git add` in an agent checkout from staging fleet telemetry into this public repo; product `data/` paths are unaffected.
 
 ### Added
+- **AGENTS.md (Cursor Cloud setup notes)** — Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the dev environment: Python venv usage, that the dashboard feed requires PostgreSQL (not the default SQLite), how to start local Postgres + create the schema, backend/frontend dev commands and ports, the SPA catch-all route gotcha, and how to run tests/lint/build (including known pre-existing test failures that need real credentials).
 - **Tech-Debt Tracker (2026-07-02)** — Full-system review triaged into `documentation/planning/tech-debt-2026-07-02/` (durable analysis artifacts) and filed as GitHub issues
   - `00_TECH_DEBT.md` overview with a complete, ID'd inventory (5 CRITICAL, 16 HIGH, plus MEDIUM/LOW) across `shit/`, the pipeline, `api/`, `frontend/`, `notifications/`, and the event queue
   - 14 issue-ready workstream files (`01`–`14`), each scoped to one PR with findings, file/line references, proposed fixes, and acceptance criteria


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the local development environment for Shitpost Alpha (FastAPI backend + React/Vite dashboard). No application code changed — this PR only adds `AGENTS.md` (durable cloud-agent setup notes) and a `CHANGELOG.md` entry.

## What was verified

- **Backend** (`api.main:app`) runs in dev mode on port 8000 (`ENVIRONMENT=development uvicorn ... --reload`); `GET /api/health` returns `{"ok": true}` and `GET /api/feed/at` serves full post/prediction/outcome JSON.
- **Frontend** (`frontend/`) dev server runs on port 5173 and proxies `/api` → :8000; `npm run build` (`tsc -b && vite build`) passes (473 modules).
- **Tests**: `pytest -c shit_tests/pytest.ini` → **1976 passed**. The remaining ~50 are pre-existing failures unrelated to setup (analyzer/ensemble tests make live OpenAI calls needing a real key; a few async-mock and timing-based perf tests).
- **Hello-world**: seeded two analyzed Trump posts (AAPL bullish, GLD bullish) into a local Postgres, then loaded and navigated the dashboard feed in the browser — predictions, thesis, outcomes, charts, and prev/next navigation all render correctly.

## Key finding captured in AGENTS.md

The dashboard feed query is **PostgreSQL-specific** (JSON `->>`/`->`, `::int`/`::text` casts, `COUNT(*) OVER()`), so `GET /api/feed/at` returns 500 on the default SQLite. A local Postgres 16 + pgvector is provisioned and `.env` points `DATABASE_URL` at it. Also documents the SPA catch-all route gotcha (wrong API paths return HTML, not JSON 404), venv usage, and that no Python linter is configured.

## Demo

[shitpost_alpha_dashboard_demo.mp4](https://cursor.com/agents/bc-d72fa60f-94bf-4a21-8ca5-5febf96570c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshitpost_alpha_dashboard_demo.mp4)

[Dashboard — AAPL post + prediction](https://cursor.com/agents/bc-d72fa60f-94bf-4a21-8ca5-5febf96570c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_post_aapl.webp)
[Dashboard — GLD post + prediction](https://cursor.com/agents/bc-d72fa60f-94bf-4a21-8ca5-5febf96570c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_post_gld.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d72fa60f-94bf-4a21-8ca5-5febf96570c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d72fa60f-94bf-4a21-8ca5-5febf96570c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

